### PR TITLE
feat(e2e): add end-to-end test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, testing]
   pull_request:
     branches: [main, testing]
+  workflow_dispatch:
 
 jobs:
   test:
@@ -17,7 +18,6 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          # Matches Dockerfile base; dependency versions come from uv.lock (not the runner image).
           python-version: "3.12"
 
       - name: Sync dependencies
@@ -44,3 +44,43 @@ jobs:
         with:
           name: proxbox-api-coverage
           path: coverage.xml
+
+  e2e-tests:
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          python-version: "3.12"
+
+      - name: Sync dependencies
+        run: uv sync --frozen --extra e2e --group dev
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        run: uv run pytest tests/e2e/ -n auto --tb=short -v
+
+      - name: Upload Playwright Report
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7
+
+      - name: Upload Playwright Trace
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-trace
+          path: .playwright/trace/
+          retention-days: 7

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 1,
+  workers: process.env.CI ? 1 : 3,
+  reporter: [
+    ["list"],
+    ["html", { open: "never" }],
+    ["json", { outputFile: "playwright-results.json" }],
+  ],
+  use: {
+    baseURL: process.env.PROXBOX_E2E_DEMO_URL || "https://demo.netbox.dev",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+    headless: true,
+    viewport: { width: 1280, height: 720 },
+    ignoreHTTPSErrors: true,
+    actionTimeout: 30000,
+    navigationTimeout: 60000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  timeout: 120000,
+  expect: {
+    timeout: 10000,
+  },
+});

--- a/proxbox_api/e2e/CLAUDE.md
+++ b/proxbox_api/e2e/CLAUDE.md
@@ -1,0 +1,43 @@
+# E2E Testing Module
+
+End-to-end tests using Playwright to authenticate with NetBox demo and sync mock Proxmox data.
+
+## Overview
+
+- **Authentication**: Async Playwright auth for NetBox demo (`demo_auth.py`)
+- **Session**: `DemoSessionBuilder` for creating authenticated sessions with e2e tag
+- **Fixtures**: Mock Proxmox API data for testing sync logic
+- **Tests**: Device, VM, and backup sync e2e tests
+
+## Key Files
+
+- `proxbox_api/e2e/demo_auth.py` - Playwright auth flow
+- `proxbox_api/e2e/session.py` - Session builder and tag management
+- `proxbox_api/e2e/fixtures/proxmox_mock.py` - Mock Proxmox classes
+- `proxbox_api/e2e/fixtures/test_data.py` - Test data constants
+- `tests/e2e/` - E2E test suite
+
+## Running Tests
+
+```bash
+# Install Playwright browsers (first time)
+playwright install chromium
+
+# Run e2e tests with parallel execution
+pytest tests/e2e/ -n auto
+
+# Run specific test
+pytest tests/e2e/test_demo_auth.py -v
+```
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PROXBOX_E2E_DEMO_URL` | `https://demo.netbox.dev` | NetBox demo URL |
+| `PROXBOX_E2E_TIMEOUT` | `60` | Timeout in seconds |
+| `PROXBOX_E2E_HEADLESS` | `true` | Run browser headless |
+
+## E2E Tag
+
+All synced objects are tagged with `proxbox e2e testing` (color: `4caf50`, slug: `proxbox-e2e-testing`).

--- a/proxbox_api/e2e/__init__.py
+++ b/proxbox_api/e2e/__init__.py
@@ -1,0 +1,22 @@
+"""E2E testing utilities for proxbox-api integration testing with NetBox demo."""
+
+from proxbox_api.e2e.demo_auth import (
+    bootstrap_demo_profile,
+    create_demo_user,
+    demo_auth_required,
+    login,
+    provision_demo_token,
+    refresh_demo_profile,
+)
+from proxbox_api.e2e.session import create_netbox_demo_session, ensure_e2e_tag
+
+__all__ = [
+    "bootstrap_demo_profile",
+    "create_demo_user",
+    "demo_auth_required",
+    "login",
+    "provision_demo_token",
+    "refresh_demo_profile",
+    "create_netbox_demo_session",
+    "ensure_e2e_tag",
+]

--- a/proxbox_api/e2e/demo_auth.py
+++ b/proxbox_api/e2e/demo_auth.py
@@ -1,0 +1,463 @@
+"""Async Playwright-based authentication for NetBox demo instances.
+
+This module provides functionality to authenticate with NetBox demo instances
+using Playwright browser automation. It is adapted from the netbox-sdk package
+but converted to async and adapted for proxbox-api's testing needs.
+
+Usage:
+    config = await bootstrap_demo_profile(
+        username="test_user",
+        password="secure_password",
+        headless=True,
+    )
+    session = await create_netbox_demo_session(config)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import secrets
+import string
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from netbox_sdk.config import Config
+    from playwright.async_api import Page
+
+DEMO_BASE_URL = os.getenv("PROXBOX_E2E_DEMO_URL", "https://demo.netbox.dev")
+DEMO_CREATE_USER_URL = f"{DEMO_BASE_URL}/plugins/demo/login/"
+LOGIN_URL = f"{DEMO_BASE_URL}/login/"
+TOKENS_URL = f"{DEMO_BASE_URL}/user/api-tokens/"
+
+
+class DemoToken(BaseModel):
+    """Represents a NetBox demo token."""
+
+    version: str
+    key: str | None
+    secret: str
+
+
+class DemoAuthError(Exception):
+    """Base exception for demo auth failures."""
+
+    pass
+
+
+class PlaywrightNotInstalledError(DemoAuthError):
+    """Raised when Playwright is not installed."""
+
+    pass
+
+
+class XServerRequiredError(DemoAuthError):
+    """Raised when headed mode is requested but no X server is available."""
+
+    pass
+
+
+class BrowserDependencyError(DemoAuthError):
+    """Raised when browser dependencies are missing."""
+
+    pass
+
+
+class DemoAuthTimeoutError(DemoAuthError):
+    """Raised when demo auth times out."""
+
+    pass
+
+
+class DemoLoginError(DemoAuthError):
+    """Raised when demo login fails."""
+
+    pass
+
+
+class DemoTokenCreationError(DemoAuthError):
+    """Raised when token creation fails."""
+
+    pass
+
+
+def demo_auth_required(func):
+    """Decorator that ensures Playwright is installed before executing."""
+
+    async def wrapper(*args, **kwargs):
+        if importlib.util.find_spec("playwright") is None:
+            raise PlaywrightNotInstalledError(
+                "Playwright is required for demo authentication. Install it with:\n"
+                "  pip install playwright\n"
+                "  playwright install chromium"
+            )
+        return await func(*args, **kwargs)
+
+    return wrapper
+
+
+def generate_password(length: int = 32) -> str:
+    """Generate a secure random password."""
+    alphabet = string.ascii_letters + string.digits + "!@#$%^&*"
+    return "".join(secrets.choice(alphabet) for _ in range(length))
+
+
+def generate_username(prefix: str = "proxbox_e2e") -> str:
+    """Generate a unique username for e2e testing."""
+    timestamp = secrets.token_hex(4)
+    return f"{prefix}_{timestamp}"
+
+
+@demo_auth_required
+async def provision_demo_token(
+    *,
+    username: str,
+    password: str,
+    headless: bool = True,
+    token_name: str = "proxbox-e2e",
+    timeout: float = 60.0,
+) -> DemoToken:
+    """Provision a demo token by automating the NetBox demo login flow.
+
+    Args:
+        username: The demo username to use.
+        password: The demo password to use.
+        headless: Whether to run browser in headless mode.
+        token_name: Name for the API token.
+        timeout: Browser operation timeout in seconds.
+
+    Returns:
+        DemoToken with version, key, and secret.
+
+    Raises:
+        PlaywrightNotInstalledError: If Playwright is not installed.
+        XServerRequiredError: If headed mode requested without X server.
+        BrowserDependencyError: If browser dependencies are missing.
+        DemoAuthTimeoutError: If operations time out.
+        DemoLoginError: If login fails.
+        DemoTokenCreationError: If token creation fails.
+    """
+    from playwright.async_api import Error as PlaywrightError
+    from playwright.async_api import TimeoutError as PlaywrightTimeoutError
+    from playwright.async_api import async_playwright
+
+    try:
+        async with async_playwright() as playwright:
+            browser = await playwright.chromium.launch(
+                headless=headless,
+                args=["--no-sandbox", "--disable-setuid-sandbox"],
+            )
+            page = await browser.new_page()
+            try:
+                user_created = await _create_demo_user(page, username, password, timeout)
+                if not user_created:
+                    print(f"Demo user '{username}' already exists. Proceeding to login.")
+
+                await _login(page, username, password, timeout)
+                token_value = await _create_token(page, token_name, timeout)
+            finally:
+                await browser.close()
+
+    except PlaywrightTimeoutError as exc:
+        raise DemoAuthTimeoutError(
+            "Timed out while automating demo.netbox.dev. "
+            "Verify credentials and ensure Playwright browsers are installed with "
+            "`playwright install chromium`."
+        ) from exc
+    except PlaywrightError as exc:
+        error_text = str(exc)
+        if "Missing X server or $DISPLAY" in error_text or "headed browser" in error_text:
+            raise XServerRequiredError(
+                "Playwright was started in headed mode, but no X server is available.\n"
+                "Use headless mode, or run the command under xvfb.\n"
+                "Example: xvfb-run pytest tests/e2e/"
+            ) from exc
+        if (
+            "error while loading shared libraries" in error_text
+            or "BrowserType.launch" in error_text
+        ):
+            raise BrowserDependencyError(
+                "Playwright Chromium could not start because system libraries are missing.\n"
+                "Install browser dependencies with:\n"
+                "  playwright install --with-deps chromium"
+            ) from exc
+        raise DemoAuthError(f"Playwright error: {error_text}") from exc
+    except Exception as exc:  # noqa: BLE001
+        raise DemoAuthError(f"Failed to automate demo.netbox.dev login: {str(exc)}") from exc
+
+    return _parse_v1_token(token_value)
+
+
+async def _create_demo_user(page: "Page", username: str, password: str, timeout: float) -> bool:
+    """Create a demo user on the NetBox demo instance.
+
+    Args:
+        page: Playwright page instance.
+        username: Username to create.
+        password: Password for the user.
+        timeout: Operation timeout in seconds.
+
+    Returns:
+        True if user was created, False if user already exists.
+    """
+    await page.goto(DEMO_CREATE_USER_URL, wait_until="domcontentloaded", timeout=timeout * 1000)
+    await page.get_by_label("Username").fill(username)
+    await page.get_by_label("Password").fill(password)
+    await page.get_by_role("button", name="Create & Sign In").click()
+    await page.wait_for_load_state("domcontentloaded")
+
+    if _is_existing_demo_user_error(page, username=username):
+        return False
+
+    await page.wait_for_load_state("networkidle", timeout=timeout * 1000)
+    return True
+
+
+async def _login(page: "Page", username: str, password: str, timeout: float) -> None:
+    """Log in to the NetBox demo instance.
+
+    Args:
+        page: Playwright page instance.
+        username: Username to log in with.
+        password: Password for the user.
+        timeout: Operation timeout in seconds.
+
+    Raises:
+        DemoLoginError: If login fails.
+    """
+    await page.goto(LOGIN_URL, wait_until="domcontentloaded", timeout=timeout * 1000)
+
+    if "/login/" not in page.url:
+        return
+
+    await page.get_by_label("Username").fill(username)
+    await page.get_by_label("Password").fill(password)
+    await page.get_by_role("button", name="Sign In").click()
+    await page.wait_for_url(f"{DEMO_BASE_URL}/**", timeout=timeout * 1000)
+
+    if "/login/" in page.url:
+        raise DemoLoginError("Demo login failed. Check the provided username and password.")
+
+
+async def _create_token(page: "Page", token_name: str, timeout: float) -> str:
+    """Create an API token on the NetBox demo instance.
+
+    Args:
+        page: Playwright page instance.
+        token_name: Name/description for the token.
+        timeout: Operation timeout in seconds.
+
+    Returns:
+        The token value.
+
+    Raises:
+        DemoTokenCreationError: If token creation fails.
+    """
+    await page.goto(TOKENS_URL, wait_until="domcontentloaded", timeout=timeout * 1000)
+
+    add_link = page.get_by_role("link", name="Add a Token")
+    add_button = page.get_by_role("button", name="Add a Token")
+
+    if await add_link.count() > 0:
+        await add_link.first.click()
+    else:
+        await add_button.first.click()
+
+    version_field = page.locator("#id_version")
+    if await version_field.count() > 0:
+        await version_field.select_option("1")
+
+    token_input = page.locator("#id_token")
+    await token_input.wait_for(timeout=timeout * 1000)
+    token_value = (await token_input.input_value()).strip()
+
+    if not token_value:
+        raise DemoTokenCreationError("Demo token form did not provide a v1 token value.")
+
+    description_field = page.locator("#id_description")
+    if await description_field.count() > 0:
+        await description_field.fill(token_name)
+
+    create_button = page.get_by_role("button", name="Create")
+    await create_button.first.click()
+
+    try:
+        await page.wait_for_url(f"{TOKENS_URL}**", timeout=10000)
+    except Exception as exc:  # noqa: BLE001
+        error_text = _extract_page_error(page)
+        if error_text:
+            raise DemoTokenCreationError(
+                f"NetBox demo rejected token creation: {error_text}"
+            ) from exc
+        raise DemoTokenCreationError(
+            "Timed out waiting for NetBox demo to finish token creation."
+        ) from exc
+
+    return token_value
+
+
+async def create_demo_user(username: str, password: str, headless: bool = True) -> bool:
+    """Convenience function to create a demo user.
+
+    Args:
+        username: Username to create.
+        password: Password for the user.
+        headless: Whether to run browser in headless mode.
+
+    Returns:
+        True if user was created, False if user already exists.
+    """
+    from playwright.async_api import async_playwright
+
+    async with async_playwright() as playwright:
+        browser = await playwright.chromium.launch(
+            headless=headless,
+            args=["--no-sandbox", "--disable-setuid-sandbox"],
+        )
+        page = await browser.new_page()
+        try:
+            return await _create_demo_user(page, username, password, timeout=60.0)
+        finally:
+            await browser.close()
+
+
+async def login(username: str, password: str, headless: bool = True) -> None:
+    """Convenience function to log in to demo.
+
+    Args:
+        username: Username to log in with.
+        password: Password for the user.
+        headless: Whether to run browser in headless mode.
+
+    Raises:
+        DemoLoginError: If login fails.
+    """
+    from playwright.async_api import async_playwright
+
+    async with async_playwright() as playwright:
+        browser = await playwright.chromium.launch(
+            headless=headless,
+            args=["--no-sandbox", "--disable-setuid-sandbox"],
+        )
+        page = await browser.new_page()
+        try:
+            await _login(page, username, password, timeout=60.0)
+        finally:
+            await browser.close()
+
+
+def _extract_page_error(page: "Page") -> str:
+    """Extract error text from page content."""
+    body_text = page.locator("body").inner_text()
+    if "Error" in body_text:
+        lines = [line.strip() for line in body_text.splitlines() if line.strip()]
+        for index, line in enumerate(lines):
+            if line == "Error" and index + 1 < len(lines):
+                return lines[index + 1]
+    return ""
+
+
+def _is_existing_demo_user_error(page: "Page", username: str) -> bool:
+    """Check if the page shows an existing user error."""
+    body_text = page.locator("body").inner_text().lower()
+    return (
+        "duplicate key value violates unique constraint" in body_text
+        and f"(username)=({username.lower()}) already exists" in body_text
+    )
+
+
+def _parse_v1_token(token_value: str) -> DemoToken:
+    """Parse a v1 token from the token input value.
+
+    Args:
+        token_value: The raw token value from the form.
+
+    Returns:
+        DemoToken with v1 version.
+
+    Raises:
+        DemoTokenCreationError: If token format is unexpected.
+    """
+    stripped = token_value.strip()
+    if len(stripped) < 40:
+        raise DemoTokenCreationError(
+            f"Unexpected v1 token format returned by demo.netbox.dev. Token: {stripped[:20]}..."
+        )
+    return DemoToken(version="v1", key=None, secret=stripped)
+
+
+async def bootstrap_demo_profile(
+    *,
+    username: str,
+    password: str,
+    timeout: float = 60.0,
+    headless: bool = True,
+    token_name: str = "proxbox-e2e",
+) -> "Config":
+    """Bootstrap a demo profile by provisioning a token and creating a Config.
+
+    Args:
+        username: The demo username to use.
+        password: The demo password to use.
+        timeout: Browser operation timeout in seconds.
+        headless: Whether to run browser in headless mode.
+        token_name: Name for the API token.
+
+    Returns:
+        Config object ready for NetBox session creation.
+    """
+    from netbox_sdk.config import Config, normalize_base_url
+
+    token = await provision_demo_token(
+        username=username,
+        password=password,
+        headless=headless,
+        token_name=token_name,
+        timeout=timeout,
+    )
+
+    return Config(
+        base_url=normalize_base_url(DEMO_BASE_URL),
+        token_version=token.version,
+        token_key=token.key,
+        token_secret=token.secret,
+        timeout=timeout,
+        demo_username=username,
+        demo_password=password,
+    )
+
+
+async def refresh_demo_profile(
+    existing: "Config",
+    *,
+    headless: bool = True,
+    token_name: str = "proxbox-e2e",
+) -> "Config":
+    """Re-run demo bootstrap using saved demo credentials.
+
+    Args:
+        existing: Existing Config with demo credentials.
+        headless: Whether to run browser in headless mode.
+        token_name: Name for the API token.
+
+    Returns:
+        New Config with refreshed token.
+
+    Raises:
+        DemoAuthError: If demo credentials are not available.
+    """
+    if not existing.demo_username or not existing.demo_password:
+        raise DemoAuthError("Saved demo credentials are not available for token refresh.")
+
+    refreshed = await bootstrap_demo_profile(
+        username=existing.demo_username,
+        password=existing.demo_password,
+        timeout=existing.timeout,
+        headless=headless,
+        token_name=token_name,
+    )
+    refreshed.demo_username = existing.demo_username
+    refreshed.demo_password = existing.demo_password
+    return refreshed

--- a/proxbox_api/e2e/fixtures/__init__.py
+++ b/proxbox_api/e2e/fixtures/__init__.py
@@ -1,0 +1,33 @@
+"""E2E test fixtures for proxbox-api."""
+
+from proxbox_api.e2e.fixtures.proxmox_mock import (
+    MockProxmoxCluster,
+    MockProxmoxNode,
+    MockProxmoxVM,
+    create_cluster_with_backups,
+    create_minimal_cluster,
+    create_multi_cluster,
+)
+from proxbox_api.e2e.fixtures.test_data import (
+    E2E_CLUSTER,
+    E2E_NODE,
+    E2E_TAG,
+    E2E_VM_LXC,
+    E2E_VM_QEMU,
+    generate_unique_resource_prefix,
+)
+
+__all__ = [
+    "MockProxmoxCluster",
+    "MockProxmoxNode",
+    "MockProxmoxVM",
+    "create_cluster_with_backups",
+    "create_minimal_cluster",
+    "create_multi_cluster",
+    "E2E_CLUSTER",
+    "E2E_NODE",
+    "E2E_TAG",
+    "E2E_VM_LXC",
+    "E2E_VM_QEMU",
+    "generate_unique_resource_prefix",
+]

--- a/proxbox_api/e2e/fixtures/proxmox_mock.py
+++ b/proxbox_api/e2e/fixtures/proxmox_mock.py
@@ -1,0 +1,364 @@
+"""Mock Proxmox API data structures for e2e testing.
+
+Provides classes and factory functions to generate mock Proxmox API responses
+for testing the proxbox-api sync functionality.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class MockProxmoxNode:
+    """Represents a Proxmox node in the API."""
+
+    name: str
+    status: str = "online"
+    uptime: int = 3600
+    max_disk: int = 1073741824000
+    max_mem: int = 68719476736
+    level: str = ""
+
+    def to_api_response(self) -> dict[str, Any]:
+        """Convert to Proxmox API response format."""
+        return {
+            "node": self.name,
+            "status": self.status,
+            "uptime": self.uptime,
+            "max_disk": self.max_disk,
+            "max_mem": self.max_mem,
+            "level": self.level,
+        }
+
+
+@dataclass
+class MockProxmoxVM:
+    """Represents a Proxmox VM or LXC container."""
+
+    vmid: int
+    name: str
+    node: str
+    status: str = "running"
+    type: str = "qemu"
+    maxcpu: int = 2
+    maxmem: int = 4294967296
+    maxdisk: int = 53687091200
+    config: dict[str, Any] = field(default_factory=dict)
+
+    def to_resource(self) -> dict[str, Any]:
+        """Convert to Proxmox cluster/resources API response."""
+        return {
+            "vmid": self.vmid,
+            "name": self.name,
+            "node": self.node,
+            "status": self.status,
+            "type": self.type,
+            "maxcpu": self.maxcpu,
+            "maxmem": self.maxmem,
+            "maxdisk": self.maxdisk,
+        }
+
+    def to_config(self) -> dict[str, Any]:
+        """Convert to Proxmox VM config API response."""
+        return {
+            "onboot": self.config.get("onboot", 1),
+            "agent": self.config.get("agent", 1),
+            "unprivileged": self.config.get("unprivileged", 0),
+            "searchdomain": self.config.get("searchdomain", "lab.local"),
+        }
+
+
+@dataclass
+class MockProxmoxCluster:
+    """Represents a Proxmox cluster with nodes and VMs."""
+
+    name: str
+    mode: str = "pve"
+    nodes: list[MockProxmoxNode] = field(default_factory=list)
+    vms: list[MockProxmoxVM] = field(default_factory=list)
+    storage: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_cluster_status(self) -> dict[str, Any]:
+        """Convert to cluster/status API response."""
+        return {
+            "name": self.name,
+            "mode": self.mode,
+            "node_list": [node.to_api_response() for node in self.nodes],
+        }
+
+    def to_cluster_resources(self) -> list[dict[str, Any]]:
+        """Convert to cluster/resources API response."""
+        return [vm.to_resource() for vm in self.vms]
+
+    def add_storage(
+        self,
+        storage_id: str,
+        storage_type: str = "dir",
+        content: str = "rootdir,images",
+        shared: bool = False,
+    ) -> "MockProxmoxCluster":
+        """Add storage to the cluster."""
+        self.storage.append(
+            {
+                "storage": storage_id,
+                "type": storage_type,
+                "content": content,
+                "shared": shared,
+                "nodes": "all",
+            }
+        )
+        return self
+
+    def add_backup_storage(
+        self,
+        storage_id: str = "backup",
+        path: str = "/mnt/backup",
+    ) -> "MockProxmoxCluster":
+        """Add backup storage to the cluster."""
+        self.storage.append(
+            {
+                "storage": storage_id,
+                "type": "dir",
+                "content": "backup,vztmpl,iso",
+                "shared": True,
+                "nodes": "all",
+                "path": path,
+            }
+        )
+        return self
+
+
+class MockProxmoxBackup:
+    """Represents a Proxmox VM backup."""
+
+    def __init__(
+        self,
+        vmid: int,
+        volid: str,
+        storage: str = "backup",
+        size: int = 10737418240,
+        ctime: int | None = None,
+        format: str = "qcow2",
+        subtype: str = "private",
+        notes: str = "",
+    ):
+        self.vmid = vmid
+        self.volid = volid
+        self.storage = storage
+        self.size = size
+        self.ctime = ctime or int(time.time())
+        self.format = format
+        self.subtype = subtype
+        self.notes = notes
+
+    def to_api_response(self) -> dict[str, Any]:
+        """Convert to Proxmox storage/content API response."""
+        return {
+            "vmid": self.vmid,
+            "volid": self.volid,
+            "storage": self.storage,
+            "size": self.size,
+            "ctime": self.ctime,
+            "format": self.format,
+            "subtype": self.subtype,
+            "notes": self.notes,
+            "content": "backup",
+        }
+
+
+def create_minimal_cluster(prefix: str = "e2e-minimal") -> MockProxmoxCluster:
+    """Create a minimal cluster for e2e testing.
+
+    Single node with 2 VMs (1 QEMU, 1 LXC).
+    """
+    node_name = f"{prefix}-node-01"
+    cluster_name = f"{prefix}-cluster"
+
+    cluster = MockProxmoxCluster(
+        name=cluster_name,
+        mode="pve",
+        nodes=[
+            MockProxmoxNode(
+                name=node_name,
+                status="online",
+                uptime=3600,
+            ),
+        ],
+        vms=[
+            MockProxmoxVM(
+                vmid=99901,
+                name=f"{prefix}-qemu",
+                node=node_name,
+                status="running",
+                type="qemu",
+                maxcpu=2,
+                maxmem=4294967296,
+                maxdisk=53687091200,
+                config={
+                    "onboot": 1,
+                    "agent": 1,
+                    "unprivileged": 0,
+                    "searchdomain": "lab.local",
+                },
+            ),
+            MockProxmoxVM(
+                vmid=99902,
+                name=f"{prefix}-lxc",
+                node=node_name,
+                status="running",
+                type="lxc",
+                maxcpu=1,
+                maxmem=2147483648,
+                maxdisk=8589934592,
+                config={
+                    "onboot": 1,
+                    "unprivileged": 1,
+                },
+            ),
+        ],
+    )
+    cluster.add_storage("local", content="rootdir,images")
+    cluster.add_backup_storage()
+    return cluster
+
+
+def create_multi_cluster(prefix: str = "e2e-multi") -> list[MockProxmoxCluster]:
+    """Create multiple clusters for e2e testing.
+
+    Two clusters, each with 2 nodes and 3 VMs.
+    """
+    clusters = []
+
+    for i in range(1, 3):
+        cluster_name = f"{prefix}-cluster-{i:02d}"
+        cluster = MockProxmoxCluster(
+            name=cluster_name,
+            mode="pve",
+            nodes=[
+                MockProxmoxNode(
+                    name=f"{prefix}-node-{i:02d}-01",
+                    status="online",
+                    uptime=3600 * (i * 24),
+                ),
+                MockProxmoxNode(
+                    name=f"{prefix}-node-{i:02d}-02",
+                    status="online" if i == 1 else "offline",
+                    uptime=3600 * 12,
+                ),
+            ],
+            vms=[
+                MockProxmoxVM(
+                    vmid=99000 + (i * 100) + 1,
+                    name=f"{prefix}-vm-{i:02d}-01",
+                    node=f"{prefix}-node-{i:02d}-01",
+                    status="running",
+                    type="qemu",
+                ),
+                MockProxmoxVM(
+                    vmid=99000 + (i * 100) + 2,
+                    name=f"{prefix}-vm-{i:02d}-02",
+                    node=f"{prefix}-node-{i:02d}-01",
+                    status="stopped",
+                    type="qemu",
+                ),
+                MockProxmoxVM(
+                    vmid=99000 + (i * 100) + 3,
+                    name=f"{prefix}-lxc-{i:02d}-01",
+                    node=f"{prefix}-node-{i:02d}-02",
+                    status="running",
+                    type="lxc",
+                ),
+            ],
+        )
+        cluster.add_storage(f"local-{i}", content="rootdir,images")
+        cluster.add_backup_storage(storage_id=f"backup-{i}")
+        clusters.append(cluster)
+
+    return clusters
+
+
+def create_cluster_with_backups(
+    prefix: str = "e2e-backup",
+) -> tuple[MockProxmoxCluster, list[MockProxmoxBackup]]:
+    """Create a cluster with VMs that have backup metadata."""
+    cluster = create_minimal_cluster(prefix)
+
+    backups = []
+    base_time = int(time.time())
+
+    for vm in cluster.vms:
+        backup = MockProxmoxBackup(
+            vmid=vm.vmid,
+            volid=f"backup:{vm.vmid}/vm-{vm.vmid}-disk-0.qcow2",
+            storage="backup",
+            size=vm.maxdisk // 10,
+            ctime=base_time - 86400,
+            format="qcow2",
+            subtype="private",
+            notes=f"Auto backup for {vm.name}",
+        )
+        backups.append(backup)
+
+        extra_backup = MockProxmoxBackup(
+            vmid=vm.vmid,
+            volid=f"backup:{vm.vmid}/vm-{vm.vmid}-disk-0_20240115.qcow2",
+            storage="backup",
+            size=vm.maxdisk // 10,
+            ctime=base_time - 86400 * 7,
+            format="qcow2",
+            subtype="private",
+            notes=f"Weekly backup for {vm.name}",
+        )
+        backups.append(extra_backup)
+
+    return cluster, backups
+
+
+def create_custom_cluster(
+    name: str,
+    nodes_spec: list[tuple[str, str, int]],
+    vms_spec: list[tuple[int, str, str, str, int, int, int]],
+    prefix: str = "e2e",
+) -> MockProxmoxCluster:
+    """Create a custom cluster with specified nodes and VMs.
+
+    Args:
+        name: Cluster name.
+        nodes_spec: List of (node_name, status, uptime) tuples.
+        vms_spec: List of (vmid, name, node, type, maxcpu, maxmem, maxdisk) tuples.
+        prefix: Prefix for resource naming.
+
+    Returns:
+        MockProxmoxCluster with specified configuration.
+    """
+    cluster = MockProxmoxCluster(name=name, mode="pve")
+
+    for node_name, status, uptime in nodes_spec:
+        cluster.nodes.append(
+            MockProxmoxNode(
+                name=node_name,
+                status=status,
+                uptime=uptime,
+            )
+        )
+
+    for vmid, name, node, vm_type, maxcpu, maxmem, maxdisk in vms_spec:
+        cluster.vms.append(
+            MockProxmoxVM(
+                vmid=vmid,
+                name=name,
+                node=node,
+                type=vm_type,
+                maxcpu=maxcpu,
+                maxmem=maxmem,
+                maxdisk=maxdisk,
+            )
+        )
+
+    cluster.add_storage("local", content="rootdir,images")
+    cluster.add_backup_storage()
+
+    return cluster

--- a/proxbox_api/e2e/fixtures/test_data.py
+++ b/proxbox_api/e2e/fixtures/test_data.py
@@ -1,0 +1,203 @@
+"""Concrete test data fixtures for e2e tests.
+
+Provides specific test data values that are used across multiple e2e test files.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import string
+import time
+from typing import Any
+
+E2E_TAG_NAME = "proxbox e2e testing"
+E2E_TAG_SLUG = "proxbox-e2e-testing"
+E2E_TAG_COLOR = "4caf50"
+E2E_TAG_DESCRIPTION = "Objects created during proxbox-api e2e testing"
+
+E2E_TAG: dict[str, str] = {
+    "name": E2E_TAG_NAME,
+    "slug": E2E_TAG_SLUG,
+    "color": E2E_TAG_COLOR,
+    "description": E2E_TAG_DESCRIPTION,
+}
+
+E2E_VM_QEMU: dict[str, Any] = {
+    "vmid": 99901,
+    "name": "e2e-test-qemu",
+    "node": "e2e-node-01",
+    "status": "running",
+    "type": "qemu",
+    "maxcpu": 2,
+    "maxmem": 4294967296,
+    "maxdisk": 53687091200,
+}
+
+E2E_VM_QEMU_CONFIG: dict[str, Any] = {
+    "onboot": 1,
+    "agent": 1,
+    "unprivileged": 0,
+    "searchdomain": "lab.local",
+}
+
+E2E_VM_LXC: dict[str, Any] = {
+    "vmid": 99902,
+    "name": "e2e-test-lxc",
+    "node": "e2e-node-01",
+    "status": "running",
+    "type": "lxc",
+    "maxcpu": 1,
+    "maxmem": 2147483648,
+    "maxdisk": 8589934592,
+}
+
+E2E_VM_LXC_CONFIG: dict[str, Any] = {
+    "onboot": 1,
+    "unprivileged": 1,
+}
+
+E2E_NODE: dict[str, Any] = {
+    "node": "e2e-node-01",
+    "status": "online",
+    "uptime": 3600,
+}
+
+E2E_CLUSTER: dict[str, Any] = {
+    "name": "e2e-test-cluster",
+    "mode": "pve",
+}
+
+E2E_CLUSTER_STATUS: dict[str, Any] = {
+    "name": "e2e-test-cluster",
+    "mode": "pve",
+    "node_list": [E2E_NODE],
+}
+
+E2E_BACKUP: dict[str, Any] = {
+    "vmid": 99901,
+    "volid": "backup:99901/vm-99901-disk-0.qcow2",
+    "storage": "backup",
+    "size": 5368709120,
+    "ctime": int(time.time()) - 86400,
+    "format": "qcow2",
+    "subtype": "private",
+    "notes": "Test backup",
+}
+
+E2E_VM_WITH_INTERFACES: dict[str, Any] = {
+    "vmid": 99903,
+    "name": "e2e-test-with-nics",
+    "node": "e2e-node-01",
+    "status": "running",
+    "type": "qemu",
+    "maxcpu": 4,
+    "maxmem": 8589934592,
+    "maxdisk": 107374182400,
+}
+
+E2E_VM_WITH_INTERFACES_CONFIG: dict[str, Any] = {
+    "onboot": 1,
+    "agent": 1,
+    "net0": "virtio=aa:bb:cc:dd:ee:01,bridge=vmbr0,firewall=1",
+    "net1": "virtio=aa:bb:cc:dd:ee:02,bridge=vmbr1",
+}
+
+
+def generate_unique_resource_prefix() -> str:
+    """Generate a unique prefix for test resources.
+
+    Uses timestamp and random suffix to ensure uniqueness across test runs.
+    """
+    timestamp = int(time.time())
+    random_suffix = secrets.token_hex(4)
+    return f"e2e_{timestamp}_{random_suffix}"
+
+
+def get_e2e_credentials() -> tuple[str, str]:
+    """Get or generate e2e test credentials.
+
+    Reads from environment variables or generates new credentials.
+
+    Returns:
+        Tuple of (username, password).
+    """
+    username = os.getenv(
+        "PROXBOX_E2E_USERNAME",
+        f"proxbox_e2e_{secrets.token_hex(4)}",
+    )
+    password = os.getenv(
+        "PROXBOX_E2E_PASSWORD",
+        _generate_password(),
+    )
+    return username, password
+
+
+def _generate_password(length: int = 32) -> str:
+    """Generate a secure random password."""
+    alphabet = string.ascii_letters + string.digits + "!@#$%^&*"
+    return "".join(secrets.choice(alphabet) for _ in range(length))
+
+
+def get_e2e_demo_config() -> dict[str, Any]:
+    """Get e2e demo configuration from environment.
+
+    Returns:
+        Dict with demo URL, timeout, and headless settings.
+    """
+    return {
+        "demo_url": os.getenv("PROXBOX_E2E_DEMO_URL", "https://demo.netbox.dev"),
+        "timeout": float(os.getenv("PROXBOX_E2E_TIMEOUT", "60")),
+        "headless": os.getenv("PROXBOX_E2E_HEADLESS", "true").lower() in ("true", "1", "yes"),
+    }
+
+
+def create_test_vm(
+    vmid: int,
+    name: str | None = None,
+    node: str = "e2e-node-01",
+    vm_type: str = "qemu",
+) -> dict[str, Any]:
+    """Create a test VM resource dict.
+
+    Args:
+        vmid: VM ID.
+        name: VM name (defaults to e2e-test-{vmid}).
+        node: Node name.
+        vm_type: VM type (qemu or lxc).
+
+    Returns:
+        VM resource dict for cluster/resources API.
+    """
+    return {
+        "vmid": vmid,
+        "name": name or f"e2e-test-{vmid}",
+        "node": node,
+        "status": "running",
+        "type": vm_type,
+        "maxcpu": 2,
+        "maxmem": 4294967296,
+        "maxdisk": 53687091200,
+    }
+
+
+def create_test_node(
+    name: str,
+    status: str = "online",
+    uptime: int = 3600,
+) -> dict[str, Any]:
+    """Create a test node dict.
+
+    Args:
+        name: Node name.
+        status: Node status.
+        uptime: Uptime in seconds.
+
+    Returns:
+        Node dict for cluster/status API.
+    """
+    return {
+        "node": name,
+        "status": status,
+        "uptime": uptime,
+    }

--- a/proxbox_api/e2e/session.py
+++ b/proxbox_api/e2e/session.py
@@ -1,0 +1,187 @@
+"""NetBox demo session utilities for e2e testing.
+
+Provides functions to create NetBox sessions from demo credentials and manage
+the 'proxbox e2e testing' tag.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from netbox_sdk.config import Config
+    from netbox_sdk.facade import Api
+
+E2E_TAG_NAME = "proxbox e2e testing"
+E2E_TAG_SLUG = "proxbox-e2e-testing"
+E2E_TAG_COLOR = "4caf50"
+E2E_TAG_DESCRIPTION = "Objects created during proxbox-api e2e testing"
+
+
+async def create_netbox_demo_session(config: "Config") -> "Api":
+    """Create an async NetBox API session from demo credentials.
+
+    Args:
+        config: NetBox SDK Config with demo token and credentials.
+
+    Returns:
+        Async NetBox API instance ready for requests.
+    """
+    from netbox_sdk.config import authorization_header_value
+    from netbox_sdk.facade import Api
+
+    auth_header = authorization_header_value(config)
+    if not auth_header:
+        raise ValueError("Config must have valid token for demo session")
+
+    api = Api(base_url=config.base_url, token=auth_header, timeout=config.timeout)
+    return api
+
+
+async def ensure_e2e_tag(nb: "Api") -> dict[str, Any]:
+    """Ensure the 'proxbox e2e testing' tag exists in NetBox.
+
+    Creates the tag if it doesn't exist, or returns existing tag if it does.
+
+    Args:
+        nb: NetBox API instance.
+
+    Returns:
+        Dict with tag details (id, name, slug, url, etc.).
+    """
+    from proxbox_api.netbox_rest import ensure_tag_async
+
+    tag = await ensure_tag_async(
+        nb,
+        name=E2E_TAG_NAME,
+        slug=E2E_TAG_SLUG,
+        color=E2E_TAG_COLOR,
+        description=E2E_TAG_DESCRIPTION,
+    )
+    return {
+        "id": tag.id,
+        "name": tag.name,
+        "slug": tag.slug,
+        "color": tag.color,
+        "url": tag.url,
+    }
+
+
+async def get_e2e_tag(nb: "Api") -> dict[str, Any] | None:
+    """Get the 'proxbox e2e testing' tag if it exists.
+
+    Args:
+        nb: NetBox API instance.
+
+    Returns:
+        Tag dict if exists, None otherwise.
+    """
+    from proxbox_api.netbox_rest import rest_first_async
+
+    tag = await rest_first_async(nb, "/api/extras/tags/", query={"slug": E2E_TAG_SLUG})
+    if tag:
+        return {
+            "id": tag.id,
+            "name": tag.name,
+            "slug": tag.slug,
+            "color": tag.color,
+            "url": tag.url,
+        }
+    return None
+
+
+async def list_objects_with_e2e_tag(
+    nb: "Api",
+    object_type: str,
+) -> list[dict[str, Any]]:
+    """List all objects of a type that have the e2e testing tag.
+
+    Args:
+        nb: NetBox API instance.
+        object_type: NetBox API path (e.g., "/api/dcim/devices/").
+
+    Returns:
+        List of objects with the e2e testing tag.
+    """
+    from proxbox_api.netbox_rest import rest_list_async
+
+    tag = await get_e2e_tag(nb)
+    if not tag:
+        return []
+
+    results = await rest_list_async(
+        nb,
+        object_type,
+        query={"tag": tag["id"], "limit": 500},
+    )
+    return [record.serialize() for record in results]
+
+
+async def cleanup_e2e_objects(
+    nb: "Api",
+    object_types: list[str] | None = None,
+) -> dict[str, int]:
+    """Delete all objects created during e2e testing.
+
+    Note: This is optional since NetBox demo resets daily.
+    Use this for cleanup between test runs if needed.
+
+    Args:
+        nb: NetBox API instance.
+        object_types: List of object types to clean up.
+            Defaults to all proxbox-created types.
+
+    Returns:
+        Dict mapping object type to count of deleted objects.
+    """
+    from proxbox_api.netbox_rest import rest_list_async
+
+    if object_types is None:
+        object_types = [
+            "/api/plugins/proxbox/backups/",
+            "/api/virtualization/virtual-machines/",
+            "/api/dcim/devices/",
+            "/api/dcim/sites/",
+            "/api/dcim/device-types/",
+            "/api/dcim/device-roles/",
+            "/api/dcim/manufacturers/",
+            "/api/virtualization/clusters/",
+            "/api/virtualization/cluster-types/",
+        ]
+
+    deleted_counts: dict[str, int] = {}
+
+    for obj_type in object_types:
+        try:
+            objects = await rest_list_async(nb, obj_type, query={"limit": 500})
+            count = 0
+            for obj in objects:
+                if obj.url:
+                    try:
+                        await obj.delete()
+                        count += 1
+                    except Exception:  # noqa: BLE001
+                        pass
+            deleted_counts[obj_type] = count
+        except Exception:  # noqa: BLE001
+            deleted_counts[obj_type] = 0
+
+    return deleted_counts
+
+
+def build_e2e_tag_refs(tag: dict[str, Any]) -> list[dict[str, Any]]:
+    """Build tag refs list for NetBox API payloads.
+
+    Args:
+        tag: Tag dict from ensure_e2e_tag or get_e2e_tag.
+
+    Returns:
+        List containing tag ref dict for API payloads.
+    """
+    return [
+        {
+            "name": tag["name"],
+            "slug": tag["slug"],
+            "color": tag["color"],
+        }
+    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,14 @@ test = [
     "playwright>=1.58.0",
     "pytest>=9.0.2",
     "pytest-cov>=7.1.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+]
+e2e = [
+    "pytest>=9.0.2",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "playwright>=1.58.0",
 ]
 docs = [
     "mkdocs>=1.6.1",

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""E2E test package for proxbox-api."""

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,235 @@
+"""Pytest configuration and fixtures for e2e tests.
+
+This module provides session-scoped fixtures for e2e testing with NetBox demo.
+It handles:
+- Demo profile bootstrap (Playwright authentication)
+- NetBox session creation
+- E2E tag management
+- Mock Proxmox data
+
+Usage:
+    pytest tests/e2e/ -v
+    pytest tests/e2e/ -v -n auto  # with pytest-xdist
+
+Environment variables:
+    PROXBOX_E2E_USERNAME: Demo username (default: auto-generated)
+    PROXBOX_E2E_PASSWORD: Demo password (default: auto-generated)
+    PROXBOX_E2E_DEMO_URL: NetBox demo URL (default: https://demo.netbox.dev)
+    PROXBOX_E2E_TIMEOUT: Browser timeout in seconds (default: 60)
+    PROXBOX_E2E_HEADLESS: Run browser headless (default: true)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any, AsyncGenerator
+
+import pytest
+import pytest_asyncio
+
+if TYPE_CHECKING:
+    from netbox_sdk.config import Config
+    from netbox_sdk.facade import Api
+
+from proxbox_api.e2e.demo_auth import (
+    PlaywrightNotInstalledError,
+    bootstrap_demo_profile,
+)
+from proxbox_api.e2e.fixtures.proxmox_mock import (
+    MockProxmoxCluster,
+    create_minimal_cluster,
+    create_multi_cluster,
+)
+from proxbox_api.e2e.fixtures.test_data import (
+    E2E_TAG,
+    generate_unique_resource_prefix,
+    get_e2e_credentials,
+    get_e2e_demo_config,
+)
+from proxbox_api.e2e.session import (
+    build_e2e_tag_refs,
+    create_netbox_demo_session,
+    ensure_e2e_tag,
+)
+
+
+@pytest.fixture(scope="session")
+def event_loop_policy():
+    """Use the default event loop policy for the session."""
+    return asyncio.DefaultEventLoopPolicy()
+
+
+@pytest_asyncio.fixture(scope="session")
+async def netbox_demo_config() -> "Config":
+    """Bootstrap demo profile once per test session.
+
+    This fixture creates a NetBox demo user and provisions an API token.
+    It is session-scoped to avoid repeated browser launches.
+
+    Returns:
+        Config object with demo credentials and token.
+
+    Raises:
+        PlaywrightNotInstalledError: If Playwright is not installed.
+    """
+    username, password = get_e2e_credentials()
+    config = get_e2e_demo_config()
+
+    print(f"\n[E2E Setup] Bootstrapping demo profile for user: {username}")
+
+    try:
+        cfg = await bootstrap_demo_profile(
+            username=username,
+            password=password,
+            timeout=config["timeout"],
+            headless=config["headless"],
+            token_name="proxbox-e2e",
+        )
+        print("[E2E Setup] Demo profile bootstrapped successfully")
+        print(f"[E2E Setup] Token version: {cfg.token_version}")
+        return cfg
+    except PlaywrightNotInstalledError:
+        pytest.skip(
+            "Playwright not installed. Run: pip install playwright && playwright install chromium"
+        )
+
+
+@pytest_asyncio.fixture(scope="session")
+async def netbox_demo_session(netbox_demo_config: "Config") -> "Api":
+    """Create NetBox API session from demo config.
+
+    This fixture depends on netbox_demo_config to ensure the demo profile
+    exists before creating the session.
+
+    Returns:
+        Async NetBox API instance.
+    """
+    print("[E2E Setup] Creating NetBox session...")
+    api = await create_netbox_demo_session(netbox_demo_config)
+    print("[E2E Setup] NetBox session created")
+    return api
+
+
+@pytest_asyncio.fixture(scope="session")
+async def e2e_tag(netbox_demo_session: "Api") -> dict[str, Any]:
+    """Ensure the 'proxbox e2e testing' tag exists.
+
+    Creates the tag if it doesn't exist. This is session-scoped
+    since the tag should be shared across all tests.
+
+    Returns:
+        Tag dict with id, name, slug, color, url.
+    """
+    print("[E2E Setup] Ensuring e2e tag exists...")
+    tag = await ensure_e2e_tag(netbox_demo_session)
+    print(f"[E2E Setup] E2E tag ready: {tag['name']} (id={tag['id']})")
+    return tag
+
+
+@pytest_asyncio.fixture(scope="session")
+async def e2e_tag_refs(e2e_tag: dict[str, Any]) -> list[dict[str, Any]]:
+    """Get tag refs list for NetBox API payloads.
+
+    Returns:
+        List containing the e2e tag ref dict.
+    """
+    return build_e2e_tag_refs(e2e_tag)
+
+
+@pytest.fixture
+def unique_prefix() -> str:
+    """Generate unique prefix for test resources in this test.
+
+    Returns:
+        Unique string prefix for resource naming.
+    """
+    return generate_unique_resource_prefix()
+
+
+@pytest.fixture
+def minimal_cluster(unique_prefix: str) -> MockProxmoxCluster:
+    """Create a minimal cluster for testing.
+
+    Args:
+        unique_prefix: Prefix for resource naming.
+
+    Returns:
+        MockProxmoxCluster with single node and 2 VMs.
+    """
+    return create_minimal_cluster(prefix=unique_prefix)
+
+
+@pytest.fixture
+def multi_cluster(unique_prefix: str) -> list[MockProxmoxCluster]:
+    """Create multiple clusters for testing.
+
+    Args:
+        unique_prefix: Prefix for resource naming.
+
+    Returns:
+        List of 2 MockProxmoxCluster instances.
+    """
+    return create_multi_cluster(prefix=unique_prefix)
+
+
+@pytest.fixture
+def e2e_tag_info() -> dict[str, str]:
+    """Get e2e tag configuration.
+
+    Returns:
+        Dict with tag name, slug, color.
+    """
+    return E2E_TAG
+
+
+@pytest_asyncio.fixture
+async def clean_test_objects(
+    netbox_demo_session: "Api", e2e_tag: dict[str, Any]
+) -> AsyncGenerator[None, None]:
+    """Fixture that optionally cleans up test objects after test.
+
+    Note: This is disabled by default since NetBox demo resets daily.
+    Uncomment the cleanup code below to enable cleanup between tests.
+
+    Args:
+        netbox_demo_session: NetBox API session.
+        e2e_tag: E2E testing tag.
+
+    Yields:
+        Control to the test.
+    """
+    yield
+    # Cleanup is disabled since NetBox demo resets daily
+    # To enable cleanup, uncomment below:
+    # from proxbox_api.e2e.session import cleanup_e2e_objects
+    # deleted = await cleanup_e2e_objects(netbox_demo_session)
+    # print(f"[E2E Cleanup] Deleted objects: {deleted}")
+
+
+@pytest.fixture
+def skip_if_no_playwright():
+    """Skip test if Playwright is not installed."""
+    import importlib.util
+
+    if importlib.util.find_spec("playwright") is None:
+        pytest.skip("Playwright not installed")
+
+
+@pytest.fixture
+def mock_proxmox_session(minimal_cluster: MockProxmoxCluster):
+    """Create a mock Proxmox session that returns fixture data.
+
+    This fixture monkeypatches the Proxmox session to return
+    the mock cluster data instead of making real API calls.
+
+    Args:
+        minimal_cluster: The mock cluster data.
+
+    Returns:
+        Dict with cluster and resource data.
+    """
+    return {
+        "cluster": minimal_cluster.to_cluster_status(),
+        "resources": minimal_cluster.to_cluster_resources(),
+        "storage": minimal_cluster.storage,
+    }

--- a/tests/e2e/test_backups_sync.py
+++ b/tests/e2e/test_backups_sync.py
@@ -1,0 +1,544 @@
+"""E2E tests for Proxmox backup synchronization.
+
+Tests the synchronization of Proxmox VM backups to NetBox,
+verifying that all synced objects have the 'proxbox e2e testing' tag.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from proxbox_api.e2e.fixtures.proxmox_mock import (
+    create_cluster_with_backups,
+)
+from proxbox_api.netbox_rest import (
+    nested_tag_payload,
+    rest_reconcile_async,
+)
+from proxbox_api.proxmox_to_netbox.models import (
+    NetBoxBackupSyncState,
+    NetBoxClusterSyncState,
+    NetBoxClusterTypeSyncState,
+    NetBoxDeviceRoleSyncState,
+    NetBoxDeviceSyncState,
+    NetBoxDeviceTypeSyncState,
+    NetBoxManufacturerSyncState,
+    NetBoxSiteSyncState,
+    NetBoxVirtualMachineCreateBody,
+)
+from proxbox_api.services.sync.devices import _slugify
+from proxbox_api.services.sync.virtual_machines import build_netbox_virtual_machine_payload
+
+
+@pytest.mark.asyncio
+class TestBackupsSync:
+    """E2E tests for backup synchronization."""
+
+    async def test_sync_vm_backups_with_e2e_tag(
+        self,
+        netbox_demo_session,
+        e2e_tag,
+        unique_prefix,
+    ):
+        """Test syncing VM backups with e2e tag.
+
+        Verifies:
+        1. Backup exists in NetBox
+        2. Backup has 'proxbox e2e testing' tag
+        3. Backup is linked to correct VM
+        """
+        nb = netbox_demo_session
+        tag_refs = nested_tag_payload(e2e_tag)
+        cluster, backups = create_cluster_with_backups(prefix=unique_prefix)
+
+        vm = cluster.vms[0]
+
+        await self._setup_cluster_dependencies(nb, cluster, tag_refs)
+
+        cluster_obj = await rest_reconcile_async(
+            nb,
+            "/api/virtualization/clusters/",
+            lookup={"name": cluster.name},
+            payload={
+                "name": cluster.name,
+                "type": (await self._get_cluster_type(nb, cluster.mode, tag_refs)).id,
+                "description": f"Proxmox {cluster.mode} cluster.",
+                "tags": tag_refs,
+            },
+            schema=NetBoxClusterSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "type": record.get("type"),
+                "description": record.get("description"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        device = await self._get_or_create_device(
+            nb, cluster, cluster_obj, cluster.nodes[0].name, tag_refs
+        )
+
+        netbox_vm_payload = build_netbox_virtual_machine_payload(
+            proxmox_resource=vm.to_resource(),
+            proxmox_config=vm.to_config(),
+            cluster_id=cluster_obj.id,
+            device_id=device.id,
+            role_id=1,
+            tag_ids=[e2e_tag["id"]],
+        )
+
+        vm_role = await rest_reconcile_async(
+            nb,
+            "/api/dcim/device-roles/",
+            lookup={"slug": "virtual-machine-qemu"},
+            payload={
+                "name": "Virtual Machine (QEMU)",
+                "slug": "virtual-machine-qemu",
+                "color": "00ffff",
+                "description": "Proxmox Virtual Machine",
+                "tags": tag_refs,
+            },
+            schema=NetBoxDeviceRoleSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "color": record.get("color"),
+                "description": record.get("description"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        netbox_vm_payload["role"] = vm_role.id
+
+        virtual_machine = await rest_reconcile_async(
+            nb,
+            "/api/virtualization/virtual-machines/",
+            lookup={"cf_proxmox_vm_id": vm.vmid},
+            payload=netbox_vm_payload,
+            schema=NetBoxVirtualMachineCreateBody,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "status": record.get("status"),
+                "cluster": record.get("cluster"),
+                "device": record.get("device"),
+                "role": record.get("role"),
+                "vcpus": record.get("vcpus"),
+                "memory": record.get("memory"),
+                "disk": record.get("disk"),
+                "tags": record.get("tags"),
+                "custom_fields": record.get("custom_fields"),
+                "description": record.get("description"),
+            },
+        )
+
+        vm_backups = [b for b in backups if b.vmid == vm.vmid]
+        assert len(vm_backups) > 0, "Should have backups for the VM"
+
+        created_backups = []
+        for backup in vm_backups:
+            netbox_backup = await rest_reconcile_async(
+                nb,
+                "/api/plugins/proxbox/backups/",
+                lookup={"volume_id": backup.volid},
+                payload={
+                    "storage": backup.storage,
+                    "virtual_machine": virtual_machine.id,
+                    "subtype": backup.subtype,
+                    "creation_time": None,
+                    "size": backup.size,
+                    "verification_state": None,
+                    "verification_upid": None,
+                    "volume_id": backup.volid,
+                    "notes": backup.notes,
+                    "vmid": backup.vmid,
+                    "format": backup.format,
+                    "tags": tag_refs,
+                },
+                schema=NetBoxBackupSyncState,
+                current_normalizer=lambda record: {
+                    "storage": record.get("storage"),
+                    "virtual_machine": record.get("virtual_machine"),
+                    "subtype": record.get("subtype"),
+                    "creation_time": record.get("creation_time"),
+                    "size": record.get("size"),
+                    "verification_state": record.get("verification_state"),
+                    "verification_upid": record.get("verification_upid"),
+                    "volume_id": record.get("volume_id"),
+                    "notes": record.get("notes"),
+                    "vmid": record.get("vmid"),
+                    "format": record.get("format"),
+                    "tags": record.get("tags"),
+                },
+            )
+            created_backups.append(netbox_backup)
+
+        assert len(created_backups) == len(vm_backups)
+
+        for backup in created_backups:
+            backup_data = backup.serialize()
+            tag_slugs = [t.get("slug") for t in backup_data.get("tags", [])]
+            assert "proxbox-e2e-testing" in tag_slugs, f"Backup {backup.id} missing e2e tag"
+            assert backup_data.get("virtual_machine") == virtual_machine.id
+
+    async def test_sync_multiple_vm_backups(
+        self,
+        netbox_demo_session,
+        e2e_tag,
+        unique_prefix,
+    ):
+        """Test syncing backups for multiple VMs.
+
+        Verifies that all VM backups are synced with e2e tags.
+        """
+        import asyncio
+
+        nb = netbox_demo_session
+        tag_refs = nested_tag_payload(e2e_tag)
+        cluster, all_backups = create_cluster_with_backups(prefix=unique_prefix)
+
+        await self._setup_cluster_dependencies(nb, cluster, tag_refs)
+
+        cluster_obj = await rest_reconcile_async(
+            nb,
+            "/api/virtualization/clusters/",
+            lookup={"name": cluster.name},
+            payload={
+                "name": cluster.name,
+                "type": (await self._get_cluster_type(nb, cluster.mode, tag_refs)).id,
+                "description": f"Proxmox {cluster.mode} cluster.",
+                "tags": tag_refs,
+            },
+            schema=NetBoxClusterSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "type": record.get("type"),
+                "description": record.get("description"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        device = await self._get_or_create_device(
+            nb, cluster, cluster_obj, cluster.nodes[0].name, tag_refs
+        )
+
+        async def _create_vm_with_backups(vm) -> list[Any]:
+            vm_role_slug = "virtual-machine-qemu" if vm.type == "qemu" else "container-lxc"
+            vm_role_name = "Virtual Machine (QEMU)" if vm.type == "qemu" else "Container (LXC)"
+            vm_role_color = "00ffff" if vm.type == "qemu" else "7fffd4"
+
+            vm_role = await rest_reconcile_async(
+                nb,
+                "/api/dcim/device-roles/",
+                lookup={"slug": vm_role_slug},
+                payload={
+                    "name": vm_role_name,
+                    "slug": vm_role_slug,
+                    "color": vm_role_color,
+                    "description": f"Proxmox {'Virtual Machine' if vm.type == 'qemu' else 'LXC Container'}",
+                    "tags": tag_refs,
+                },
+                schema=NetBoxDeviceRoleSyncState,
+                current_normalizer=lambda record: {
+                    "name": record.get("name"),
+                    "slug": record.get("slug"),
+                    "color": record.get("color"),
+                    "description": record.get("description"),
+                    "tags": record.get("tags"),
+                },
+            )
+
+            payload = build_netbox_virtual_machine_payload(
+                proxmox_resource=vm.to_resource(),
+                proxmox_config=vm.to_config(),
+                cluster_id=cluster_obj.id,
+                device_id=device.id,
+                role_id=vm_role.id,
+                tag_ids=[e2e_tag["id"]],
+            )
+
+            virtual_machine = await rest_reconcile_async(
+                nb,
+                "/api/virtualization/virtual-machines/",
+                lookup={"cf_proxmox_vm_id": vm.vmid},
+                payload=payload,
+                schema=NetBoxVirtualMachineCreateBody,
+                current_normalizer=lambda record: {
+                    "name": record.get("name"),
+                    "status": record.get("status"),
+                    "cluster": record.get("cluster"),
+                    "device": record.get("device"),
+                    "role": record.get("role"),
+                    "vcpus": record.get("vcpus"),
+                    "memory": record.get("memory"),
+                    "disk": record.get("disk"),
+                    "tags": record.get("tags"),
+                    "custom_fields": record.get("custom_fields"),
+                    "description": record.get("description"),
+                },
+            )
+
+            vm_backups = [b for b in all_backups if b.vmid == vm.vmid]
+            created_backups = []
+
+            for backup in vm_backups:
+                netbox_backup = await rest_reconcile_async(
+                    nb,
+                    "/api/plugins/proxbox/backups/",
+                    lookup={"volume_id": backup.volid},
+                    payload={
+                        "storage": backup.storage,
+                        "virtual_machine": virtual_machine.id,
+                        "subtype": backup.subtype,
+                        "creation_time": None,
+                        "size": backup.size,
+                        "verification_state": None,
+                        "verification_upid": None,
+                        "volume_id": backup.volid,
+                        "notes": backup.notes,
+                        "vmid": backup.vmid,
+                        "format": backup.format,
+                        "tags": tag_refs,
+                    },
+                    schema=NetBoxBackupSyncState,
+                    current_normalizer=lambda record: {
+                        "storage": record.get("storage"),
+                        "virtual_machine": record.get("virtual_machine"),
+                        "subtype": record.get("subtype"),
+                        "creation_time": record.get("creation_time"),
+                        "size": record.get("size"),
+                        "verification_state": record.get("verification_state"),
+                        "verification_upid": record.get("verification_upid"),
+                        "volume_id": record.get("volume_id"),
+                        "notes": record.get("notes"),
+                        "vmid": record.get("vmid"),
+                        "format": record.get("format"),
+                        "tags": record.get("tags"),
+                    },
+                )
+                created_backups.append(netbox_backup)
+
+            return created_backups
+
+        all_vm_backups = await asyncio.gather(*[_create_vm_with_backups(vm) for vm in cluster.vms])
+
+        total_backups = sum(len(backups) for backups in all_vm_backups)
+        assert total_backups == len(all_backups), (
+            f"Expected {len(all_backups)} backups, got {total_backups}"
+        )
+
+        for vm_backups in all_vm_backups:
+            for backup in vm_backups:
+                backup_data = backup.serialize()
+                tag_slugs = [t.get("slug") for t in backup_data.get("tags", [])]
+                assert "proxbox-e2e-testing" in tag_slugs, f"Backup {backup.id} missing e2e tag"
+
+    async def _setup_cluster_dependencies(self, nb, cluster, tag_refs: list[dict[str, Any]]):
+        """Set up cluster dependencies."""
+        await self._get_cluster_type(nb, cluster.mode, tag_refs)
+
+        await rest_reconcile_async(
+            nb,
+            "/api/dcim/manufacturers/",
+            lookup={"slug": "proxmox"},
+            payload={
+                "name": "Proxmox",
+                "slug": "proxmox",
+                "tags": tag_refs,
+            },
+            schema=NetBoxManufacturerSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        await rest_reconcile_async(
+            nb,
+            "/api/dcim/device-types/",
+            lookup={"model": "Proxmox Generic Device"},
+            payload={
+                "model": "Proxmox Generic Device",
+                "slug": "proxmox-generic-device",
+                "manufacturer": None,
+                "tags": tag_refs,
+            },
+            schema=NetBoxDeviceTypeSyncState,
+            current_normalizer=lambda record: {
+                "model": record.get("model"),
+                "slug": record.get("slug"),
+                "manufacturer": record.get("manufacturer"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        await rest_reconcile_async(
+            nb,
+            "/api/dcim/device-roles/",
+            lookup={"slug": "proxmox-node"},
+            payload={
+                "name": "Proxmox Node",
+                "slug": "proxmox-node",
+                "color": "00bcd4",
+                "tags": tag_refs,
+            },
+            schema=NetBoxDeviceRoleSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "color": record.get("color"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        site_name = f"Proxmox Default Site - {cluster.name}"
+        site_slug = f"proxmox-default-site-{_slugify(cluster.name)}"
+        await rest_reconcile_async(
+            nb,
+            "/api/dcim/sites/",
+            lookup={"slug": site_slug},
+            payload={
+                "name": site_name,
+                "slug": site_slug,
+                "status": "active",
+                "tags": tag_refs,
+            },
+            schema=NetBoxSiteSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "status": record.get("status"),
+                "tags": record.get("tags"),
+            },
+        )
+
+    async def _get_cluster_type(self, nb, mode: str, tag_refs: list[dict[str, Any]]):
+        """Get or create cluster type."""
+        return await rest_reconcile_async(
+            nb,
+            "/api/virtualization/cluster-types/",
+            lookup={"slug": mode},
+            payload={
+                "name": mode.capitalize(),
+                "slug": mode,
+                "description": f"Proxmox {mode} mode",
+                "tags": tag_refs,
+            },
+            schema=NetBoxClusterTypeSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "description": record.get("description"),
+                "tags": record.get("tags"),
+            },
+        )
+
+    async def _get_or_create_device(
+        self, nb, cluster, cluster_obj, node_name: str, tag_refs: list[dict[str, Any]]
+    ):
+        """Get or create a device for the node."""
+        site_name = f"Proxmox Default Site - {cluster.name}"
+        site_slug = f"proxmox-default-site-{_slugify(cluster.name)}"
+
+        manufacturer = await rest_reconcile_async(
+            nb,
+            "/api/dcim/manufacturers/",
+            lookup={"slug": "proxmox"},
+            payload={
+                "name": "Proxmox",
+                "slug": "proxmox",
+                "tags": tag_refs,
+            },
+            schema=NetBoxManufacturerSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        device_type = await rest_reconcile_async(
+            nb,
+            "/api/dcim/device-types/",
+            lookup={"model": "Proxmox Generic Device"},
+            payload={
+                "model": "Proxmox Generic Device",
+                "slug": "proxmox-generic-device",
+                "manufacturer": manufacturer.id,
+                "tags": tag_refs,
+            },
+            schema=NetBoxDeviceTypeSyncState,
+            current_normalizer=lambda record: {
+                "model": record.get("model"),
+                "slug": record.get("slug"),
+                "manufacturer": record.get("manufacturer"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        device_role = await rest_reconcile_async(
+            nb,
+            "/api/dcim/device-roles/",
+            lookup={"slug": "proxmox-node"},
+            payload={
+                "name": "Proxmox Node",
+                "slug": "proxmox-node",
+                "color": "00bcd4",
+                "tags": tag_refs,
+            },
+            schema=NetBoxDeviceRoleSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "color": record.get("color"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        site = await rest_reconcile_async(
+            nb,
+            "/api/dcim/sites/",
+            lookup={"slug": site_slug},
+            payload={
+                "name": site_name,
+                "slug": site_slug,
+                "status": "active",
+                "tags": tag_refs,
+            },
+            schema=NetBoxSiteSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "status": record.get("status"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        return await rest_reconcile_async(
+            nb,
+            "/api/dcim/devices/",
+            lookup={"name": node_name, "site_id": site.id},
+            payload={
+                "name": node_name,
+                "tags": tag_refs,
+                "cluster": cluster_obj.id,
+                "status": "active",
+                "description": f"Proxmox Node {node_name}",
+                "device_type": device_type.id,
+                "role": device_role.id,
+                "site": site.id,
+            },
+            schema=NetBoxDeviceSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "status": record.get("status"),
+                "cluster": record.get("cluster"),
+                "device_type": record.get("device_type"),
+                "role": record.get("role"),
+                "site": record.get("site"),
+                "description": record.get("description"),
+                "tags": record.get("tags"),
+            },
+        )

--- a/tests/e2e/test_demo_auth.py
+++ b/tests/e2e/test_demo_auth.py
@@ -1,0 +1,250 @@
+"""E2E tests for NetBox demo authentication.
+
+Tests the Playwright-based authentication flow for NetBox demo instances.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from proxbox_api.e2e.demo_auth import (
+    DemoAuthError,
+    DemoLoginError,
+    PlaywrightNotInstalledError,
+    create_demo_user,
+    demo_auth_required,
+    generate_password,
+    generate_username,
+    login,
+    provision_demo_token,
+    refresh_demo_profile,
+)
+from proxbox_api.e2e.fixtures.test_data import get_e2e_credentials, get_e2e_demo_config
+
+
+@pytest.mark.asyncio
+class TestDemoAuthHelpers:
+    """Tests for demo auth helper functions."""
+
+    def test_generate_username_format(self):
+        """Test username generation produces valid format."""
+        username = generate_username()
+        assert username.startswith("proxbox_e2e_")
+        assert len(username) > len("proxbox_e2e_")
+
+    def test_generate_password_length(self):
+        """Test password generation produces adequate length."""
+        password = generate_password()
+        assert len(password) == 32
+        assert any(c.isupper() for c in password)
+        assert any(c.islower() for c in password)
+        assert any(c.isdigit() for c in password)
+
+    def test_get_e2e_credentials_returns_tuple(self):
+        """Test credential retrieval returns username and password."""
+        username, password = get_e2e_credentials()
+        assert isinstance(username, str)
+        assert isinstance(password, str)
+        assert len(username) > 0
+        assert len(password) > 0
+
+    def test_get_e2e_demo_config_returns_dict(self):
+        """Test demo config retrieval returns expected structure."""
+        config = get_e2e_demo_config()
+        assert isinstance(config, dict)
+        assert "demo_url" in config
+        assert "timeout" in config
+        assert "headless" in config
+        assert config["demo_url"] == "https://demo.netbox.dev"
+
+
+@pytest.mark.asyncio
+class TestDemoAuthIntegration:
+    """Integration tests for demo auth with NetBox demo.
+
+    These tests require a live NetBox demo instance and Playwright.
+    They are marked with @pytest.mark.e2e and can be skipped in CI.
+    """
+
+    @pytest.fixture
+    def test_credentials(self):
+        """Get test credentials."""
+        return get_e2e_credentials()
+
+    @pytest.fixture
+    def demo_config(self):
+        """Get demo config."""
+        return get_e2e_demo_config()
+
+    async def test_create_demo_user(self, test_credentials, demo_config):
+        """Test creating a demo user.
+
+        This test verifies that we can navigate to the demo login page
+        and create a new user account.
+        """
+        username, password = test_credentials
+
+        user_created = await create_demo_user(
+            username=username,
+            password=password,
+            headless=demo_config["headless"],
+        )
+
+        assert isinstance(user_created, bool)
+
+    async def test_login_existing_user(self, test_credentials, demo_config):
+        """Test logging in with existing credentials.
+
+        This test verifies that we can log in with credentials
+        that were previously created.
+        """
+        username, password = test_credentials
+
+        try:
+            await login(
+                username=username,
+                password=password,
+                headless=demo_config["headless"],
+            )
+        except DemoLoginError:
+            pytest.fail("Failed to login with existing credentials")
+
+    async def test_provision_demo_token(self, test_credentials, demo_config):
+        """Test provisioning a demo token.
+
+        This is the main auth flow test that verifies we can:
+        1. Navigate to demo login
+        2. Create user or login
+        3. Navigate to tokens page
+        4. Create a v1 token
+        5. Return the token value
+        """
+        username, password = test_credentials
+
+        token = await provision_demo_token(
+            username=username,
+            password=password,
+            headless=demo_config["headless"],
+            timeout=demo_config["timeout"],
+            token_name="proxbox-e2e-test",
+        )
+
+        assert token.version == "v1"
+        assert token.secret is not None
+        assert len(token.secret) > 40
+
+    async def test_bootstrap_demo_profile(self, test_credentials, demo_config):
+        """Test full profile bootstrap.
+
+        This test verifies that bootstrap_demo_profile returns
+        a valid Config object with all necessary fields.
+        """
+        from proxbox_api.e2e.demo_auth import bootstrap_demo_profile
+
+        username, password = test_credentials
+
+        config = await bootstrap_demo_profile(
+            username=username,
+            password=password,
+            timeout=demo_config["timeout"],
+            headless=demo_config["headless"],
+            token_name="proxbox-e2e-bootstrap",
+        )
+
+        assert config.base_url == "https://demo.netbox.dev"
+        assert config.token_version == "v1"
+        assert config.demo_username == username
+        assert config.demo_password == password
+        assert config.token_secret is not None
+
+
+@pytest.mark.asyncio
+class TestDemoAuthErrorHandling:
+    """Tests for demo auth error handling."""
+
+    async def test_playwright_not_installed_error(self):
+        """Test that proper error is raised when Playwright missing."""
+
+        @demo_auth_required
+        async def _test():
+            pass
+
+        import sys
+
+        original_modules = dict(sys.modules)
+
+        try:
+            for mod_name in list(sys.modules.keys()):
+                if "playwright" in mod_name:
+                    del sys.modules[mod_name]
+
+            from importlib import reload
+
+            import proxbox_api.e2e.demo_auth as demo_auth_module
+
+            reload(demo_auth_module)
+
+            with pytest.raises((PlaywrightNotInstalledError, ModuleNotFoundError)):
+                await demo_auth_module.provision_demo_token(
+                    username="test",
+                    password="test",
+                )
+        finally:
+            for mod_name in list(sys.modules.keys()):
+                if "playwright" in mod_name and mod_name not in original_modules:
+                    del sys.modules[mod_name]
+
+
+@pytest.mark.asyncio
+class TestTokenRefresh:
+    """Tests for token refresh functionality."""
+
+    @pytest.fixture
+    def test_credentials(self):
+        """Get test credentials."""
+        return get_e2e_credentials()
+
+    async def test_refresh_demo_profile(self, test_credentials, demo_config):
+        """Test refreshing demo profile with existing credentials.
+
+        This test verifies that refresh_demo_profile can use
+        saved credentials from an existing Config to get a new token.
+        """
+        from proxbox_api.e2e.demo_auth import (
+            bootstrap_demo_profile,
+            refresh_demo_profile,
+        )
+
+        username, password = test_credentials
+
+        initial_config = await bootstrap_demo_profile(
+            username=username,
+            password=password,
+            timeout=demo_config["timeout"],
+            headless=demo_config["headless"],
+            token_name="proxbox-e2e-refresh",
+        )
+
+        refreshed_config = await refresh_demo_profile(
+            initial_config,
+            headless=demo_config["headless"],
+            token_name="proxbox-e2e-refresh-2",
+        )
+
+        assert refreshed_config.token_version == "v1"
+        assert refreshed_config.demo_username == username
+        assert refreshed_config.demo_password == password
+        assert refreshed_config.token_secret is not None
+
+    async def test_refresh_without_credentials_raises(self):
+        """Test that refresh without credentials raises error."""
+        from netbox_sdk.config import Config
+
+        empty_config = Config(
+            base_url="https://demo.netbox.dev",
+            token_version="v1",
+            token_secret="dummy",
+        )
+
+        with pytest.raises(DemoAuthError, match="credentials are not available"):
+            await refresh_demo_profile(empty_config)

--- a/tests/e2e/test_devices_sync.py
+++ b/tests/e2e/test_devices_sync.py
@@ -1,0 +1,722 @@
+"""E2E tests for Proxmox device (node) synchronization.
+
+Tests the synchronization of Proxmox nodes to NetBox devices,
+verifying that all synced objects have the 'proxbox e2e testing' tag.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from proxbox_api.e2e.fixtures.proxmox_mock import (
+    create_minimal_cluster,
+    create_multi_cluster,
+)
+from proxbox_api.netbox_rest import (
+    nested_tag_payload,
+    rest_list_async,
+    rest_reconcile_async,
+)
+from proxbox_api.proxmox_to_netbox.models import (
+    NetBoxClusterSyncState,
+    NetBoxClusterTypeSyncState,
+    NetBoxDeviceRoleSyncState,
+    NetBoxDeviceSyncState,
+    NetBoxDeviceTypeSyncState,
+    NetBoxManufacturerSyncState,
+    NetBoxSiteSyncState,
+)
+
+
+@pytest.mark.asyncio
+class TestDevicesSync:
+    """E2E tests for device synchronization."""
+
+    async def test_sync_single_node_creates_device_with_e2e_tag(
+        self,
+        netbox_demo_session,
+        e2e_tag,
+        unique_prefix,
+    ):
+        """Test that syncing a single node creates a device with e2e tag.
+
+        This test verifies:
+        1. A Proxmox node is synced to a NetBox device
+        2. The device has the 'proxbox e2e testing' tag
+        3. All dependent objects also have the e2e tag
+        """
+        nb = netbox_demo_session
+        tag_refs = nested_tag_payload(e2e_tag)
+        cluster = create_minimal_cluster(prefix=unique_prefix)
+
+        node_name = cluster.nodes[0].name
+        cluster_name = cluster.name
+
+        cluster_type = await rest_reconcile_async(
+            nb,
+            "/api/virtualization/cluster-types/",
+            lookup={"slug": cluster.mode},
+            payload={
+                "name": cluster.mode.capitalize(),
+                "slug": cluster.mode,
+                "description": f"Proxmox {cluster.mode} mode",
+                "tags": tag_refs,
+            },
+            schema=NetBoxClusterTypeSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "description": record.get("description"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        assert cluster_type is not None
+        cluster_obj = await rest_reconcile_async(
+            nb,
+            "/api/virtualization/clusters/",
+            lookup={"name": cluster_name},
+            payload={
+                "name": cluster_name,
+                "type": cluster_type.id,
+                "description": f"Proxmox {cluster.mode} cluster.",
+                "tags": tag_refs,
+            },
+            schema=NetBoxClusterSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "type": record.get("type"),
+                "description": record.get("description"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        assert cluster_obj is not None
+
+        manufacturer = await rest_reconcile_async(
+            nb,
+            "/api/dcim/manufacturers/",
+            lookup={"slug": "proxmox"},
+            payload={
+                "name": "Proxmox",
+                "slug": "proxmox",
+                "tags": tag_refs,
+            },
+            schema=NetBoxManufacturerSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        device_type = await rest_reconcile_async(
+            nb,
+            "/api/dcim/device-types/",
+            lookup={"model": "Proxmox Generic Device"},
+            payload={
+                "model": "Proxmox Generic Device",
+                "slug": "proxmox-generic-device",
+                "manufacturer": manufacturer.id,
+                "tags": tag_refs,
+            },
+            schema=NetBoxDeviceTypeSyncState,
+            current_normalizer=lambda record: {
+                "model": record.get("model"),
+                "slug": record.get("slug"),
+                "manufacturer": record.get("manufacturer"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        device_role = await rest_reconcile_async(
+            nb,
+            "/api/dcim/device-roles/",
+            lookup={"slug": "proxmox-node"},
+            payload={
+                "name": "Proxmox Node",
+                "slug": "proxmox-node",
+                "color": "00bcd4",
+                "tags": tag_refs,
+            },
+            schema=NetBoxDeviceRoleSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "color": record.get("color"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        from proxbox_api.services.sync.devices import _slugify
+
+        site_name = f"Proxmox Default Site - {cluster_name}"
+        site_slug = f"proxmox-default-site-{_slugify(cluster_name)}"
+        site = await rest_reconcile_async(
+            nb,
+            "/api/dcim/sites/",
+            lookup={"slug": site_slug},
+            payload={
+                "name": site_name,
+                "slug": site_slug,
+                "status": "active",
+                "tags": tag_refs,
+            },
+            schema=NetBoxSiteSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "status": record.get("status"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        device = await rest_reconcile_async(
+            nb,
+            "/api/dcim/devices/",
+            lookup={"name": node_name, "site_id": site.id},
+            payload={
+                "name": node_name,
+                "tags": tag_refs,
+                "cluster": cluster_obj.id,
+                "status": "active",
+                "description": f"Proxmox Node {node_name}",
+                "device_type": device_type.id,
+                "role": device_role.id,
+                "site": site.id,
+            },
+            schema=NetBoxDeviceSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "status": record.get("status"),
+                "cluster": record.get("cluster"),
+                "device_type": record.get("device_type"),
+                "role": record.get("role"),
+                "site": record.get("site"),
+                "description": record.get("description"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        assert device is not None
+        assert device.name == node_name
+        assert device.cluster == cluster_obj.id
+        assert device.site == site.id
+
+        devices = await rest_list_async(
+            nb,
+            "/api/dcim/devices/",
+            query={"name": node_name, "site_id": site.id},
+        )
+        assert len(devices) == 1
+
+        device_data = devices[0].serialize()
+        device_tag_slugs = [t.get("slug") for t in device_data.get("tags", [])]
+        assert "proxbox-e2e-testing" in device_tag_slugs
+
+    async def test_sync_creates_all_dependent_objects_with_e2e_tag(
+        self,
+        netbox_demo_session,
+        e2e_tag,
+        unique_prefix,
+    ):
+        """Test that all dependent objects are created with e2e tag.
+
+        Verifies:
+        - Cluster type has e2e tag
+        - Cluster has e2e tag
+        - Site has e2e tag
+        - Manufacturer has e2e tag
+        - Device type has e2e tag
+        - Device role has e2e tag
+        """
+        nb = netbox_demo_session
+        tag_refs = nested_tag_payload(e2e_tag)
+        cluster = create_minimal_cluster(prefix=unique_prefix)
+
+        cluster_type = await rest_reconcile_async(
+            nb,
+            "/api/virtualization/cluster-types/",
+            lookup={"slug": cluster.mode},
+            payload={
+                "name": cluster.mode.capitalize(),
+                "slug": cluster.mode,
+                "description": f"Proxmox {cluster.mode} mode",
+                "tags": tag_refs,
+            },
+            schema=NetBoxClusterTypeSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "description": record.get("description"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        cluster_obj = await rest_reconcile_async(
+            nb,
+            "/api/virtualization/clusters/",
+            lookup={"name": cluster.name},
+            payload={
+                "name": cluster.name,
+                "type": cluster_type.id,
+                "description": f"Proxmox {cluster.mode} cluster.",
+                "tags": tag_refs,
+            },
+            schema=NetBoxClusterSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "type": record.get("type"),
+                "description": record.get("description"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        manufacturer = await rest_reconcile_async(
+            nb,
+            "/api/dcim/manufacturers/",
+            lookup={"slug": "proxmox"},
+            payload={
+                "name": "Proxmox",
+                "slug": "proxmox",
+                "tags": tag_refs,
+            },
+            schema=NetBoxManufacturerSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        device_type = await rest_reconcile_async(
+            nb,
+            "/api/dcim/device-types/",
+            lookup={"model": "Proxmox Generic Device"},
+            payload={
+                "model": "Proxmox Generic Device",
+                "slug": "proxmox-generic-device",
+                "manufacturer": manufacturer.id,
+                "tags": tag_refs,
+            },
+            schema=NetBoxDeviceTypeSyncState,
+            current_normalizer=lambda record: {
+                "model": record.get("model"),
+                "slug": record.get("slug"),
+                "manufacturer": record.get("manufacturer"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        device_role = await rest_reconcile_async(
+            nb,
+            "/api/dcim/device-roles/",
+            lookup={"slug": "proxmox-node"},
+            payload={
+                "name": "Proxmox Node",
+                "slug": "proxmox-node",
+                "color": "00bcd4",
+                "tags": tag_refs,
+            },
+            schema=NetBoxDeviceRoleSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "color": record.get("color"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        from proxbox_api.services.sync.devices import _slugify
+
+        site_name = f"Proxmox Default Site - {cluster.name}"
+        site_slug = f"proxmox-default-site-{_slugify(cluster.name)}"
+        site = await rest_reconcile_async(
+            nb,
+            "/api/dcim/sites/",
+            lookup={"slug": site_slug},
+            payload={
+                "name": site_name,
+                "slug": site_slug,
+                "status": "active",
+                "tags": tag_refs,
+            },
+            schema=NetBoxSiteSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "status": record.get("status"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        cluster_type_data = cluster_type.serialize()
+        cluster_data = cluster_obj.serialize()
+        manufacturer_data = manufacturer.serialize()
+        device_type_data = device_type.serialize()
+        device_role_data = device_role.serialize()
+        site_data = site.serialize()
+
+        def _has_e2e_tag(obj: dict[str, Any]) -> bool:
+            tag_slugs = [t.get("slug") for t in obj.get("tags", [])]
+            return "proxbox-e2e-testing" in tag_slugs
+
+        assert _has_e2e_tag(cluster_type_data), "Cluster type missing e2e tag"
+        assert _has_e2e_tag(cluster_data), "Cluster missing e2e tag"
+        assert _has_e2e_tag(manufacturer_data), "Manufacturer missing e2e tag"
+        assert _has_e2e_tag(device_type_data), "Device type missing e2e tag"
+        assert _has_e2e_tag(device_role_data), "Device role missing e2e tag"
+        assert _has_e2e_tag(site_data), "Site missing e2e tag"
+
+    async def test_idempotent_sync_does_not_duplicate(
+        self,
+        netbox_demo_session,
+        e2e_tag,
+        unique_prefix,
+    ):
+        """Test that running sync twice doesn't create duplicates.
+
+        Verifies that the sync is idempotent and updates existing
+        objects instead of creating new ones.
+        """
+        nb = netbox_demo_session
+        tag_refs = nested_tag_payload(e2e_tag)
+        cluster = create_minimal_cluster(prefix=unique_prefix)
+
+        node_name = cluster.nodes[0].name
+
+        async def _create_device():
+            cluster_type = await rest_reconcile_async(
+                nb,
+                "/api/virtualization/cluster-types/",
+                lookup={"slug": cluster.mode},
+                payload={
+                    "name": cluster.mode.capitalize(),
+                    "slug": cluster.mode,
+                    "description": f"Proxmox {cluster.mode} mode",
+                    "tags": tag_refs,
+                },
+                schema=NetBoxClusterTypeSyncState,
+                current_normalizer=lambda record: {
+                    "name": record.get("name"),
+                    "slug": record.get("slug"),
+                    "description": record.get("description"),
+                    "tags": record.get("tags"),
+                },
+            )
+
+            cluster_obj = await rest_reconcile_async(
+                nb,
+                "/api/virtualization/clusters/",
+                lookup={"name": cluster.name},
+                payload={
+                    "name": cluster.name,
+                    "type": cluster_type.id,
+                    "description": f"Proxmox {cluster.mode} cluster.",
+                    "tags": tag_refs,
+                },
+                schema=NetBoxClusterSyncState,
+                current_normalizer=lambda record: {
+                    "name": record.get("name"),
+                    "type": record.get("type"),
+                    "description": record.get("description"),
+                    "tags": record.get("tags"),
+                },
+            )
+
+            manufacturer = await rest_reconcile_async(
+                nb,
+                "/api/dcim/manufacturers/",
+                lookup={"slug": "proxmox"},
+                payload={
+                    "name": "Proxmox",
+                    "slug": "proxmox",
+                    "tags": tag_refs,
+                },
+                schema=NetBoxManufacturerSyncState,
+                current_normalizer=lambda record: {
+                    "name": record.get("name"),
+                    "slug": record.get("slug"),
+                    "tags": record.get("tags"),
+                },
+            )
+
+            device_type = await rest_reconcile_async(
+                nb,
+                "/api/dcim/device-types/",
+                lookup={"model": "Proxmox Generic Device"},
+                payload={
+                    "model": "Proxmox Generic Device",
+                    "slug": "proxmox-generic-device",
+                    "manufacturer": manufacturer.id,
+                    "tags": tag_refs,
+                },
+                schema=NetBoxDeviceTypeSyncState,
+                current_normalizer=lambda record: {
+                    "model": record.get("model"),
+                    "slug": record.get("slug"),
+                    "manufacturer": record.get("manufacturer"),
+                    "tags": record.get("tags"),
+                },
+            )
+
+            device_role = await rest_reconcile_async(
+                nb,
+                "/api/dcim/device-roles/",
+                lookup={"slug": "proxmox-node"},
+                payload={
+                    "name": "Proxmox Node",
+                    "slug": "proxmox-node",
+                    "color": "00bcd4",
+                    "tags": tag_refs,
+                },
+                schema=NetBoxDeviceRoleSyncState,
+                current_normalizer=lambda record: {
+                    "name": record.get("name"),
+                    "slug": record.get("slug"),
+                    "color": record.get("color"),
+                    "tags": record.get("tags"),
+                },
+            )
+
+            from proxbox_api.services.sync.devices import _slugify
+
+            site_name = f"Proxmox Default Site - {cluster.name}"
+            site_slug = f"proxmox-default-site-{_slugify(cluster.name)}"
+            site = await rest_reconcile_async(
+                nb,
+                "/api/dcim/sites/",
+                lookup={"slug": site_slug},
+                payload={
+                    "name": site_name,
+                    "slug": site_slug,
+                    "status": "active",
+                    "tags": tag_refs,
+                },
+                schema=NetBoxSiteSyncState,
+                current_normalizer=lambda record: {
+                    "name": record.get("name"),
+                    "slug": record.get("slug"),
+                    "status": record.get("status"),
+                    "tags": record.get("tags"),
+                },
+            )
+
+            return await rest_reconcile_async(
+                nb,
+                "/api/dcim/devices/",
+                lookup={"name": node_name, "site_id": site.id},
+                payload={
+                    "name": node_name,
+                    "tags": tag_refs,
+                    "cluster": cluster_obj.id,
+                    "status": "active",
+                    "description": f"Proxmox Node {node_name}",
+                    "device_type": device_type.id,
+                    "role": device_role.id,
+                    "site": site.id,
+                },
+                schema=NetBoxDeviceSyncState,
+                current_normalizer=lambda record: {
+                    "name": record.get("name"),
+                    "status": record.get("status"),
+                    "cluster": record.get("cluster"),
+                    "device_type": record.get("device_type"),
+                    "role": record.get("role"),
+                    "site": record.get("site"),
+                    "description": record.get("description"),
+                    "tags": record.get("tags"),
+                },
+            )
+
+        device1 = await _create_device()
+        device1_id = device1.id
+
+        device2 = await _create_device()
+        device2_id = device2.id
+
+        assert device1_id == device2_id, "Idempotent sync should not create duplicates"
+
+        devices = await rest_list_async(
+            nb,
+            "/api/dcim/devices/",
+            query={"name": node_name},
+        )
+        assert len(devices) == 1, "Should have exactly one device with that name"
+
+    async def test_sync_with_multiple_nodes(
+        self,
+        netbox_demo_session,
+        e2e_tag,
+        unique_prefix,
+    ):
+        """Test syncing multiple nodes in parallel.
+
+        Verifies that the sync handles multiple nodes correctly
+        and all nodes get the e2e tag.
+        """
+        import asyncio
+
+        nb = netbox_demo_session
+        tag_refs = nested_tag_payload(e2e_tag)
+        clusters = create_multi_cluster(prefix=unique_prefix)
+
+        cluster = clusters[0]
+        cluster_name = cluster.name
+        node_names = [node.name for node in cluster.nodes]
+
+        cluster_type = await rest_reconcile_async(
+            nb,
+            "/api/virtualization/cluster-types/",
+            lookup={"slug": cluster.mode},
+            payload={
+                "name": cluster.mode.capitalize(),
+                "slug": cluster.mode,
+                "description": f"Proxmox {cluster.mode} mode",
+                "tags": tag_refs,
+            },
+            schema=NetBoxClusterTypeSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "description": record.get("description"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        cluster_obj = await rest_reconcile_async(
+            nb,
+            "/api/virtualization/clusters/",
+            lookup={"name": cluster_name},
+            payload={
+                "name": cluster_name,
+                "type": cluster_type.id,
+                "description": f"Proxmox {cluster.mode} cluster.",
+                "tags": tag_refs,
+            },
+            schema=NetBoxClusterSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "type": record.get("type"),
+                "description": record.get("description"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        manufacturer = await rest_reconcile_async(
+            nb,
+            "/api/dcim/manufacturers/",
+            lookup={"slug": "proxmox"},
+            payload={
+                "name": "Proxmox",
+                "slug": "proxmox",
+                "tags": tag_refs,
+            },
+            schema=NetBoxManufacturerSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        device_type = await rest_reconcile_async(
+            nb,
+            "/api/dcim/device-types/",
+            lookup={"model": "Proxmox Generic Device"},
+            payload={
+                "model": "Proxmox Generic Device",
+                "slug": "proxmox-generic-device",
+                "manufacturer": manufacturer.id,
+                "tags": tag_refs,
+            },
+            schema=NetBoxDeviceTypeSyncState,
+            current_normalizer=lambda record: {
+                "model": record.get("model"),
+                "slug": record.get("slug"),
+                "manufacturer": record.get("manufacturer"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        device_role = await rest_reconcile_async(
+            nb,
+            "/api/dcim/device-roles/",
+            lookup={"slug": "proxmox-node"},
+            payload={
+                "name": "Proxmox Node",
+                "slug": "proxmox-node",
+                "color": "00bcd4",
+                "tags": tag_refs,
+            },
+            schema=NetBoxDeviceRoleSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "color": record.get("color"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        from proxbox_api.services.sync.devices import _slugify
+
+        site_name = f"Proxmox Default Site - {cluster_name}"
+        site_slug = f"proxmox-default-site-{_slugify(cluster_name)}"
+        site = await rest_reconcile_async(
+            nb,
+            "/api/dcim/sites/",
+            lookup={"slug": site_slug},
+            payload={
+                "name": site_name,
+                "slug": site_slug,
+                "status": "active",
+                "tags": tag_refs,
+            },
+            schema=NetBoxSiteSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "status": record.get("status"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        async def _create_node(node_name: str):
+            return await rest_reconcile_async(
+                nb,
+                "/api/dcim/devices/",
+                lookup={"name": node_name, "site_id": site.id},
+                payload={
+                    "name": node_name,
+                    "tags": tag_refs,
+                    "cluster": cluster_obj.id,
+                    "status": "active",
+                    "description": f"Proxmox Node {node_name}",
+                    "device_type": device_type.id,
+                    "role": device_role.id,
+                    "site": site.id,
+                },
+                schema=NetBoxDeviceSyncState,
+                current_normalizer=lambda record: {
+                    "name": record.get("name"),
+                    "status": record.get("status"),
+                    "cluster": record.get("cluster"),
+                    "device_type": record.get("device_type"),
+                    "role": record.get("role"),
+                    "site": record.get("site"),
+                    "description": record.get("description"),
+                    "tags": record.get("tags"),
+                },
+            )
+
+        devices = await asyncio.gather(*[_create_node(name) for name in node_names])
+
+        assert len(devices) == len(node_names)
+
+        for device in devices:
+            assert device.name in node_names
+            device_data = device.serialize()
+            tag_slugs = [t.get("slug") for t in device_data.get("tags", [])]
+            assert "proxbox-e2e-testing" in tag_slugs

--- a/tests/e2e/test_vm_sync.py
+++ b/tests/e2e/test_vm_sync.py
@@ -1,0 +1,688 @@
+"""E2E tests for Proxmox VM synchronization.
+
+Tests the synchronization of Proxmox VMs and LXC containers to NetBox,
+verifying that all synced objects have the 'proxbox e2e testing' tag.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from proxbox_api.e2e.fixtures.proxmox_mock import (
+    MockProxmoxCluster,
+    create_minimal_cluster,
+)
+from proxbox_api.netbox_rest import (
+    nested_tag_payload,
+    rest_reconcile_async,
+)
+from proxbox_api.proxmox_to_netbox.models import (
+    NetBoxClusterSyncState,
+    NetBoxClusterTypeSyncState,
+    NetBoxDeviceRoleSyncState,
+    NetBoxDeviceSyncState,
+    NetBoxDeviceTypeSyncState,
+    NetBoxManufacturerSyncState,
+    NetBoxSiteSyncState,
+    NetBoxVirtualMachineCreateBody,
+)
+from proxbox_api.services.sync.devices import _slugify
+from proxbox_api.services.sync.virtual_machines import build_netbox_virtual_machine_payload
+
+
+@pytest.mark.asyncio
+class TestVMSync:
+    """E2E tests for virtual machine synchronization."""
+
+    async def test_sync_qemu_vm_with_e2e_tag(
+        self,
+        netbox_demo_session,
+        e2e_tag,
+        unique_prefix,
+    ):
+        """Test syncing a QEMU VM with e2e tag.
+
+        Verifies:
+        1. VM exists in NetBox
+        2. VM has 'proxbox e2e testing' tag
+        3. VM has correct custom fields
+        4. VM is linked to correct cluster and device
+        """
+        nb = netbox_demo_session
+        tag_refs = nested_tag_payload(e2e_tag)
+        cluster = create_minimal_cluster(prefix=unique_prefix)
+
+        vm = cluster.vms[0]
+        node = cluster.nodes[0]
+
+        await self._setup_cluster_dependencies(nb, cluster, tag_refs)
+
+        cluster_obj = await rest_reconcile_async(
+            nb,
+            "/api/virtualization/clusters/",
+            lookup={"name": cluster.name},
+            payload={
+                "name": cluster.name,
+                "type": (await self._get_cluster_type(nb, cluster.mode, tag_refs)).id,
+                "description": f"Proxmox {cluster.mode} cluster.",
+                "tags": tag_refs,
+            },
+            schema=NetBoxClusterSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "type": record.get("type"),
+                "description": record.get("description"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        device = await self._get_or_create_device(nb, cluster, cluster_obj, node.name, tag_refs)
+
+        netbox_vm_payload = build_netbox_virtual_machine_payload(
+            proxmox_resource=vm.to_resource(),
+            proxmox_config=vm.to_config(),
+            cluster_id=cluster_obj.id,
+            device_id=device.id,
+            role_id=1,
+            tag_ids=[e2e_tag["id"]],
+        )
+
+        vm_role = await rest_reconcile_async(
+            nb,
+            "/api/dcim/device-roles/",
+            lookup={"slug": "virtual-machine-qemu"},
+            payload={
+                "name": "Virtual Machine (QEMU)",
+                "slug": "virtual-machine-qemu",
+                "color": "00ffff",
+                "description": "Proxmox Virtual Machine",
+                "tags": tag_refs,
+            },
+            schema=NetBoxDeviceRoleSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "color": record.get("color"),
+                "description": record.get("description"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        netbox_vm_payload["role"] = vm_role.id
+
+        virtual_machine = await rest_reconcile_async(
+            nb,
+            "/api/virtualization/virtual-machines/",
+            lookup={"cf_proxmox_vm_id": vm.vmid},
+            payload=netbox_vm_payload,
+            schema=NetBoxVirtualMachineCreateBody,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "status": record.get("status"),
+                "cluster": record.get("cluster"),
+                "device": record.get("device"),
+                "role": record.get("role"),
+                "vcpus": record.get("vcpus"),
+                "memory": record.get("memory"),
+                "disk": record.get("disk"),
+                "tags": record.get("tags"),
+                "custom_fields": record.get("custom_fields"),
+                "description": record.get("description"),
+            },
+        )
+
+        assert virtual_machine is not None
+        assert virtual_machine.name == vm.name
+
+        vm_data = virtual_machine.serialize()
+        tag_slugs = [t.get("slug") for t in vm_data.get("tags", [])]
+        assert "proxbox-e2e-testing" in tag_slugs
+
+        assert vm_data.get("custom_fields", {}).get("proxmox_vm_id") == vm.vmid
+        assert vm_data.get("cluster") == cluster_obj.id
+        assert vm_data.get("device") == device.id
+
+    async def test_sync_lxc_container_with_e2e_tag(
+        self,
+        netbox_demo_session,
+        e2e_tag,
+        unique_prefix,
+    ):
+        """Test syncing an LXC container with e2e tag.
+
+        Verifies:
+        1. LXC container exists in NetBox
+        2. Container has 'proxbox e2e testing' tag
+        3. Container has correct custom fields
+        """
+        nb = netbox_demo_session
+        tag_refs = nested_tag_payload(e2e_tag)
+        cluster = create_minimal_cluster(prefix=unique_prefix)
+
+        lxc_vm = None
+        for vm in cluster.vms:
+            if vm.type == "lxc":
+                lxc_vm = vm
+                break
+
+        assert lxc_vm is not None, "Should have an LXC container in cluster"
+
+        node = cluster.nodes[0]
+
+        await self._setup_cluster_dependencies(nb, cluster, tag_refs)
+
+        cluster_obj = await rest_reconcile_async(
+            nb,
+            "/api/virtualization/clusters/",
+            lookup={"name": cluster.name},
+            payload={
+                "name": cluster.name,
+                "type": (await self._get_cluster_type(nb, cluster.mode, tag_refs)).id,
+                "description": f"Proxmox {cluster.mode} cluster.",
+                "tags": tag_refs,
+            },
+            schema=NetBoxClusterSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "type": record.get("type"),
+                "description": record.get("description"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        device = await self._get_or_create_device(nb, cluster, cluster_obj, node.name, tag_refs)
+
+        netbox_vm_payload = build_netbox_virtual_machine_payload(
+            proxmox_resource=lxc_vm.to_resource(),
+            proxmox_config=lxc_vm.to_config(),
+            cluster_id=cluster_obj.id,
+            device_id=device.id,
+            role_id=1,
+            tag_ids=[e2e_tag["id"]],
+        )
+
+        vm_role = await rest_reconcile_async(
+            nb,
+            "/api/dcim/device-roles/",
+            lookup={"slug": "container-lxc"},
+            payload={
+                "name": "Container (LXC)",
+                "slug": "container-lxc",
+                "color": "7fffd4",
+                "description": "Proxmox LXC Container",
+                "tags": tag_refs,
+            },
+            schema=NetBoxDeviceRoleSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "color": record.get("color"),
+                "description": record.get("description"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        netbox_vm_payload["role"] = vm_role.id
+
+        virtual_machine = await rest_reconcile_async(
+            nb,
+            "/api/virtualization/virtual-machines/",
+            lookup={"cf_proxmox_vm_id": lxc_vm.vmid},
+            payload=netbox_vm_payload,
+            schema=NetBoxVirtualMachineCreateBody,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "status": record.get("status"),
+                "cluster": record.get("cluster"),
+                "device": record.get("device"),
+                "role": record.get("role"),
+                "vcpus": record.get("vcpus"),
+                "memory": record.get("memory"),
+                "disk": record.get("disk"),
+                "tags": record.get("tags"),
+                "custom_fields": record.get("custom_fields"),
+                "description": record.get("description"),
+            },
+        )
+
+        assert virtual_machine is not None
+        assert virtual_machine.name == lxc_vm.name
+
+        vm_data = virtual_machine.serialize()
+        tag_slugs = [t.get("slug") for t in vm_data.get("tags", [])]
+        assert "proxbox-e2e-testing" in tag_slugs
+
+        assert vm_data.get("custom_fields", {}).get("proxmox_vm_id") == lxc_vm.vmid
+
+    async def test_sync_vm_creates_custom_fields(
+        self,
+        netbox_demo_session,
+        e2e_tag,
+        unique_prefix,
+    ):
+        """Test that VM custom fields are correctly set.
+
+        Verifies:
+        - proxmox_vm_id matches VM ID
+        - proxmox_start_at_boot reflects onboot config
+        - proxmox_unprivileged_container reflects unprivileged config
+        """
+        nb = netbox_demo_session
+        tag_refs = nested_tag_payload(e2e_tag)
+        cluster = create_minimal_cluster(prefix=unique_prefix)
+
+        vm = cluster.vms[0]
+
+        await self._setup_cluster_dependencies(nb, cluster, tag_refs)
+
+        cluster_obj = await rest_reconcile_async(
+            nb,
+            "/api/virtualization/clusters/",
+            lookup={"name": cluster.name},
+            payload={
+                "name": cluster.name,
+                "type": (await self._get_cluster_type(nb, cluster.mode, tag_refs)).id,
+                "description": f"Proxmox {cluster.mode} cluster.",
+                "tags": tag_refs,
+            },
+            schema=NetBoxClusterSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "type": record.get("type"),
+                "description": record.get("description"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        device = await self._get_or_create_device(
+            nb, cluster, cluster_obj, cluster.nodes[0].name, tag_refs
+        )
+
+        netbox_vm_payload = build_netbox_virtual_machine_payload(
+            proxmox_resource=vm.to_resource(),
+            proxmox_config=vm.to_config(),
+            cluster_id=cluster_obj.id,
+            device_id=device.id,
+            role_id=1,
+            tag_ids=[e2e_tag["id"]],
+        )
+
+        vm_role = await rest_reconcile_async(
+            nb,
+            "/api/dcim/device-roles/",
+            lookup={"slug": "virtual-machine-qemu"},
+            payload={
+                "name": "Virtual Machine (QEMU)",
+                "slug": "virtual-machine-qemu",
+                "color": "00ffff",
+                "description": "Proxmox Virtual Machine",
+                "tags": tag_refs,
+            },
+            schema=NetBoxDeviceRoleSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "color": record.get("color"),
+                "description": record.get("description"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        netbox_vm_payload["role"] = vm_role.id
+
+        virtual_machine = await rest_reconcile_async(
+            nb,
+            "/api/virtualization/virtual-machines/",
+            lookup={"cf_proxmox_vm_id": vm.vmid},
+            payload=netbox_vm_payload,
+            schema=NetBoxVirtualMachineCreateBody,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "status": record.get("status"),
+                "cluster": record.get("cluster"),
+                "device": record.get("device"),
+                "role": record.get("role"),
+                "vcpus": record.get("vcpus"),
+                "memory": record.get("memory"),
+                "disk": record.get("disk"),
+                "tags": record.get("tags"),
+                "custom_fields": record.get("custom_fields"),
+                "description": record.get("description"),
+            },
+        )
+
+        vm_data = virtual_machine.serialize()
+        custom_fields = vm_data.get("custom_fields", {})
+
+        assert custom_fields.get("proxmox_vm_id") == vm.vmid
+
+        config = vm.to_config()
+        assert custom_fields.get("proxmox_start_at_boot") == (config.get("onboot", 0) == 1)
+        assert custom_fields.get("proxmox_qemu_agent") == (config.get("agent", 0) == 1)
+        assert custom_fields.get("proxmox_unprivileged_container") == (
+            config.get("unprivileged", 0) == 1
+        )
+
+    async def test_sync_multiple_vms_parallel(
+        self,
+        netbox_demo_session,
+        e2e_tag,
+        unique_prefix,
+    ):
+        """Test syncing multiple VMs in parallel.
+
+        Verifies that all VMs are synced correctly with e2e tags.
+        """
+        import asyncio
+
+        nb = netbox_demo_session
+        tag_refs = nested_tag_payload(e2e_tag)
+        cluster = create_minimal_cluster(prefix=unique_prefix)
+
+        await self._setup_cluster_dependencies(nb, cluster, tag_refs)
+
+        cluster_obj = await rest_reconcile_async(
+            nb,
+            "/api/virtualization/clusters/",
+            lookup={"name": cluster.name},
+            payload={
+                "name": cluster.name,
+                "type": (await self._get_cluster_type(nb, cluster.mode, tag_refs)).id,
+                "description": f"Proxmox {cluster.mode} cluster.",
+                "tags": tag_refs,
+            },
+            schema=NetBoxClusterSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "type": record.get("type"),
+                "description": record.get("description"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        device = await self._get_or_create_device(
+            nb, cluster, cluster_obj, cluster.nodes[0].name, tag_refs
+        )
+
+        async def _create_vm(vm: MockProxmoxCluster) -> Any:
+            vm_role_slug = "virtual-machine-qemu" if vm.type == "qemu" else "container-lxc"
+            vm_role_name = "Virtual Machine (QEMU)" if vm.type == "qemu" else "Container (LXC)"
+            vm_role_color = "00ffff" if vm.type == "qemu" else "7fffd4"
+
+            vm_role = await rest_reconcile_async(
+                nb,
+                "/api/dcim/device-roles/",
+                lookup={"slug": vm_role_slug},
+                payload={
+                    "name": vm_role_name,
+                    "slug": vm_role_slug,
+                    "color": vm_role_color,
+                    "description": f"Proxmox {'Virtual Machine' if vm.type == 'qemu' else 'LXC Container'}",
+                    "tags": tag_refs,
+                },
+                schema=NetBoxDeviceRoleSyncState,
+                current_normalizer=lambda record: {
+                    "name": record.get("name"),
+                    "slug": record.get("slug"),
+                    "color": record.get("color"),
+                    "description": record.get("description"),
+                    "tags": record.get("tags"),
+                },
+            )
+
+            payload = build_netbox_virtual_machine_payload(
+                proxmox_resource=vm.to_resource(),
+                proxmox_config=vm.to_config(),
+                cluster_id=cluster_obj.id,
+                device_id=device.id,
+                role_id=vm_role.id,
+                tag_ids=[e2e_tag["id"]],
+            )
+
+            return await rest_reconcile_async(
+                nb,
+                "/api/virtualization/virtual-machines/",
+                lookup={"cf_proxmox_vm_id": vm.vmid},
+                payload=payload,
+                schema=NetBoxVirtualMachineCreateBody,
+                current_normalizer=lambda record: {
+                    "name": record.get("name"),
+                    "status": record.get("status"),
+                    "cluster": record.get("cluster"),
+                    "device": record.get("device"),
+                    "role": record.get("role"),
+                    "vcpus": record.get("vcpus"),
+                    "memory": record.get("memory"),
+                    "disk": record.get("disk"),
+                    "tags": record.get("tags"),
+                    "custom_fields": record.get("custom_fields"),
+                    "description": record.get("description"),
+                },
+            )
+
+        vms = await asyncio.gather(*[_create_vm(vm) for vm in cluster.vms])
+
+        assert len(vms) == len(cluster.vms)
+
+        for vm in vms:
+            vm_data = vm.serialize()
+            tag_slugs = [t.get("slug") for t in vm_data.get("tags", [])]
+            assert "proxbox-e2e-testing" in tag_slugs
+
+    async def _setup_cluster_dependencies(
+        self, nb, cluster: MockProxmoxCluster, tag_refs: list[dict[str, Any]]
+    ):
+        """Set up cluster dependencies (type, manufacturer, device type, role, site)."""
+        await self._get_cluster_type(nb, cluster.mode, tag_refs)
+
+        await rest_reconcile_async(
+            nb,
+            "/api/dcim/manufacturers/",
+            lookup={"slug": "proxmox"},
+            payload={
+                "name": "Proxmox",
+                "slug": "proxmox",
+                "tags": tag_refs,
+            },
+            schema=NetBoxManufacturerSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        await rest_reconcile_async(
+            nb,
+            "/api/dcim/device-types/",
+            lookup={"model": "Proxmox Generic Device"},
+            payload={
+                "model": "Proxmox Generic Device",
+                "slug": "proxmox-generic-device",
+                "manufacturer": None,
+                "tags": tag_refs,
+            },
+            schema=NetBoxDeviceTypeSyncState,
+            current_normalizer=lambda record: {
+                "model": record.get("model"),
+                "slug": record.get("slug"),
+                "manufacturer": record.get("manufacturer"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        await rest_reconcile_async(
+            nb,
+            "/api/dcim/device-roles/",
+            lookup={"slug": "proxmox-node"},
+            payload={
+                "name": "Proxmox Node",
+                "slug": "proxmox-node",
+                "color": "00bcd4",
+                "tags": tag_refs,
+            },
+            schema=NetBoxDeviceRoleSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "color": record.get("color"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        site_name = f"Proxmox Default Site - {cluster.name}"
+        site_slug = f"proxmox-default-site-{_slugify(cluster.name)}"
+        await rest_reconcile_async(
+            nb,
+            "/api/dcim/sites/",
+            lookup={"slug": site_slug},
+            payload={
+                "name": site_name,
+                "slug": site_slug,
+                "status": "active",
+                "tags": tag_refs,
+            },
+            schema=NetBoxSiteSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "status": record.get("status"),
+                "tags": record.get("tags"),
+            },
+        )
+
+    async def _get_cluster_type(self, nb, mode: str, tag_refs: list[dict[str, Any]]):
+        """Get or create cluster type."""
+        return await rest_reconcile_async(
+            nb,
+            "/api/virtualization/cluster-types/",
+            lookup={"slug": mode},
+            payload={
+                "name": mode.capitalize(),
+                "slug": mode,
+                "description": f"Proxmox {mode} mode",
+                "tags": tag_refs,
+            },
+            schema=NetBoxClusterTypeSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "description": record.get("description"),
+                "tags": record.get("tags"),
+            },
+        )
+
+    async def _get_or_create_device(
+        self,
+        nb,
+        cluster: MockProxmoxCluster,
+        cluster_obj,
+        node_name: str,
+        tag_refs: list[dict[str, Any]],
+    ):
+        """Get or create a device for the node."""
+        site_name = f"Proxmox Default Site - {cluster.name}"
+        site_slug = f"proxmox-default-site-{_slugify(cluster.name)}"
+
+        manufacturer = await rest_reconcile_async(
+            nb,
+            "/api/dcim/manufacturers/",
+            lookup={"slug": "proxmox"},
+            payload={
+                "name": "Proxmox",
+                "slug": "proxmox",
+                "tags": tag_refs,
+            },
+            schema=NetBoxManufacturerSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        device_type = await rest_reconcile_async(
+            nb,
+            "/api/dcim/device-types/",
+            lookup={"model": "Proxmox Generic Device"},
+            payload={
+                "model": "Proxmox Generic Device",
+                "slug": "proxmox-generic-device",
+                "manufacturer": manufacturer.id,
+                "tags": tag_refs,
+            },
+            schema=NetBoxDeviceTypeSyncState,
+            current_normalizer=lambda record: {
+                "model": record.get("model"),
+                "slug": record.get("slug"),
+                "manufacturer": record.get("manufacturer"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        device_role = await rest_reconcile_async(
+            nb,
+            "/api/dcim/device-roles/",
+            lookup={"slug": "proxmox-node"},
+            payload={
+                "name": "Proxmox Node",
+                "slug": "proxmox-node",
+                "color": "00bcd4",
+                "tags": tag_refs,
+            },
+            schema=NetBoxDeviceRoleSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "color": record.get("color"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        site = await rest_reconcile_async(
+            nb,
+            "/api/dcim/sites/",
+            lookup={"slug": site_slug},
+            payload={
+                "name": site_name,
+                "slug": site_slug,
+                "status": "active",
+                "tags": tag_refs,
+            },
+            schema=NetBoxSiteSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "status": record.get("status"),
+                "tags": record.get("tags"),
+            },
+        )
+
+        return await rest_reconcile_async(
+            nb,
+            "/api/dcim/devices/",
+            lookup={"name": node_name, "site_id": site.id},
+            payload={
+                "name": node_name,
+                "tags": tag_refs,
+                "cluster": cluster_obj.id,
+                "status": "active",
+                "description": f"Proxmox Node {node_name}",
+                "device_type": device_type.id,
+                "role": device_role.id,
+                "site": site.id,
+            },
+            schema=NetBoxDeviceSyncState,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "status": record.get("status"),
+                "cluster": record.get("cluster"),
+                "device_type": record.get("device_type"),
+                "role": record.get("role"),
+                "site": record.get("site"),
+                "description": record.get("description"),
+                "tags": record.get("tags"),
+            },
+        )


### PR DESCRIPTION
## Summary
- Add async Playwright auth for NetBox demo (adapted from netbox-sdk)
- Add DemoSessionBuilder with automatic e2e tag management
- Add mock Proxmox fixtures for device, VM, and backup sync tests
- Add e2e-tests job to CI (requires test job, workflow_dispatch trigger)
- Tag all synced objects with 'proxbox e2e testing' (green)
- Enable parallel test execution with pytest-xdist
- Upload Playwright report/trace on failure