### PR TITLE
docs: add MkDocs Material docs with pt-BR option

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,71 @@
+name: docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "requirements-docs.txt"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "requirements-docs.txt"
+      - ".github/workflows/docs.yml"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install docs dependencies
+        run: pip install -r requirements-docs.txt
+
+      - name: Build docs
+        run: mkdocs build --strict
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install docs dependencies
+        run: pip install -r requirements-docs.txt
+
+      - name: Build docs
+        run: mkdocs build --strict
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./site

--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # Installing proxbox-api (Plugin backend made using FastAPI)
 
+## Documentation (MkDocs Material)
+
+Project documentation is available under `docs/` and built with MkDocs Material.
+
+### Local docs build
+
+```bash
+pip install -r requirements-docs.txt
+mkdocs serve
+```
+
+### Languages
+
+- English (default)
+- Brazilian Portuguese (`pt-BR`) as optional translation
+
 ## Using docker (recommended)
 
 ### Pull the docker image

--- a/docs/api/http-reference.md
+++ b/docs/api/http-reference.md
@@ -1,0 +1,111 @@
+# HTTP API Reference
+
+This page summarizes main HTTP endpoints exposed by `proxbox-api`.
+
+For full request/response schemas, use runtime OpenAPI at `/docs`.
+
+## Root and utility
+
+- `GET /` - Service metadata and links.
+- `GET /cache` - Inspect in-memory cache snapshot.
+- `GET /clear-cache` - Clear in-memory cache.
+- `GET /sync-processes` - List sync process records from NetBox plugin API.
+- `POST /sync-processes` - Create a sync process record in NetBox plugin API.
+
+## NetBox routes (`/netbox`)
+
+- `POST /netbox/endpoint` - Create singleton NetBox endpoint.
+- `GET /netbox/endpoint` - List NetBox endpoint records.
+- `GET /netbox/endpoint/{netbox_id}` - Get endpoint by ID.
+- `PUT /netbox/endpoint/{netbox_id}` - Update endpoint.
+- `DELETE /netbox/endpoint/{netbox_id}` - Delete endpoint.
+- `GET /netbox/status` - Fetch NetBox API status.
+- `GET /netbox/openapi` - Fetch NetBox OpenAPI.
+
+### NetBox singleton rule
+
+Attempting to create a second endpoint returns HTTP 400 with:
+
+```json
+{
+  "detail": "Only one NetBox endpoint is allowed"
+}
+```
+
+## Proxmox routes (`/proxmox`)
+
+### Endpoint configuration CRUD
+
+- `POST /proxmox/endpoints`
+- `GET /proxmox/endpoints`
+- `GET /proxmox/endpoints/{endpoint_id}`
+- `PUT /proxmox/endpoints/{endpoint_id}`
+- `DELETE /proxmox/endpoints/{endpoint_id}`
+
+Validation rules:
+
+- Require `password` or (`token_name` and `token_value`).
+- `token_name` and `token_value` must be set together.
+- Endpoint names must be unique.
+
+### Session and discovery
+
+- `GET /proxmox/sessions`
+- `GET /proxmox/version`
+- `GET /proxmox/`
+- `GET /proxmox/storage`
+- `GET /proxmox/nodes/{node}/storage/{storage}/content`
+- `GET /proxmox/{top_level}`
+- `GET /proxmox/{node}/{type}/{vmid}/config`
+
+### Cluster and node data
+
+- `GET /proxmox/cluster/status`
+- `GET /proxmox/cluster/resources`
+- `GET /proxmox/nodes/`
+- `GET /proxmox/nodes/{node}/network`
+- `GET /proxmox/nodes/{node}/qemu`
+
+### Viewer code generation
+
+- `POST /proxmox/viewer/generate`
+- `GET /proxmox/viewer/openapi`
+- `GET /proxmox/viewer/openapi/embedded`
+- `GET /proxmox/viewer/integration/contracts`
+- `GET /proxmox/viewer/pydantic`
+
+## DCIM routes (`/dcim`)
+
+- `GET /dcim/devices`
+- `GET /dcim/devices/create`
+- `GET /dcim/devices/{node}/interfaces/create`
+- `GET /dcim/devices/interfaces/create`
+
+## Virtualization routes (`/virtualization`)
+
+- `GET /virtualization/cluster-types/create` (placeholder)
+- `GET /virtualization/clusters/create` (placeholder)
+- `GET /virtualization/virtual-machines/create`
+- `GET /virtualization/virtual-machines/`
+- `GET /virtualization/virtual-machines/{id}`
+- `GET /virtualization/virtual-machines/summary/example`
+- `GET /virtualization/virtual-machines/backups/create`
+- `GET /virtualization/virtual-machines/backups/all/create`
+
+Additional test/helper and TODO endpoints also exist in this route group.
+
+## Extras routes (`/extras`)
+
+- `GET /extras/extras/custom-fields/create`
+
+This endpoint creates expected custom fields used by VM synchronization metadata.
+
+## Proxbox plugin config routes
+
+These route handlers exist in `proxbox_api/routes/proxbox/__init__.py` but are not currently mounted in `main.py`:
+
+- `GET /netbox/plugins-config`
+- `GET /netbox/default-settings`
+- `GET /settings`
+
+Mounting them requires including that router in app startup if desired.

--- a/docs/api/websocket-reference.md
+++ b/docs/api/websocket-reference.md
@@ -1,0 +1,58 @@
+# WebSocket API Reference
+
+`proxbox-api` exposes WebSocket endpoints for streaming sync progress and command execution feedback.
+
+## `GET /` (WebSocket)
+
+Endpoint:
+
+- `ws://<host>:<port>/`
+
+Behavior:
+
+- Accepts connection.
+- Sends incremental message counter every 2 seconds.
+
+Use case:
+
+- Basic connectivity check.
+
+## `GET /ws/virtual-machines` (WebSocket)
+
+Endpoint:
+
+- `ws://<host>:<port>/ws/virtual-machines`
+
+Behavior:
+
+- Accepts connection and sends welcome text.
+- Triggers VM synchronization workflow (`create_virtual_machines`).
+- Emits JSON progress events while VM sync runs (when websocket mode is enabled in flow).
+
+Use case:
+
+- Monitor VM sync lifecycle in near real-time.
+
+## `GET /ws` (WebSocket)
+
+Endpoint:
+
+- `ws://<host>:<port>/ws`
+
+Behavior:
+
+- Accepts connection and listens for command text.
+- Supported commands:
+  - `Full Update Sync`
+  - `Sync Nodes`
+  - `Sync Virtual Machines`
+- Runs corresponding sync tasks and streams status messages.
+
+Invalid command behavior:
+
+- Returns guidance with valid command list.
+
+## Notes
+
+- WebSocket flows depend on a valid NetBox endpoint and Proxmox sessions.
+- Long-running operations may create sync-process records and journal entries in NetBox plugin objects.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,60 @@
+# Architecture Overview
+
+`proxbox-api` is organized around FastAPI routing, session dependencies, sync services, and schema layers.
+
+## High-level layers
+
+- API layer: `proxbox_api/main.py`, `proxbox_api/routes/*`
+- Session layer: `proxbox_api/session/*`
+- Service layer: `proxbox_api/services/sync/*`
+- Schema and enum layer: `proxbox_api/schemas/*`, `proxbox_api/enum/*`
+- Persistence layer: `proxbox_api/database.py`
+- Utility layer: decorators, logging, cache, exceptions
+
+## Runtime components
+
+- FastAPI app with grouped routers:
+  - `/netbox`
+  - `/proxmox`
+  - `/dcim`
+  - `/virtualization`
+  - `/extras`
+- SQLite-backed endpoint configuration.
+- NetBox API access via `netbox-sdk` sync proxy.
+- Proxmox API access via `proxmoxer` sessions.
+
+## Core data models
+
+### `NetBoxEndpoint`
+
+- Fields: `name`, `ip_address`, `domain`, `port`, `token`, `verify_ssl`
+- Includes computed `url` property for NetBox session creation.
+- API-level singleton behavior is enforced by create endpoint logic.
+
+### `ProxmoxEndpoint`
+
+- Fields: `name`, `ip_address`, `domain`, `port`, `username`, `password`, `verify_ssl`, `token_name`, `token_value`
+- Supports both password and token auth models.
+
+## Startup flow
+
+1. App initializes and attempts database table creation.
+2. NetBox endpoint is loaded if present.
+3. NetBox session is initialized and stored in compatibility layer.
+4. CORS origins are assembled.
+5. Routers are mounted.
+
+## OpenAPI extension
+
+`proxbox_api/openapi_custom.py` overrides FastAPI OpenAPI generation and embeds generated Proxmox OpenAPI metadata when available:
+
+- Source file: `proxbox_api/generated/proxmox/openapi.json`
+- Extension fields:
+  - `info.x-proxmox-generated-openapi`
+  - `x-proxmox-generated-openapi`
+
+## Sync lifecycle
+
+- Sync endpoints orchestrate Proxmox discovery and NetBox object creation.
+- Journal entries and sync-process records are used for traceability.
+- WebSocket endpoints stream long-running sync progress.

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,0 +1,88 @@
+# Configuration
+
+`proxbox-api` uses SQLite for local bootstrap configuration and runtime dependencies.
+
+## Database location
+
+- Default SQLite file: `database.db` in repository root.
+- ORM: SQLModel.
+- Tables are created automatically at startup.
+
+## NetBox endpoint (singleton)
+
+NetBox endpoint configuration is managed with:
+
+- `POST /netbox/endpoint`
+- `GET /netbox/endpoint`
+- `PUT /netbox/endpoint/{netbox_id}`
+- `DELETE /netbox/endpoint/{netbox_id}`
+
+Only one NetBox endpoint record is allowed.
+
+### Example payload
+
+```json
+{
+  "name": "netbox-primary",
+  "ip_address": "10.0.0.20",
+  "domain": "netbox.local",
+  "port": 443,
+  "token": "<NETBOX_API_TOKEN>",
+  "verify_ssl": true
+}
+```
+
+## Proxmox endpoints (multiple)
+
+Proxmox endpoint records are managed with:
+
+- `POST /proxmox/endpoints`
+- `GET /proxmox/endpoints`
+- `GET /proxmox/endpoints/{endpoint_id}`
+- `PUT /proxmox/endpoints/{endpoint_id}`
+- `DELETE /proxmox/endpoints/{endpoint_id}`
+
+Authentication rules for create and update:
+
+- You must provide either `password`, or both `token_name` and `token_value`.
+- `token_name` and `token_value` must be provided together.
+
+### Password-based example
+
+```json
+{
+  "name": "pve-lab-1",
+  "ip_address": "10.0.0.10",
+  "domain": "pve-lab-1.local",
+  "port": 8006,
+  "username": "root@pam",
+  "password": "<PASSWORD>",
+  "verify_ssl": false
+}
+```
+
+### Token-based example
+
+```json
+{
+  "name": "pve-lab-token",
+  "ip_address": "10.0.0.11",
+  "domain": "pve-lab-token.local",
+  "port": 8006,
+  "username": "root@pam",
+  "token_name": "api-token",
+  "token_value": "<TOKEN_VALUE>",
+  "verify_ssl": true
+}
+```
+
+## Runtime session behavior
+
+- NetBox session is derived from the single stored NetBox endpoint.
+- Proxmox sessions default to local database endpoint records.
+- Legacy source mode (`source=netbox`) is still supported in Proxmox session dependency behavior.
+
+## CORS behavior
+
+- Origins are populated from NetBox endpoint records plus default development origins.
+- Methods are currently allowed for all (`allow_methods=["*"]`).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,78 @@
+# Installation
+
+This page documents supported ways to run `proxbox-api`.
+
+## Requirements
+
+- Python 3.10+
+- `uv` (recommended) or `pip`
+- Network access to NetBox and Proxmox targets
+
+## Option 1: Docker (recommended for quick start)
+
+Pull image:
+
+```bash
+docker pull emersonfelipesp/proxbox-api:latest
+```
+
+Run container:
+
+```bash
+docker run -d -p 8800:8800 --name proxbox-api emersonfelipesp/proxbox-api:latest
+```
+
+Service URL:
+
+- <http://127.0.0.1:8800>
+
+## Option 2: Local development from source
+
+Clone repository:
+
+```bash
+git clone https://github.com/emersonfelipesp/proxbox-api.git
+cd proxbox-api
+```
+
+Install runtime dependencies:
+
+```bash
+pip install -e .
+```
+
+Or use `uv`:
+
+```bash
+uv sync
+```
+
+Run API:
+
+```bash
+uv run fastapi run --host 0.0.0.0 --port 8800
+```
+
+Alternative with uvicorn:
+
+```bash
+uv run uvicorn proxbox_api.main:app --host 0.0.0.0 --port 8800 --reload
+```
+
+## TLS with local certificates
+
+If you need HTTPS locally, generate a certificate with `mkcert` and pass it to uvicorn:
+
+```bash
+mkcert -install
+mkcert proxbox.backend.local localhost 127.0.0.1 ::1
+uv run uvicorn proxbox_api.main:app --host 0.0.0.0 --port 8800 --ssl-keyfile=./localhost+2-key.pem --ssl-certfile=./localhost+2.pem
+```
+
+## Verify installation
+
+Open:
+
+- Root: <http://127.0.0.1:8800/>
+- Swagger: <http://127.0.0.1:8800/docs>
+- ReDoc: <http://127.0.0.1:8800/redoc>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,38 @@
+# proxbox-api Documentation
+
+`proxbox-api` is a FastAPI backend that connects Proxmox infrastructure workflows with NetBox data models and plugin objects.
+
+This documentation covers installation, configuration, architecture, API references, synchronization flows, and contribution guidelines.
+
+## What this service does
+
+- Stores local endpoint bootstrap data in SQLite for NetBox and Proxmox connections.
+- Exposes REST APIs for Proxmox and NetBox endpoint management.
+- Exposes Proxmox data and sync orchestration endpoints.
+- Provides WebSocket endpoints for long-running sync feedback.
+- Includes a generated OpenAPI extension for Proxmox API viewer contracts.
+
+## Main capabilities
+
+- NetBox endpoint bootstrap (singleton endpoint behavior).
+- Proxmox endpoint CRUD (multiple endpoints).
+- Cluster, node, storage, and VM data collection.
+- Virtual machine and backup synchronization toward NetBox.
+- Custom field bootstrap under NetBox extras.
+
+## Audience
+
+- Network automation engineers integrating NetBox and Proxmox.
+- Backend developers extending sync behavior.
+- Operators deploying the API as a standalone service.
+
+## Quick links
+
+- API docs (runtime): `/docs` (Swagger UI), `/redoc`.
+- Health/info root endpoint: `/`.
+- Project repository: <https://github.com/emersonfelipesp/proxbox-api>
+
+## Language
+
+- Default language: English.
+- Optional translation: Brazilian Portuguese (`pt-BR`) using the language switcher.

--- a/docs/pt-BR/api/http-reference.md
+++ b/docs/pt-BR/api/http-reference.md
@@ -1,0 +1,38 @@
+# Referencia HTTP da API
+
+Esta pagina resume os principais endpoints HTTP do `proxbox-api`.
+
+## Utilitarios
+
+- `GET /`
+- `GET /cache`
+- `GET /clear-cache`
+- `GET /sync-processes`
+- `POST /sync-processes`
+
+## Rotas NetBox
+
+- `POST /netbox/endpoint`
+- `GET /netbox/endpoint`
+- `GET /netbox/endpoint/{netbox_id}`
+- `PUT /netbox/endpoint/{netbox_id}`
+- `DELETE /netbox/endpoint/{netbox_id}`
+- `GET /netbox/status`
+- `GET /netbox/openapi`
+
+Regra singleton:
+
+- Apenas um endpoint NetBox pode ser criado.
+
+## Rotas Proxmox
+
+- CRUD de endpoints: `/proxmox/endpoints*`
+- Sessao e descoberta: `/proxmox/sessions`, `/proxmox/version`, `/proxmox/`
+- Cluster e nodes: `/proxmox/cluster/*`, `/proxmox/nodes/*`
+- Viewer codegen: `/proxmox/viewer/*`
+
+## Rotas de sincronizacao
+
+- `/dcim/*`
+- `/virtualization/*`
+- `/extras/*`

--- a/docs/pt-BR/api/websocket-reference.md
+++ b/docs/pt-BR/api/websocket-reference.md
@@ -1,0 +1,15 @@
+# Referencia WebSocket da API
+
+## Endpoints
+
+- `ws://<host>:<port>/`
+- `ws://<host>:<port>/ws/virtual-machines`
+- `ws://<host>:<port>/ws`
+
+## Comandos em `/ws`
+
+- `Full Update Sync`
+- `Sync Nodes`
+- `Sync Virtual Machines`
+
+Comando invalido retorna orientacao com comandos suportados.

--- a/docs/pt-BR/architecture/overview.md
+++ b/docs/pt-BR/architecture/overview.md
@@ -1,0 +1,17 @@
+# Visao Geral da Arquitetura
+
+`proxbox-api` e organizado em camadas de rotas FastAPI, dependencias de sessao, servicos de sync e esquemas.
+
+## Camadas principais
+
+- API: `proxbox_api/main.py`, `proxbox_api/routes/*`
+- Sessao: `proxbox_api/session/*`
+- Servicos: `proxbox_api/services/sync/*`
+- Persistencia: `proxbox_api/database.py`
+
+## Componentes de runtime
+
+- App FastAPI com roteadores em `/netbox`, `/proxmox`, `/dcim`, `/virtualization` e `/extras`.
+- Configuracao de endpoint em SQLite.
+- Sessao NetBox por `netbox-sdk`.
+- Sessao Proxmox por `proxmoxer`.

--- a/docs/pt-BR/getting-started/configuration.md
+++ b/docs/pt-BR/getting-started/configuration.md
@@ -1,0 +1,25 @@
+# Configuracao
+
+O `proxbox-api` usa SQLite para configuracao local e dependencias de execucao.
+
+## Endpoint NetBox (singleton)
+
+- `POST /netbox/endpoint`
+- `GET /netbox/endpoint`
+- `PUT /netbox/endpoint/{netbox_id}`
+- `DELETE /netbox/endpoint/{netbox_id}`
+
+Apenas um endpoint NetBox e permitido.
+
+## Endpoints Proxmox (multiplos)
+
+- `POST /proxmox/endpoints`
+- `GET /proxmox/endpoints`
+- `GET /proxmox/endpoints/{endpoint_id}`
+- `PUT /proxmox/endpoints/{endpoint_id}`
+- `DELETE /proxmox/endpoints/{endpoint_id}`
+
+Regras de autenticacao:
+
+- Forneca `password`, ou `token_name` + `token_value`.
+- `token_name` e `token_value` devem ser enviados juntos.

--- a/docs/pt-BR/getting-started/installation.md
+++ b/docs/pt-BR/getting-started/installation.md
@@ -1,0 +1,31 @@
+# Instalacao
+
+Esta pagina documenta formas suportadas para executar o `proxbox-api`.
+
+## Requisitos
+
+- Python 3.10+
+- `uv` (recomendado) ou `pip`
+- Acesso de rede aos destinos NetBox e Proxmox
+
+## Opcao 1: Docker
+
+```bash
+docker pull emersonfelipesp/proxbox-api:latest
+docker run -d -p 8800:8800 --name proxbox-api emersonfelipesp/proxbox-api:latest
+```
+
+## Opcao 2: Codigo-fonte local
+
+```bash
+git clone https://github.com/emersonfelipesp/proxbox-api.git
+cd proxbox-api
+pip install -e .
+uv run fastapi run --host 0.0.0.0 --port 8800
+```
+
+Alternativa:
+
+```bash
+uv run uvicorn proxbox_api.main:app --host 0.0.0.0 --port 8800 --reload
+```

--- a/docs/pt-BR/index.md
+++ b/docs/pt-BR/index.md
@@ -1,0 +1,18 @@
+# Documentacao do proxbox-api
+
+`proxbox-api` e um backend FastAPI que conecta fluxos de infraestrutura do Proxmox com modelos e objetos de plugin do NetBox.
+
+Esta documentacao cobre instalacao, configuracao, arquitetura, referencias de API, fluxos de sincronizacao e contribuicao.
+
+## O que este servico faz
+
+- Armazena dados locais de bootstrap para conexoes NetBox e Proxmox em SQLite.
+- Expoe APIs REST para gerenciamento de endpoints NetBox e Proxmox.
+- Expoe endpoints de dados Proxmox e orquestracao de sincronizacao.
+- Fornece endpoints WebSocket para feedback de sincronizacoes longas.
+- Inclui extensao OpenAPI gerada para contratos do API viewer do Proxmox.
+
+## Idioma
+
+- Idioma padrao: Ingles.
+- Traducao opcional: Portugues Brasileiro (`pt-BR`) pelo seletor de idioma.

--- a/docs/pt-BR/sync/workflows.md
+++ b/docs/pt-BR/sync/workflows.md
@@ -1,0 +1,25 @@
+# Fluxos de Sincronizacao
+
+## Full update
+
+Endpoint:
+
+- `GET /full-update`
+
+Fluxo:
+
+1. Cria sync-process no NetBox.
+2. Sincroniza nodes Proxmox em devices NetBox.
+3. Sincroniza VMs Proxmox em VMs NetBox.
+4. Atualiza runtime e status final.
+
+## Sync de VMs
+
+Endpoint principal:
+
+- `GET /virtualization/virtual-machines/create`
+
+## Sync de backups
+
+- `GET /virtualization/virtual-machines/backups/create`
+- `GET /virtualization/virtual-machines/backups/all/create`

--- a/docs/sync/workflows.md
+++ b/docs/sync/workflows.md
@@ -1,0 +1,57 @@
+# Synchronization Workflows
+
+This page explains major synchronization workflows between Proxmox and NetBox.
+
+## Full update flow
+
+HTTP endpoint:
+
+- `GET /full-update`
+
+High-level sequence:
+
+1. Create NetBox sync-process record.
+2. Sync Proxmox nodes into NetBox devices.
+3. Sync Proxmox virtual machines into NetBox VMs.
+4. Mark sync-process as completed and store runtime.
+
+## Virtual machine sync flow
+
+Primary endpoint:
+
+- `GET /virtualization/virtual-machines/create`
+
+Core behavior:
+
+- Reads cluster resources from Proxmox sessions.
+- Resolves VM configs per VM (`qemu`/`lxc`).
+- Builds normalized NetBox payload.
+- Creates dependencies (cluster, device, role) as needed.
+- Creates VM interfaces and IP addresses when possible.
+- Writes journal entries for auditability.
+
+## Backup sync flow
+
+Endpoints:
+
+- `GET /virtualization/virtual-machines/backups/create`
+- `GET /virtualization/virtual-machines/backups/all/create`
+
+Core behavior:
+
+- Discovers backup content in Proxmox storage.
+- Maps backups to NetBox VMs.
+- Creates backup objects under NetBox plugin model.
+- Handles duplicate detection.
+- Optional deletion of backups missing in Proxmox source.
+
+## Tracking and observability
+
+- Sync process records are created in NetBox plugin objects.
+- Journal entries are written with summary and errors.
+- WebSocket workflows provide interactive status output.
+
+## Failure handling
+
+- Domain errors are raised via `ProxboxException` and returned as structured JSON by app-level handler.
+- Route handlers perform best-effort continuation in certain batch loops.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,68 @@
+site_name: proxbox-api
+site_description: FastAPI backend for Proxmox and NetBox integration
+site_url: https://emersonfelipesp.github.io/proxbox-api/
+repo_url: https://github.com/emersonfelipesp/proxbox-api
+repo_name: emersonfelipesp/proxbox-api
+
+theme:
+  name: material
+  language: en
+  features:
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - content.code.copy
+    - content.action.edit
+  icon:
+    repo: fontawesome/brands/github
+
+extra:
+  alternate:
+    - name: English
+      link: /
+      lang: en
+    - name: Portugues (Brasil)
+      link: /pt-BR/
+      lang: pt-BR
+
+plugins:
+  - search
+  - i18n:
+      docs_structure: folder
+      reconfigure_material: true
+      languages:
+        - locale: en
+          name: English
+          default: true
+          build: true
+        - locale: pt-BR
+          name: Portugues (Brasil)
+          build: true
+
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true
+  - tables
+  - pymdownx.superfences
+  - pymdownx.inlinehilite
+  - pymdownx.highlight:
+      anchor_linenums: true
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Installation: getting-started/installation.md
+      - Configuration: getting-started/configuration.md
+  - Architecture:
+      - Overview: architecture/overview.md
+  - API:
+      - HTTP Reference: api/http-reference.md
+      - WebSocket Reference: api/websocket-reference.md
+  - Synchronization:
+      - Workflows: sync/workflows.md
+  - Development:
+      - Testing: development/testing.md
+      - Deployment: development/deployment.md
+      - Troubleshooting: development/troubleshooting.md
+      - Contributing: development/contributing.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,3 @@
+mkdocs>=1.6.0
+mkdocs-material>=9.5.0
+mkdocs-static-i18n>=1.2.3

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -21,3 +21,17 @@
 - [x] Refactor VM sync payload build to use `proxmox_to_netbox` mapper/service helper.
 - [x] Add tests for Proxmox-to-NetBox mapping and schema contract resolution.
 - [x] Run final compile/test validation and fix regressions.
+
+## MkDocs Material Documentation
+
+- [x] Create `material-for-mkdocs` branch from `main`.
+- [x] Add MkDocs Material configuration with English default and optional pt-BR locale.
+- [x] Write full English documentation for architecture, install, config, API, sync, troubleshooting, tests, and contribution.
+- [x] Add pt-BR translated documentation pages with mirrored structure.
+- [x] Add GitHub Actions workflow to build docs and publish to `gh-pages` on push to `main`.
+- [x] Run strict docs build and resolve configuration warnings/errors.
+
+## Review
+
+- Completed. Added `mkdocs.yml`, full `docs/` tree in EN + pt-BR, docs workflow at `.github/workflows/docs.yml`, and `requirements-docs.txt`.
+- Verified with `mkdocs build --strict` on branch `material-for-mkdocs`.


### PR DESCRIPTION
## Summary
- add a complete MkDocs Material documentation site for proxbox-api with English as default language
- add Brazilian Portuguese (pt-BR) as an optional translated docs tree and language switcher
- add GitHub Actions workflow to run strict docs build and deploy to `gh-pages` on pushes to `main`

## Validation
- mkdocs build --strict