### PR TITLE
fix(docker): add uv to runtime image for release Docker CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ FROM python:3.13-slim-bookworm
 
 WORKDIR /app
 
+# uv is not in the venv; include the binary so release CI can `uv sync` dev tools in-container.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
 ENV PATH="/app/.venv/bin:$PATH" \
     PORT=8000 \
     PYTHONUNBUFFERED=1


### PR DESCRIPTION
The release workflow runs a mounted script that calls `uv sync` and `uv run` inside the container; the runtime image previously had only the venv, so `uv` was missing (exit 127). Copy the uv binary into the runtime stage so in-container tests match local dev.