### PR TITLE
fix(storage-sync): deduplicate cluster/name writes per sync run

### DIFF
--- a/proxbox_api/services/sync/storages.py
+++ b/proxbox_api/services/sync/storages.py
@@ -43,6 +43,11 @@ async def create_storages(
         return_exceptions=True,
     )
 
+    # Some deployments expose the same cluster via multiple endpoints and/or repeated
+    # storage rows in the same API response. Reconcile each (cluster, storage) once per run
+    # to avoid duplicate create attempts against the unique DB constraint.
+    unique_payloads: dict[tuple[str, str], dict] = {}
+
     for cluster_data in cluster_storage_sets:
         if isinstance(cluster_data, Exception):
             continue
@@ -63,7 +68,10 @@ async def create_storages(
                 "enabled": not bool(storage.get("disable")),
                 "tags": tag_refs,
             }
-            record = await rest_reconcile_async(
+            unique_payloads.setdefault((cluster_name, storage_name), payload)
+
+    for (cluster_name, storage_name), payload in unique_payloads.items():
+        record = await rest_reconcile_async(
                 nb,
                 "/api/plugins/proxbox/storage/",
                 lookup={"cluster": cluster_name, "name": storage_name},
@@ -80,17 +88,17 @@ async def create_storages(
                     "enabled": item.get("enabled"),
                     "tags": item.get("tags"),
                 },
+        )
+        data = record.serialize()
+        synced.append(data)
+        if use_websocket and websocket:
+            await websocket.send_json(
+                {
+                    "step": "storage",
+                    "status": "synced",
+                    "message": f"Synced storage {cluster_name}/{storage_name}",
+                    "result": {"id": data.get("id"), "name": storage_name},
+                }
             )
-            data = record.serialize()
-            synced.append(data)
-            if use_websocket and websocket:
-                await websocket.send_json(
-                    {
-                        "step": "storage",
-                        "status": "synced",
-                        "message": f"Synced storage {cluster_name}/{storage_name}",
-                        "result": {"id": data.get("id"), "name": storage_name},
-                    }
-                )
 
     return synced

--- a/tests/test_storage_sync.py
+++ b/tests/test_storage_sync.py
@@ -107,6 +107,40 @@ def test_create_storages_stream_emits_complete_event(monkeypatch):
     assert '"count": 2' in payload
 
 
+def test_create_storages_deduplicates_cluster_storage_pairs(monkeypatch):
+    class _Record:
+        def __init__(self, payload):
+            self.payload = payload
+
+        def serialize(self):
+            return {"id": 1, **self.payload}
+
+    storages = [
+        {"storage": "local-zfs", "type": "zfspool", "shared": 0, "disable": 0},
+        {"storage": "local-zfs", "type": "zfspool", "shared": 0, "disable": 0},
+    ]
+    calls: list[tuple[dict, dict]] = []
+
+    def _fake_get_storage_list(_px):
+        return storages
+
+    async def _fake_reconcile(_nb, _path, lookup, payload, **kwargs):
+        calls.append((lookup, payload))
+        return _Record(payload)
+
+    monkeypatch.setattr("proxbox_api.services.sync.storages.get_storage_list", _fake_get_storage_list)
+    monkeypatch.setattr("proxbox_api.services.sync.storages.dump_models", lambda items: items)
+    monkeypatch.setattr("proxbox_api.services.sync.storages.rest_reconcile_async", _fake_reconcile)
+
+    tag = SimpleNamespace(id=1, name="Proxbox", slug="proxbox", color="ff5722")
+    pxs = [SimpleNamespace(name="TEST-CLUSTER"), SimpleNamespace(name="TEST-CLUSTER")]
+
+    asyncio.run(create_storages(netbox_session=object(), pxs=pxs, tag=tag))
+
+    assert len(calls) == 1
+    assert calls[0][0] == {"cluster": "TEST-CLUSTER", "name": "local-zfs"}
+
+
 async def _collect_async_frames(stream) -> list[str]:
     output: list[str] = []
     async for frame in stream:


### PR DESCRIPTION
Avoid duplicate create attempts when the same cluster/storage pair appears\nmultiple times across endpoints or repeated API rows.\n\n- Collect unique payloads keyed by (cluster, storage name) before reconcile\n- Reconcile each key once per run\n- Add regression test for duplicate cluster/storage pairs\n\nThis prevents IntegrityError on unique constraint\n(netbox_proxbox_proxmoxstorage_cluster_name_*_uniq) during full sync.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>