### PR TITLE
[codex] Treat missing VM primary IP as a warning

### DIFF
--- a/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
+++ b/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
@@ -797,7 +797,8 @@ async def create_virtual_machines(
                         {
                             "object": "virtual_machine",
                             "data": {
-                                "error": "No IP address found; primary IP not set.",
+                                "completed": True,
+                                "warning": "No IP address found; primary IP not set.",
                                 "rowid": virtual_machine.get("name"),
                             },
                         }

--- a/proxbox_api/utils/streaming.py
+++ b/proxbox_api/utils/streaming.py
@@ -83,6 +83,9 @@ class WebSocketSSEBridge:
             return f"{object_name} stream completed"
         data = payload.get("data")
         if isinstance(data, dict):
+            warning = data.get("warning")
+            if warning:
+                return str(warning)
             error = data.get("error")
             if error:
                 return str(error)

--- a/tests/test_qemu_guest_agent_sync.py
+++ b/tests/test_qemu_guest_agent_sync.py
@@ -291,3 +291,44 @@ def test_vm_sync_skips_guest_agent_call_when_disabled(monkeypatch):
     )
     assert len(result) == 1
     assert ip_payloads and ip_payloads[0]["address"] == "10.0.0.22/24"
+
+
+def test_vm_sync_marks_missing_primary_ip_as_warning(monkeypatch):
+    data = _vm_sync_inputs({"agent": 0, "net0": "virtio=AA:BB:CC:DD:EE:FF,bridge=vmbr0"})
+    ip_payloads: list[dict] = []
+    _install_common_sync_patches(monkeypatch, vm_config=data["vm_config"], ip_payloads=ip_payloads)
+
+    class _WebSocket:
+        def __init__(self):
+            self.payloads: list[dict] = []
+
+        async def send_json(self, payload: dict):
+            self.payloads.append(payload)
+
+    websocket = _WebSocket()
+
+    result = asyncio.run(
+        create_virtual_machines(
+            netbox_session=data["netbox_session"],
+            pxs=data["pxs"],
+            cluster_status=data["cluster_status"],
+            cluster_resources=data["cluster_resources"],
+            custom_fields=data["custom_fields"],
+            tag=data["tag"],
+            websocket=websocket,
+            use_websocket=True,
+        )
+    )
+
+    assert len(result) == 1
+    warning_payloads = [
+        payload
+        for payload in websocket.payloads
+        if payload.get("object") == "virtual_machine"
+        and isinstance(payload.get("data"), dict)
+        and payload["data"].get("warning")
+    ]
+    assert warning_payloads
+    assert warning_payloads[0]["data"]["completed"] is True
+    assert "No IP address found; primary IP not set." in warning_payloads[0]["data"]["warning"]
+    assert not ip_payloads


### PR DESCRIPTION
## What changed
- Treat VM syncs without a primary IP as a warning instead of a hard failure.
- Preserve the warning text in SSE progress messages.
- Add a regression test for the missing-primary-IP VM case.

## Why
Some VMs do not have an IP address yet, and the sync already skips primary_ip4 assignment in that case. The previous SSE payload marked that condition as an error, which made full sync jobs look failed even when the VM was synced successfully.

## Validation
- uv run pytest proxbox-api/tests/test_qemu_guest_agent_sync.py -q
- uv run pytest proxbox-api/tests/test_error_handling.py -q
- uv run pytest proxbox-api/tests/test_api_routes.py proxbox-api/tests/test_vm_sync.py -q
- python -m compileall proxbox_api tests
- UV_CACHE_DIR=/tmp/uv-cache uv run ruff check proxbox_api tests