### PR TITLE
ci(docker): fix in-container tests with read-only tests mount

### DIFF
--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -74,6 +74,9 @@ jobs:
           cat <<'EOF' > /tmp/docker-tests.sh
           #!/bin/sh
           set -eux
+          # tests/ is bind-mounted read-only; keep bytecode out of the tree
+          export PYTHONPYCACHEPREFIX=/tmp/pycache
+          mkdir -p "$PYTHONPYCACHEPREFIX"
           uv sync --frozen --extra test --group dev
           uv run ruff check .
           uv run ruff format --check .
@@ -191,6 +194,9 @@ jobs:
           cat <<'EOF' > /tmp/docker-tests.sh
           #!/bin/sh
           set -eux
+          # tests/ is bind-mounted read-only; keep bytecode out of the tree
+          export PYTHONPYCACHEPREFIX=/tmp/pycache
+          mkdir -p "$PYTHONPYCACHEPREFIX"
           uv sync --frozen --extra test --group dev
           uv run ruff check .
           uv run ruff format --check .

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -66,6 +66,9 @@ jobs:
           cat <<'EOF' > /tmp/docker-tests.sh
           #!/bin/sh
           set -eux
+          # tests/ is bind-mounted read-only; keep bytecode out of the tree
+          export PYTHONPYCACHEPREFIX=/tmp/pycache
+          mkdir -p "$PYTHONPYCACHEPREFIX"
           uv sync --frozen --extra test --group dev
           uv run ruff check .
           uv run ruff format --check .

--- a/.github/workflows/release-docker-verify.yml
+++ b/.github/workflows/release-docker-verify.yml
@@ -18,6 +18,9 @@ jobs:
           cat <<'EOF' > /tmp/docker-tests.sh
           #!/bin/sh
           set -eux
+          # tests/ is bind-mounted read-only; keep bytecode out of the tree
+          export PYTHONPYCACHEPREFIX=/tmp/pycache
+          mkdir -p "$PYTHONPYCACHEPREFIX"
           uv sync --frozen --extra test --group dev
           uv run ruff check .
           uv run ruff format --check .


### PR DESCRIPTION
Set `PYTHONPYCACHEPREFIX=/tmp/pycache` in the shared Docker test script so `compileall` (and pytest bytecode) does not write under `tests/`, which is bind-mounted read-only in GitHub Actions.