### PR TITLE
ci: run release workflow on published GitHub Release

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -79,6 +79,9 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: false
+          ignore-empty-workdir: true
 
       - name: Download dist artifacts
         uses: actions/download-artifact@v8
@@ -155,6 +158,9 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: false
+          ignore-empty-workdir: true
 
       - name: Download dist artifacts
         uses: actions/download-artifact@v8


### PR DESCRIPTION
Runs Release validation and publish when a GitHub Release is published (release: types: [published]). Pushing a tag alone without publishing a release does not start this workflow.

Checkouts use the release tag. project.version in pyproject.toml must match the tag (vVERSION). workflow_dispatch still runs TestPyPI and matrix validation only (no PyPI or Docker).