### PR TITLE
feat: add integration refactor for Proxmox->NetBox schema-driven mapping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ proxbox-api is a FastAPI backend that coordinates data flow between Proxmox clus
 - Persistence layer (`proxbox_api/database.py`): SQLite-backed SQLModel table for NetBox endpoint bootstrap and runtime session creation.
 - Utility layer (`proxbox_api/utils/*`, `proxbox_api/logger.py`, `proxbox_api/cache.py`, `proxbox_api/exception.py`): Cross-cutting helpers for logging, exception formatting, in-memory cache, and sync lifecycle tracking.
 - Proxmox codegen layer (`proxbox_api/proxmox_codegen/*`): Playwright crawl, `apidoc.js` parsing, OpenAPI conversion, and Pydantic v2 model generation for Proxmox endpoints.
+- Proxmox-to-NetBox transform layer (`proxbox_api/proxmox_to_netbox/*`): Pydantic-driven normalization from raw Proxmox payloads to valid NetBox create payloads with live schema contract resolution.
 
 ### Runtime Components
 
@@ -107,6 +108,8 @@ Defined in `requirements-test.txt`:
 - `proxbox_api/custom_objects/`: custom NetBox object wrappers.
 - `proxbox_api/proxmox_codegen/`: Proxmox API viewer extraction and schema generation pipeline.
 - `proxbox_api/generated/proxmox/`: generated OpenAPI and Pydantic artifacts.
+- `proxbox_api/proxmox_to_netbox/`: Proxmox input to NetBox output schema transformations.
+- `proxbox_api/generated/netbox/`: cached NetBox OpenAPI contract artifacts.
 
 ## Safe Extension Pattern
 

--- a/proxbox_api/CLAUDE.md
+++ b/proxbox_api/CLAUDE.md
@@ -13,7 +13,9 @@ Core FastAPI package: app bootstrap, shared dependencies, persistence, and helpe
 - `exception.py`: Custom exception types and async exception logging helpers.
 - `logger.py`: Logging setup utilities for console and file outputs.
 - `main.py`: FastAPI application entrypoint and route registration.
+- `openapi_custom.py`: FastAPI OpenAPI override and Proxmox generated-schema embedding.
 - `proxmox_codegen/`: Proxmox API Viewer crawler and OpenAPI/Pydantic code generation pipeline.
+- `proxmox_to_netbox/`: Schema-driven normalization from Proxmox payloads to NetBox create payloads.
 - `test_main.py`: Basic API smoke tests for the FastAPI root endpoint.
 - `utils.py`: Legacy utility helpers for sync status rendering.
 

--- a/proxbox_api/generated/CLAUDE.md
+++ b/proxbox_api/generated/CLAUDE.md
@@ -8,6 +8,7 @@ Holds generated code and schema artifacts produced by build-time and runtime gen
 
 - `__init__.py`: Package marker for generated artifacts.
 - `proxmox/`: Proxmox API viewer generation outputs (`openapi.json`, `pydantic_models.py`, `raw_capture.json`).
+- `netbox/`: NetBox OpenAPI cache output (`openapi.json`) fetched from live endpoint when available.
 
 ## Extension Guidance
 

--- a/proxbox_api/generated/netbox/CLAUDE.md
+++ b/proxbox_api/generated/netbox/CLAUDE.md
@@ -1,0 +1,14 @@
+# proxbox_api/generated/netbox Directory Guide
+
+## Purpose
+
+Stores cached NetBox OpenAPI schema documents fetched from live NetBox instances.
+
+## Typical Files
+
+- `openapi.json`: Last fetched NetBox OpenAPI document used by transformation contracts.
+- `__init__.py`: Package marker for generated cache artifacts.
+
+## Extension Guidance
+
+- Treat files in this directory as generated cache artifacts.

--- a/proxbox_api/generated/netbox/__init__.py
+++ b/proxbox_api/generated/netbox/__init__.py
@@ -1,0 +1,1 @@
+"""Generated NetBox schema cache artifacts package."""

--- a/proxbox_api/main.py
+++ b/proxbox_api/main.py
@@ -49,6 +49,7 @@ from proxbox_api.routes.proxmox.nodes import (
 from proxbox_api.routes.proxmox.cluster import ClusterStatusDep
 
 from proxbox_api.dependencies import NetBoxSessionDep
+from proxbox_api.openapi_custom import custom_openapi_builder
 
 """
 CORS ORIGINS
@@ -67,6 +68,15 @@ app = FastAPI(
     description="## Proxbox Backend made in FastAPI framework",
     version="0.0.1",
 )
+
+
+def custom_openapi():
+    """Override FastAPI OpenAPI generation with embedded Proxmox generated schema."""
+
+    return custom_openapi_builder(app)
+
+
+app.openapi = custom_openapi
 
 
 from sqlmodel import select

--- a/proxbox_api/openapi_custom.py
+++ b/proxbox_api/openapi_custom.py
@@ -1,0 +1,47 @@
+"""FastAPI custom OpenAPI integration including generated Proxmox schema extension."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.openapi.utils import get_openapi
+
+
+def _generated_proxmox_openapi() -> dict[str, Any]:
+    path = Path(__file__).resolve().parent / "generated" / "proxmox" / "openapi.json"
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def custom_openapi_builder(app: FastAPI) -> dict[str, Any]:
+    """Build and cache custom OpenAPI schema following FastAPI official override pattern."""
+
+    if app.openapi_schema:
+        return app.openapi_schema
+
+    openapi_schema = get_openapi(
+        title=app.title,
+        version=app.version,
+        summary="Proxbox API with embedded generated Proxmox OpenAPI contract",
+        description=app.description,
+        routes=app.routes,
+    )
+
+    proxmox_generated = _generated_proxmox_openapi()
+    if proxmox_generated:
+        openapi_schema.setdefault("info", {})["x-proxmox-generated-openapi"] = {
+            "source": "proxbox_api/generated/proxmox/openapi.json",
+            "endpoint_count": len((proxmox_generated.get("paths") or {}).keys()),
+            "version": proxmox_generated.get("info", {}).get("version"),
+        }
+        openapi_schema["x-proxmox-generated-openapi"] = proxmox_generated
+
+    app.openapi_schema = openapi_schema
+    return app.openapi_schema

--- a/proxbox_api/proxmox_to_netbox/CLAUDE.md
+++ b/proxbox_api/proxmox_to_netbox/CLAUDE.md
@@ -1,0 +1,29 @@
+# proxbox_api/proxmox_to_netbox Directory Guide
+
+## Purpose
+
+Provides schema-driven normalization from Proxmox raw payloads into NetBox create/update payload bodies.
+
+## Modules and Responsibilities
+
+- `__init__.py`: Public exports for VM transformation entrypoints.
+- `errors.py`: Domain exceptions for transformation failures.
+- `proxmox_schema.py`: Reads generated Proxmox OpenAPI artifact used as input contract.
+- `netbox_schema.py`: Fetches/caches NetBox OpenAPI (live first), with docs-derived fallback contract.
+- `models.py`: Pydantic v2 input/output models with normalization and validation logic.
+- `normalize.py`: Orchestration logic that validates source and target schema contracts.
+- `mappers/virtual_machine.py`: VM mapper to NetBox request bodies.
+- `mappers/interfaces.py`: Placeholder for interface mapping extensions.
+- `mappers/ipam.py`: Placeholder for IPAM mapping extensions.
+
+## Data Flow
+
+1. Load generated Proxmox OpenAPI to assert source operation availability.
+2. Resolve NetBox schema contract from live endpoint, cache, or fallback rules.
+3. Normalize Proxmox raw payloads with Pydantic validators/computed fields.
+4. Emit validated NetBox payload dictionaries ready for API create operations.
+
+## Extension Guidance
+
+- Keep transformation logic in Pydantic models and mappers, not in route handlers.
+- Favor explicit status/type maps and unit conversions to maintain deterministic sync output.

--- a/proxbox_api/proxmox_to_netbox/__init__.py
+++ b/proxbox_api/proxmox_to_netbox/__init__.py
@@ -1,0 +1,9 @@
+"""Proxmox-to-NetBox normalization and schema-driven mapping package."""
+
+from proxbox_api.proxmox_to_netbox.models import ProxmoxToNetBoxVirtualMachine
+from proxbox_api.proxmox_to_netbox.normalize import build_virtual_machine_transform
+
+__all__ = [
+    "ProxmoxToNetBoxVirtualMachine",
+    "build_virtual_machine_transform",
+]

--- a/proxbox_api/proxmox_to_netbox/errors.py
+++ b/proxbox_api/proxmox_to_netbox/errors.py
@@ -1,0 +1,5 @@
+"""Domain exceptions for Proxmox-to-NetBox transformation workflows."""
+
+
+class ProxmoxToNetBoxError(Exception):
+    """Raised when Proxmox raw payload cannot be transformed safely."""

--- a/proxbox_api/proxmox_to_netbox/mappers/CLAUDE.md
+++ b/proxbox_api/proxmox_to_netbox/mappers/CLAUDE.md
@@ -1,0 +1,15 @@
+# proxbox_api/proxmox_to_netbox/mappers Directory Guide
+
+## Purpose
+
+Contains domain-specific mapping modules from Proxmox raw objects to NetBox payload dictionaries.
+
+## Modules and Responsibilities
+
+- `virtual_machine.py`: Maps Proxmox VM resource/config into NetBox VM create payload.
+- `interfaces.py`: Placeholder for VM/interface mapping expansion.
+- `ipam.py`: Placeholder for IPAM mapping expansion.
+
+## Extension Guidance
+
+- Keep mapper functions thin and delegate validation to `models.py` Pydantic schemas.

--- a/proxbox_api/proxmox_to_netbox/mappers/__init__.py
+++ b/proxbox_api/proxmox_to_netbox/mappers/__init__.py
@@ -1,0 +1,1 @@
+"""Mapper modules for Proxmox raw payload to NetBox object payloads."""

--- a/proxbox_api/proxmox_to_netbox/mappers/interfaces.py
+++ b/proxbox_api/proxmox_to_netbox/mappers/interfaces.py
@@ -1,0 +1,1 @@
+"""Interface mapping placeholders for Proxmox to NetBox transformations."""

--- a/proxbox_api/proxmox_to_netbox/mappers/ipam.py
+++ b/proxbox_api/proxmox_to_netbox/mappers/ipam.py
@@ -1,0 +1,1 @@
+"""IPAM mapping placeholders for Proxmox to NetBox transformations."""

--- a/proxbox_api/proxmox_to_netbox/mappers/virtual_machine.py
+++ b/proxbox_api/proxmox_to_netbox/mappers/virtual_machine.py
@@ -1,0 +1,29 @@
+"""Virtual machine mapper utilities for Proxmox to NetBox conversions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from proxbox_api.proxmox_to_netbox.normalize import build_virtual_machine_transform
+
+
+def map_proxmox_vm_to_netbox_vm_body(
+    resource: dict[str, Any],
+    config: dict[str, Any] | None,
+    *,
+    cluster_id: int,
+    device_id: int | None,
+    role_id: int | None,
+    tag_ids: list[int],
+) -> dict[str, Any]:
+    """Map Proxmox VM raw payload to NetBox VM create body dictionary."""
+
+    body = build_virtual_machine_transform(
+        resource=resource,
+        config=config,
+        cluster_id=cluster_id,
+        device_id=device_id,
+        role_id=role_id,
+        tag_ids=tag_ids,
+    )
+    return body.model_dump(exclude_none=True, by_alias=True)

--- a/proxbox_api/proxmox_to_netbox/models.py
+++ b/proxbox_api/proxmox_to_netbox/models.py
@@ -1,0 +1,177 @@
+"""Pydantic v2 models for Proxmox input and NetBox VM payload output."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    computed_field,
+    field_validator,
+    model_validator,
+)
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return False
+
+
+def _mb_from_bytes(value: Any) -> int:
+    try:
+        as_int = int(value)
+    except (TypeError, ValueError):
+        return 0
+    if as_int <= 0:
+        return 0
+    return as_int // 1_000_000
+
+
+class ProxmoxVmResourceInput(BaseModel):
+    """Raw Proxmox VM resource payload from cluster resources endpoint."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    vmid: int
+    name: str
+    node: str
+    status: str = "stopped"
+    type: Literal["qemu", "lxc", "unknown"] = "unknown"
+    maxcpu: int | None = None
+    maxmem: int | None = None
+    maxdisk: int | None = None
+
+    @field_validator("type", mode="before")
+    @classmethod
+    def normalize_type(cls, value: Any) -> str:
+        text = str(value or "unknown").strip().lower()
+        if text in {"qemu", "lxc"}:
+            return text
+        return "unknown"
+
+    @computed_field(return_type=int)
+    @property
+    def memory_mb(self) -> int:
+        return _mb_from_bytes(self.maxmem)
+
+    @computed_field(return_type=int)
+    @property
+    def disk_mb(self) -> int:
+        return _mb_from_bytes(self.maxdisk)
+
+
+class ProxmoxVmConfigInput(BaseModel):
+    """Raw Proxmox VM config payload from `/nodes/{node}/{type}/{vmid}/config`."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    onboot: int | str | bool | None = None
+    agent: int | str | bool | None = None
+    unprivileged: int | str | bool | None = None
+    searchdomain: str | None = None
+
+    @computed_field(return_type=bool)
+    @property
+    def start_at_boot(self) -> bool:
+        return _as_bool(self.onboot)
+
+    @computed_field(return_type=bool)
+    @property
+    def qemu_agent_enabled(self) -> bool:
+        return _as_bool(self.agent)
+
+    @computed_field(return_type=bool)
+    @property
+    def unprivileged_container(self) -> bool:
+        return _as_bool(self.unprivileged)
+
+
+class NetBoxVirtualMachineCreateBody(BaseModel):
+    """Validated NetBox create body for virtualization virtual machine endpoint."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    name: str
+    status: str
+    cluster: int
+    device: int | None = None
+    role: int | None = None
+    vcpus: int = 0
+    memory: int = 0
+    disk: int = 0
+    tags: list[int] = Field(default_factory=list)
+    custom_fields: dict[str, Any] = Field(default_factory=dict)
+    description: str | None = None
+
+    @field_validator("status", mode="before")
+    @classmethod
+    def normalize_status(cls, value: Any) -> str:
+        mapping = {
+            "running": "active",
+            "online": "active",
+            "active": "active",
+            "stopped": "offline",
+            "paused": "offline",
+            "offline": "offline",
+            "planned": "planned",
+        }
+        text = str(value or "active").strip().lower()
+        return mapping.get(text, "active")
+
+    @model_validator(mode="after")
+    def validate_required_relations(self):
+        if self.cluster <= 0:
+            raise ValueError("cluster must be a positive NetBox object id")
+        if self.device is not None and self.device <= 0:
+            raise ValueError("device must be positive when provided")
+        if self.role is not None and self.role <= 0:
+            raise ValueError("role must be positive when provided")
+        return self
+
+
+class ProxmoxToNetBoxVirtualMachine(BaseModel):
+    """Schema-driven transform object for Proxmox input to NetBox VM create payload."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    resource: ProxmoxVmResourceInput
+    config: ProxmoxVmConfigInput = Field(default_factory=ProxmoxVmConfigInput)
+    cluster_id: int
+    device_id: int | None = None
+    role_id: int | None = None
+    tag_ids: list[int] = Field(default_factory=list)
+
+    @computed_field(return_type=dict)
+    @property
+    def vm_custom_fields(self) -> dict[str, Any]:
+        return {
+            "proxmox_vm_id": self.resource.vmid,
+            "proxmox_start_at_boot": self.config.start_at_boot,
+            "proxmox_unprivileged_container": self.config.unprivileged_container,
+            "proxmox_qemu_agent": self.config.qemu_agent_enabled,
+            "proxmox_search_domain": self.config.searchdomain,
+        }
+
+    def as_netbox_create_body(self) -> NetBoxVirtualMachineCreateBody:
+        """Return validated NetBox virtual machine create body."""
+
+        return NetBoxVirtualMachineCreateBody(
+            name=self.resource.name,
+            status=self.resource.status,
+            cluster=self.cluster_id,
+            device=self.device_id,
+            role=self.role_id,
+            vcpus=int(self.resource.maxcpu or 0),
+            memory=self.resource.memory_mb,
+            disk=self.resource.disk_mb,
+            tags=[tag for tag in self.tag_ids if int(tag) > 0],
+            custom_fields=self.vm_custom_fields,
+            description=f"Synced from Proxmox node {self.resource.node}",
+        )

--- a/proxbox_api/proxmox_to_netbox/netbox_schema.py
+++ b/proxbox_api/proxmox_to_netbox/netbox_schema.py
@@ -1,0 +1,133 @@
+"""NetBox OpenAPI fetch and fallback schema contract helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+from proxbox_api.database import NetBoxEndpoint, get_session
+from sqlmodel import select
+
+
+def netbox_openapi_cache_path() -> Path:
+    """Return canonical path for cached NetBox OpenAPI document."""
+
+    return Path(__file__).resolve().parents[1] / "generated" / "netbox" / "openapi.json"
+
+
+def _candidate_schema_urls(base_url: str) -> list[str]:
+    base = base_url.rstrip("/")
+    return [
+        f"{base}/api/schema/?format=openapi",
+        f"{base}/api/schema/?format=openapi-json",
+        f"{base}/api/schema/",
+    ]
+
+
+def _extract_netbox_endpoint_from_db() -> NetBoxEndpoint | None:
+    try:
+        database_session = next(get_session())
+        endpoint = database_session.exec(select(NetBoxEndpoint)).first()
+        return endpoint
+    except Exception:
+        return None
+
+
+def fetch_live_netbox_openapi(timeout: int = 20) -> dict[str, Any] | None:
+    """Fetch live NetBox OpenAPI from configured endpoint using known schema URLs."""
+
+    endpoint = _extract_netbox_endpoint_from_db()
+    if endpoint is None:
+        return None
+
+    headers = {"Accept": "application/json"}
+    if endpoint.token:
+        headers["Authorization"] = f"Token {endpoint.token}"
+
+    for url in _candidate_schema_urls(endpoint.url):
+        try:
+            request = Request(url=url, headers=headers)
+            with urlopen(request, timeout=timeout) as response:
+                body = response.read().decode("utf-8")
+            data = json.loads(body)
+            if isinstance(data, dict) and "paths" in data:
+                return data
+        except (URLError, TimeoutError, json.JSONDecodeError, ValueError):
+            continue
+        except Exception:
+            continue
+    return None
+
+
+def save_netbox_openapi_cache(document: dict[str, Any]) -> None:
+    """Persist fetched NetBox OpenAPI document to local cache."""
+
+    path = netbox_openapi_cache_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(document, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def load_netbox_openapi_cache() -> dict[str, Any] | None:
+    """Load cached NetBox OpenAPI from disk if present."""
+
+    path = netbox_openapi_cache_path()
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def netbox_virtual_machine_fallback_contract() -> dict[str, Any]:
+    """Return conservative fallback contract derived from NetBox REST docs."""
+
+    return {
+        "required_fields": ["name", "status", "cluster"],
+        "optional_fields": [
+            "device",
+            "role",
+            "vcpus",
+            "memory",
+            "disk",
+            "tags",
+            "custom_fields",
+            "description",
+        ],
+        "status_examples": ["active", "offline", "planned"],
+        "endpoint": "/api/virtualization/virtual-machines/",
+    }
+
+
+def resolve_netbox_schema_contract() -> dict[str, Any]:
+    """Resolve NetBox schema contract from live OpenAPI, cache, or fallback docs."""
+
+    live = fetch_live_netbox_openapi()
+    if live:
+        save_netbox_openapi_cache(live)
+        return {
+            "source": "live",
+            "openapi": live,
+        }
+
+    cached = load_netbox_openapi_cache()
+    if cached:
+        return {
+            "source": "cache",
+            "openapi": cached,
+        }
+
+    return {
+        "source": "fallback",
+        "openapi": {},
+        "contract": netbox_virtual_machine_fallback_contract(),
+    }
+
+
+def netbox_openapi_schema_source() -> str:
+    """Return human-readable source used for NetBox schema contract resolution."""
+
+    return str(resolve_netbox_schema_contract().get("source", "unknown"))

--- a/proxbox_api/proxmox_to_netbox/normalize.py
+++ b/proxbox_api/proxmox_to_netbox/normalize.py
@@ -1,0 +1,62 @@
+"""Normalization helpers converting Proxmox raw payloads into NetBox-ready bodies."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from proxbox_api.proxmox_to_netbox.errors import ProxmoxToNetBoxError
+from proxbox_api.proxmox_to_netbox.models import (
+    NetBoxVirtualMachineCreateBody,
+    ProxmoxToNetBoxVirtualMachine,
+)
+from proxbox_api.proxmox_to_netbox.netbox_schema import resolve_netbox_schema_contract
+from proxbox_api.proxmox_to_netbox.proxmox_schema import proxmox_operation_schema
+
+
+def _validate_netbox_contract(payload: NetBoxVirtualMachineCreateBody) -> None:
+    contract = resolve_netbox_schema_contract()
+    source = contract.get("source")
+    if source in {"live", "cache"}:
+        return
+    fallback = contract.get("contract", {})
+    required = fallback.get("required_fields", [])
+    data = payload.model_dump(exclude_none=True)
+    missing = [field for field in required if field not in data]
+    if missing:
+        raise ProxmoxToNetBoxError(
+            f"NetBox fallback contract required fields missing: {missing}"
+        )
+
+
+def build_virtual_machine_transform(
+    resource: dict[str, Any],
+    config: dict[str, Any] | None,
+    *,
+    cluster_id: int,
+    device_id: int | None,
+    role_id: int | None,
+    tag_ids: list[int],
+) -> NetBoxVirtualMachineCreateBody:
+    """Build validated NetBox VM create payload from Proxmox raw payload and config."""
+
+    operation = proxmox_operation_schema(
+        path="/cluster/resources",
+        method="GET",
+    )
+    if operation is None:
+        raise ProxmoxToNetBoxError(
+            "Generated Proxmox OpenAPI is missing /cluster/resources GET operation."
+        )
+
+    transform = ProxmoxToNetBoxVirtualMachine(
+        resource=resource,
+        config=config or {},
+        cluster_id=cluster_id,
+        device_id=device_id,
+        role_id=role_id,
+        tag_ids=tag_ids,
+    )
+
+    body = transform.as_netbox_create_body()
+    _validate_netbox_contract(body)
+    return body

--- a/proxbox_api/proxmox_to_netbox/proxmox_schema.py
+++ b/proxbox_api/proxmox_to_netbox/proxmox_schema.py
@@ -1,0 +1,45 @@
+"""Utilities to read generated Proxmox OpenAPI artifacts for mapping contracts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def proxmox_generated_openapi_path() -> Path:
+    """Return canonical generated Proxmox OpenAPI artifact path."""
+
+    return (
+        Path(__file__).resolve().parents[1] / "generated" / "proxmox" / "openapi.json"
+    )
+
+
+def load_proxmox_generated_openapi() -> dict[str, Any]:
+    """Load generated Proxmox OpenAPI document if available."""
+
+    path = proxmox_generated_openapi_path()
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def proxmox_operation_schema(
+    path: str,
+    method: str,
+    openapi: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Get operation schema from generated Proxmox OpenAPI by path and method."""
+
+    document = openapi or load_proxmox_generated_openapi()
+    paths = document.get("paths", {}) if isinstance(document, dict) else {}
+    item = paths.get(path)
+    if not isinstance(item, dict):
+        return None
+    operation = item.get(method.lower())
+    if not isinstance(operation, dict):
+        return None
+    return operation

--- a/proxbox_api/routes/proxmox/CLAUDE.md
+++ b/proxbox_api/routes/proxmox/CLAUDE.md
@@ -17,6 +17,7 @@ Endpoints that expose Proxmox sessions, cluster data, nodes, storage, and VM con
 - cluster.py and nodes.py provide typed response schemas and dependency aliases.
 - VM and storage helpers are consumed by virtualization sync endpoints.
 - Viewer codegen endpoints delegate generation to `proxbox_api.proxmox_codegen`.
+- Viewer codegen endpoints also expose integration contract diagnostics for Proxmox-to-NetBox schema workflows.
 
 ## Extension Guidance
 

--- a/proxbox_api/routes/proxmox/viewer_codegen.py
+++ b/proxbox_api/routes/proxmox/viewer_codegen.py
@@ -10,6 +10,10 @@ from fastapi.responses import PlainTextResponse
 
 from proxbox_api.exception import ProxboxException
 from proxbox_api.proxmox_codegen.pipeline import generate_proxmox_codegen_bundle_async
+from proxbox_api.proxmox_to_netbox.proxmox_schema import (
+    load_proxmox_generated_openapi,
+)
+from proxbox_api.proxmox_to_netbox.netbox_schema import netbox_openapi_schema_source
 
 
 router = APIRouter()
@@ -145,6 +149,33 @@ async def proxmox_viewer_openapi(
             message="Failed to load generated OpenAPI schema.",
             python_exception=str(error),
         )
+
+
+@router.get("/openapi/embedded")
+async def proxmox_viewer_openapi_embedded():
+    """Return generated Proxmox OpenAPI as consumed by custom FastAPI OpenAPI extension."""
+
+    schema = load_proxmox_generated_openapi()
+    if not schema:
+        raise ProxboxException(
+            message="Generated Proxmox OpenAPI schema not found.",
+            detail="Run /proxmox/viewer/generate first.",
+        )
+    return schema
+
+
+@router.get("/integration/contracts")
+async def proxmox_netbox_integration_contracts():
+    """Report Proxmox and NetBox schema contract sources for transformation workflows."""
+
+    proxmox = load_proxmox_generated_openapi()
+    return {
+        "proxmox_generated_openapi_present": bool(proxmox),
+        "proxmox_generated_path_count": len((proxmox.get("paths") or {}).keys())
+        if proxmox
+        else 0,
+        "netbox_schema_source": netbox_openapi_schema_source(),
+    }
 
 
 @router.get("/pydantic", response_class=PlainTextResponse)

--- a/proxbox_api/routes/virtualization/virtual_machines/__init__.py
+++ b/proxbox_api/routes/virtualization/virtual_machines/__init__.py
@@ -46,6 +46,12 @@ from proxbox_api.cache import global_cache
 from proxbox_api.routes.proxmox import (
     get_proxmox_node_storage_content,
 )  # Get Proxmox Node Storage Content
+from proxbox_api.proxmox_to_netbox.mappers.virtual_machine import (
+    map_proxmox_vm_to_netbox_vm_body,
+)
+from proxbox_api.services.sync.virtual_machines import (
+    build_netbox_virtual_machine_payload,
+)
 
 router = APIRouter()
 
@@ -302,39 +308,18 @@ async def create_virtual_machines(
             )
 
         # try:
-        print("name: ", resource.get("name"))
-        print(
-            "status: ",
-            VirtualMachine.status_field.get(resource.get("status"), "active"),
+        netbox_vm_payload = build_netbox_virtual_machine_payload(
+            proxmox_resource=resource,
+            proxmox_config=vm_config,
+            cluster_id=int(getattr(cluster, "id", 0) or 0),
+            device_id=int(getattr(device, "id", 0) or 0),
+            role_id=int(getattr(role, "id", 0) or 0),
+            tag_ids=[int(getattr(tag, "id", 0) or 0)],
         )
-        print("cluster: ", getattr(cluster, "id"))
-        print("device: ", getattr(device, "id"))
-        print("vcpus: ", int(resource.get("maxcpu", 0)))
-        print("memory: ", int(resource.get("maxmem")) // 1000000)
-        print("disk: ", int(resource.get("maxdisk", 0)) // 1000000)
-        print("tags: ", [getattr(tag, "id")])
-        print("role: ", getattr(role, "id"))
 
         virtual_machine = await asyncio.to_thread(
             lambda: VirtualMachine(
-                name=resource.get("name"),
-                status=VirtualMachine.status_field.get(
-                    resource.get("status"), "active"
-                ),
-                cluster=getattr(cluster, "id"),
-                device=getattr(device, "id"),
-                vcpus=int(resource.get("maxcpu", 0)),
-                memory=int(resource.get("maxmem")) // 1000000,
-                disk=int(resource.get("maxdisk", 0)) // 1000000,
-                tags=[getattr(tag, "id")],
-                role=getattr(role, "id"),
-                custom_fields={
-                    "proxmox_vm_id": resource.get("vmid"),
-                    "proxmox_start_at_boot": start_at_boot,
-                    "proxmox_unprivileged_container": unprivileged_container,
-                    "proxmox_qemu_agent": qemu_agent,
-                    "proxmox_search_domain": search_domain,
-                },
+                **netbox_vm_payload,
             )
         )
 

--- a/proxbox_api/services/sync/virtual_machines.py
+++ b/proxbox_api/services/sync/virtual_machines.py
@@ -1,2 +1,30 @@
-"""Virtual machine synchronization service placeholder module."""
+"""Virtual machine synchronization service helpers for Proxmox-to-NetBox mapping."""
 
+from __future__ import annotations
+
+from typing import Any
+
+from proxbox_api.proxmox_to_netbox.mappers.virtual_machine import (
+    map_proxmox_vm_to_netbox_vm_body,
+)
+
+
+def build_netbox_virtual_machine_payload(
+    *,
+    proxmox_resource: dict[str, Any],
+    proxmox_config: dict[str, Any] | None,
+    cluster_id: int,
+    device_id: int | None,
+    role_id: int | None,
+    tag_ids: list[int],
+) -> dict[str, Any]:
+    """Build NetBox virtual machine payload from Proxmox raw resource/config payloads."""
+
+    return map_proxmox_vm_to_netbox_vm_body(
+        resource=proxmox_resource,
+        config=proxmox_config,
+        cluster_id=cluster_id,
+        device_id=device_id,
+        role_id=role_id,
+        tag_ids=tag_ids,
+    )

--- a/proxbox_api/test_main.py
+++ b/proxbox_api/test_main.py
@@ -32,6 +32,12 @@ def test_read_root():
     }
 
 
+def test_custom_openapi_contains_embedded_proxmox_extension():
+    schema = app.openapi()
+    assert isinstance(schema, dict)
+    assert "x-proxmox-generated-openapi" in schema
+
+
 def test_openapi_generation_pipeline_from_sample_capture():
     sample_capture = {
         "/version": {

--- a/proxbox_api/test_proxmox_to_netbox.py
+++ b/proxbox_api/test_proxmox_to_netbox.py
@@ -1,0 +1,69 @@
+"""Tests for Proxmox-to-NetBox normalization and schema contract helpers."""
+
+from pathlib import Path
+
+from proxbox_api.proxmox_to_netbox.mappers.virtual_machine import (
+    map_proxmox_vm_to_netbox_vm_body,
+)
+from proxbox_api.proxmox_to_netbox.netbox_schema import resolve_netbox_schema_contract
+from proxbox_api.proxmox_to_netbox.proxmox_schema import load_proxmox_generated_openapi
+
+
+def test_map_proxmox_vm_to_netbox_vm_body():
+    resource = {
+        "vmid": 101,
+        "name": "db-vm-01",
+        "node": "pve01",
+        "status": "running",
+        "type": "qemu",
+        "maxcpu": 4,
+        "maxmem": 8_589_934_592,
+        "maxdisk": 107_374_182_400,
+    }
+    config = {
+        "onboot": 1,
+        "agent": 1,
+        "unprivileged": 0,
+        "searchdomain": "lab.local",
+    }
+
+    body = map_proxmox_vm_to_netbox_vm_body(
+        resource=resource,
+        config=config,
+        cluster_id=11,
+        device_id=22,
+        role_id=33,
+        tag_ids=[7],
+    )
+
+    assert body["name"] == "db-vm-01"
+    assert body["status"] == "active"
+    assert body["cluster"] == 11
+    assert body["device"] == 22
+    assert body["role"] == 33
+    assert body["vcpus"] == 4
+    assert body["memory"] > 0
+    assert body["disk"] > 0
+    assert body["custom_fields"]["proxmox_vm_id"] == 101
+    assert body["custom_fields"]["proxmox_start_at_boot"] is True
+
+
+def test_load_proxmox_generated_openapi_present():
+    document = load_proxmox_generated_openapi()
+    assert isinstance(document, dict)
+    assert "paths" in document
+
+
+def test_netbox_schema_contract_resolves_source():
+    resolved = resolve_netbox_schema_contract()
+    assert resolved.get("source") in {"live", "cache", "fallback"}
+
+    if resolved.get("source") == "fallback":
+        contract = resolved.get("contract") or {}
+        assert "required_fields" in contract
+        assert "endpoint" in contract
+
+
+def test_generated_netbox_cache_package_exists():
+    package_path = Path(__file__).resolve().parent / "generated" / "netbox"
+    assert package_path.exists()

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -12,3 +12,12 @@
 ## Review
 
 - Done. Async parallel crawl verified, generated artifacts validated, compileall and pytest passed.
+
+## Integration Refactor
+
+- [x] Create `integration-refactor` branch and run baseline checks.
+- [x] Add FastAPI custom OpenAPI override and embed generated Proxmox OpenAPI.
+- [x] Add `proxmox_to_netbox` package with schema loaders and Pydantic v2 VM normalization.
+- [x] Refactor VM sync payload build to use `proxmox_to_netbox` mapper/service helper.
+- [x] Add tests for Proxmox-to-NetBox mapping and schema contract resolution.
+- [x] Run final compile/test validation and fix regressions.


### PR DESCRIPTION
## Why

This PR adds an integration-focused refactor to make Proxbox expose generated Proxmox OpenAPI contracts in FastAPI and introduce a schema-driven Proxmox-to-NetBox transformation layer for VM synchronization payloads.

The goal is to move from ad-hoc payload shaping to validated Pydantic v2 models that accept raw Proxmox data and emit NetBox-ready request bodies.

## What changed

- Added FastAPI custom OpenAPI override following official FastAPI docs pattern (`get_openapi` + `app.openapi_schema` cache).
- Embedded generated Proxmox OpenAPI (`proxbox_api/generated/proxmox/openapi.json`) into app OpenAPI via vendor extension.
- Added `proxmox_to_netbox` package with:
  - Proxmox schema readers from generated artifacts.
  - NetBox schema contract resolution (live fetch first, local cache second, docs-derived fallback third).
  - Pydantic v2 VM transform models with field/model validators and computed fields.
  - Mapper and normalization orchestration for Proxmox raw VM payload -> NetBox VM create payload.
- Refactored VM sync payload construction to use the new transformation helper/service.
- Added integration diagnostics endpoints under Proxmox viewer routes.
- Added generated NetBox schema cache package path and docs.

## New modules

- `proxbox_api/openapi_custom.py`
- `proxbox_api/proxmox_to_netbox/*`
- `proxbox_api/proxmox_to_netbox/mappers/*`
- `proxbox_api/generated/netbox/*`

## Runtime API additions

- `GET /proxmox/viewer/openapi/embedded`
- `GET /proxmox/viewer/integration/contracts`

## Validation

- `python -m compileall proxbox_api` passed
- `pytest` passed (`8 passed`)

## Notes on behavior

- NetBox schema source is resolved in order:
  1. live NetBox schema from configured endpoint in DB
  2. cached local NetBox OpenAPI artifact
  3. conservative fallback contract derived from official NetBox docs
- VM mapping now flows through Pydantic v2 normalization, generating deterministic NetBox create payload dictionaries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: introduces a new transformation layer and changes VM sync payload construction; also overrides OpenAPI generation and adds live NetBox schema fetching/caching which could affect runtime behavior if schemas/paths differ or are unavailable.
> 
> **Overview**
> **Adds a schema-driven Proxmox→NetBox transformation layer and wires it into VM sync.** VM creation now builds its NetBox payload via new Pydantic v2 normalization/mapping (`proxbox_api/proxmox_to_netbox`) instead of ad-hoc field assembly.
> 
> **Extends API contract visibility and diagnostics.** FastAPI OpenAPI generation is overridden to embed the generated Proxmox `openapi.json` as a vendor extension, and new Proxmox viewer endpoints expose the embedded schema plus integration contract/source diagnostics; a NetBox OpenAPI cache package is added and tests cover the new OpenAPI extension and VM mapping/contract resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6fee7d5547af4206adf6ee0e8ce076f40b122921. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->