### PR TITLE
fix invalid migration custom fields

### DIFF
--- a/proxbox_api/routes/extras/__init__.py
+++ b/proxbox_api/routes/extras/__init__.py
@@ -504,7 +504,8 @@ async def create_custom_fields(
                 "group_name": "Proxmox",
             },
             {
-                "object_types": ["virtualization.vmmigration"],
+                # NetBox does not expose a VMMigration content type; store migration telemetry on the VM.
+                "object_types": ["virtualization.virtualmachine"],
                 "type": "integer",
                 "name": "proxmox_migration_duration",
                 "label": "Migration Duration",
@@ -517,7 +518,7 @@ async def create_custom_fields(
                 "group_name": "Proxmox",
             },
             {
-                "object_types": ["virtualization.vmmigration"],
+                "object_types": ["virtualization.virtualmachine"],
                 "type": "text",
                 "name": "proxmox_migration_type",
                 "label": "Migration Type",

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -244,6 +244,18 @@ def test_create_custom_fields_uses_rest_reconcile_with_async_session():
     )
     assert first_post["object_types"] == ["virtualization.virtualmachine"]
     assert first_post["ui_editable"] == "hidden"
+    migration_payloads = {
+        payload["name"]: payload
+        for method, path, _query, payload, _expect_json in session.client.calls
+        if method == "POST" and path == "/api/extras/custom-fields/"
+        and payload["name"] in {"proxmox_migration_duration", "proxmox_migration_type"}
+    }
+    assert migration_payloads["proxmox_migration_duration"]["object_types"] == [
+        "virtualization.virtualmachine"
+    ]
+    assert migration_payloads["proxmox_migration_type"]["object_types"] == [
+        "virtualization.virtualmachine"
+    ]
 
 
 def test_create_custom_fields_caches_successful_bootstrap(monkeypatch):


### PR DESCRIPTION
Fix NetBox custom-field bootstrap so migration telemetry fields use the supported `virtualization.virtualmachine` content type instead of the invalid `virtualization.vmmigration` value.\n\nValidation:\n- uv run python -m compileall proxbox_api tests\n- uv run pytest tests/test_api_routes.py -q