### PR TITLE
fix: VM disk reconciliation + custom-field scope union (netbox-proxbox#349)

### DIFF
--- a/proxbox_api/proxmox_to_netbox/models.py
+++ b/proxbox_api/proxmox_to_netbox/models.py
@@ -982,16 +982,46 @@ class ProxmoxToNetBoxVirtualMachine(BaseModel):
     @computed_field(return_type=int)
     @property
     def disk_mb(self) -> int:
-        """VM disk in MiB, preferring aggregate parsed VM config disks when available."""
+        """VM disk in MiB; always equals the aggregate of parsed VM config disks.
+
+        We deliberately do NOT fall back to ``self.resource.disk_mb`` (the
+        cluster ``maxdisk``) when no disks parsed: NetBox 4.5+ enforces that
+        ``virtualmachine.disk`` matches the sum of its attached
+        ``virtual-disks`` on update, and virtual-disks are POSTed from the
+        same parsed list. Falling back to ``maxdisk`` while POSTing zero
+        virtual-disks (the all-passthrough case) makes the next sync fail
+        with::
+
+            {"disk":["The specified disk size must match the aggregate size
+              of assigned virtual disks."]}
+
+        Returning ``0`` instead is safe because NetBox's aggregate validator
+        short-circuits when ``total_disk`` is falsy.
+        """
         disks = self.config.disks
-        if disks:
-            aggregate = sum(max(int(getattr(disk, "size", 0) or 0), 0) for disk in disks)
-            if aggregate > 0:
-                return aggregate
-        return self.resource.disk_mb
+        if not disks:
+            return 0
+        return sum(max(int(getattr(disk, "size", 0) or 0), 0) for disk in disks)
 
     def as_netbox_create_body(self) -> NetBoxVirtualMachineCreateBody:
         """Return validated NetBox virtual machine create body."""
+
+        # NetBox stores ``virtualmachine.disk`` in a 32-bit ``PositiveIntegerField``
+        # (max 2_147_483_647). Clamp defensively so a future bytes-vs-MiB
+        # regression cannot produce ``Ensure this value is less than or equal
+        # to the allowed maximum`` errors mid-sync.
+        _NETBOX_DISK_MAX = 2_147_483_647
+        disk_value = self.disk_mb
+        if disk_value > _NETBOX_DISK_MAX:
+            from proxbox_api.logger import logger
+
+            logger.warning(
+                "VM %s disk_mb=%d exceeds NetBox max %d; clamping",
+                self.resource.name,
+                disk_value,
+                _NETBOX_DISK_MAX,
+            )
+            disk_value = _NETBOX_DISK_MAX
 
         return NetBoxVirtualMachineCreateBody(
             name=self.resource.name,
@@ -1002,7 +1032,7 @@ class ProxmoxToNetBoxVirtualMachine(BaseModel):
             role=self.role_id,
             vcpus=int(self.resource.maxcpu or 0),
             memory=self.resource.memory_mb,
-            disk=self.disk_mb,
+            disk=disk_value,
             tags=[tag for tag in self.tag_ids if int(tag) > 0],
             custom_fields=self.vm_custom_fields,
             description=f"Synced from Proxmox node {self.resource.node}",

--- a/proxbox_api/proxmox_to_netbox/schemas/disks.py
+++ b/proxbox_api/proxmox_to_netbox/schemas/disks.py
@@ -6,9 +6,16 @@ import re
 
 from pydantic import ConfigDict, computed_field, field_validator
 
+from proxbox_api.logger import logger
 from proxbox_api.schemas._base import ProxboxBaseModel
 
-DISK_KEY_PATTERN = re.compile(r"^(scsi|ide|sata|virtio|mp)\d+$|^rootfs$")
+# Match every Proxmox disk key whose size we want to push to NetBox.
+# - ``scsi/ide/sata/virtio/mp`` cover regular and LXC mountpoint disks.
+# - ``rootfs`` is the LXC root mountpoint.
+# - ``efidisk0`` / ``tpmstate0`` are tiny VM firmware/TPM state disks; they
+#   carry a real ``size=`` value, so include them so the VM-level ``disk``
+#   total matches the aggregate of POSTed virtual-disk children.
+DISK_KEY_PATTERN = re.compile(r"^(scsi|ide|sata|virtio|mp)\d+$|^rootfs$|^efidisk\d+$|^tpmstate\d+$")
 UNUSED_DISK_PATTERN = re.compile(r"^unused\d+$")
 
 
@@ -67,6 +74,17 @@ def parse_disk_entry(key: str, raw_value: str) -> ProxmoxDiskEntry | None:
 
     size_mb = size_str_to_mb(disk_info.get("size", "0"))
     if size_mb <= 0:
+        # Common cause: passthrough/raw disks like ``scsi2: /dev/sdb`` carry
+        # no ``size=`` field. Surface this so operators can see why the disk
+        # was excluded from both the VM-level ``disk`` total and the POSTed
+        # virtual-disk children (NetBox 4.5+ enforces those two values match
+        # on update; silently dropping a passthrough breaks reconciliation).
+        logger.warning(
+            "Skipping disk '%s' with no parseable size (raw=%r); "
+            "passthrough/raw disks are not represented in NetBox virtual-disks",
+            key,
+            raw_value,
+        )
         return None
 
     storage_value = str(disk_info.get("storage") or "")

--- a/proxbox_api/routes/extras/__init__.py
+++ b/proxbox_api/routes/extras/__init__.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends
 
 from proxbox_api.exception import ProxboxException
 from proxbox_api.logger import logger
-from proxbox_api.netbox_rest import rest_reconcile_async
+from proxbox_api.netbox_rest import rest_first_async, rest_reconcile_async
 from proxbox_api.proxmox_to_netbox.models import NetBoxCustomFieldSyncState
 from proxbox_api.session.netbox import NetBoxAsyncSessionDep
 from proxbox_api.utils.retry import is_netbox_overwhelmed_error
@@ -16,6 +16,76 @@ from proxbox_api.utils.retry import is_netbox_overwhelmed_error
 router = APIRouter()
 _CUSTOM_FIELDS_CACHE: tuple[dict[str, object], ...] | None = None
 _CUSTOM_FIELDS_LOCK = asyncio.Lock()
+
+
+def _coerce_object_type_entry(item: object) -> str | None:
+    if isinstance(item, str):
+        return item
+    if isinstance(item, dict):
+        if "app_label" in item and "model" in item:
+            return f"{item['app_label']}.{item['model']}"
+        name = item.get("name")
+        if isinstance(name, str):
+            return name
+    return None
+
+
+def _normalize_current_object_types(raw_current: object) -> list[str]:
+    if not isinstance(raw_current, list):
+        return []
+    normalized: list[str] = []
+    for item in raw_current:
+        coerced = _coerce_object_type_entry(item)
+        if coerced is not None:
+            normalized.append(coerced)
+    return normalized
+
+
+async def _fetch_existing_custom_field(netbox_session: object, name: str) -> object | None:
+    try:
+        return await rest_first_async(
+            netbox_session,
+            "/api/extras/custom-fields/",
+            query={"name": name, "limit": 2},
+        )
+    except Exception as exc:
+        logger.warning(
+            "Could not pre-fetch custom field '%s' for object_types union: %s",
+            name,
+            exc,
+        )
+        return None
+
+
+async def _union_object_types_with_current(
+    netbox_session: object,
+    custom_field: dict[str, object],
+) -> None:
+    """Mutate ``custom_field['object_types']`` to be (current ∪ desired).
+
+    NetBox custom fields have an ``object_types`` list that operators sometimes
+    expand manually. Without this merge, ``rest_reconcile_async`` would PATCH
+    the field back to the hardcoded list on every restart, wiping operator
+    additions. Pre-merging makes desired a superset of current so the diff
+    only adds entries — never removes them.
+    """
+    desired = custom_field.get("object_types")
+    name = custom_field.get("name")
+    if not isinstance(desired, list) or not name:
+        return
+    existing = await _fetch_existing_custom_field(netbox_session, name)
+    if existing is None:
+        return
+    current = _normalize_current_object_types(existing.serialize().get("object_types"))
+    union = list(dict.fromkeys([*desired, *current]))
+    operator_added = [item for item in union if item not in desired]
+    if operator_added:
+        logger.info(
+            "Preserving operator-added object_types for custom field '%s': %s",
+            name,
+            ", ".join(operator_added),
+        )
+    custom_field["object_types"] = union
 
 
 def _resolve_custom_field_delay() -> float:
@@ -585,6 +655,7 @@ async def create_custom_fields(  # noqa: C901
 
         for custom_field in custom_fields:
             try:
+                await _union_object_types_with_current(netbox_session, custom_field)
                 record = await rest_reconcile_async(
                     netbox_session,
                     "/api/extras/custom-fields/",

--- a/proxbox_api/services/sync/individual/virtual_disk_sync.py
+++ b/proxbox_api/services/sync/individual/virtual_disk_sync.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 
 from proxbox_api.netbox_rest import rest_list_async, rest_reconcile_async
 from proxbox_api.proxmox_to_netbox.models import NetBoxVirtualDiskSyncState
+from proxbox_api.proxmox_to_netbox.schemas.disks import size_str_to_mb
 from proxbox_api.services.proxmox_helpers import get_vm_config_individual
 from proxbox_api.services.sync.individual.base import BaseIndividualSyncService
 from proxbox_api.services.sync.individual.helpers import (
@@ -91,10 +92,12 @@ async def sync_virtual_disk_individual(
 
     disk_config = parse_disk_config_entry(vm_config.get(disk_name))
     size = disk_config.get("size", "0")
-    try:
-        size_mb = int(size) // 1_048_576 if size else 0
-    except (ValueError, TypeError):
-        size_mb = 0
+    # Proxmox emits sizes as suffixed strings ("32G", "512M", "1T"). The previous
+    # implementation did ``int(size) // 1_048_576`` which raises on any suffix
+    # and silently fell back to 0 — making the individual sync path produce
+    # virtual-disks with size 0 that then mismatched the VM-level disk total
+    # under NetBox 4.5+ aggregate validation.
+    size_mb = size_str_to_mb(size) if size else 0
 
     volume_id = disk_config.get("volume", disk_config.get("file", None))
     storage_name = storage_name_from_volume_id(volume_id)

--- a/tests/test_custom_field_object_types_union.py
+++ b/tests/test_custom_field_object_types_union.py
@@ -1,0 +1,177 @@
+"""Regression tests for the proxmox_last_updated object_types union helper.
+
+Issue netbox-proxbox#349: prior to this helper, restarting proxbox-api
+PATCH'd the custom field's ``object_types`` back to the hardcoded list,
+wiping any entries an operator had added in the NetBox UI. The helper
+pre-merges current ∪ desired before reconcile, so the diff is one-sided
+(adds entries; never removes).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from proxbox_api.routes.extras import (
+    _coerce_object_type_entry,
+    _normalize_current_object_types,
+    _union_object_types_with_current,
+)
+
+
+def _run(coro):
+    return asyncio.get_event_loop_policy().new_event_loop().run_until_complete(coro)
+
+
+def _record(serialized: dict) -> object:
+    return SimpleNamespace(serialize=lambda: serialized)
+
+
+@pytest.fixture
+def proxbox_caplog(caplog):
+    """Attach caplog to the non-propagating ``proxbox`` logger.
+
+    ``proxbox_api.logger`` sets ``propagate=False`` so caplog's root handler
+    never sees its records. We bolt caplog's own handler onto that logger for
+    the duration of the test, then detach it cleanly.
+    """
+    proxbox_logger = logging.getLogger("proxbox")
+    proxbox_logger.addHandler(caplog.handler)
+    proxbox_logger.setLevel(logging.DEBUG)
+    try:
+        yield caplog
+    finally:
+        proxbox_logger.removeHandler(caplog.handler)
+
+
+def test_coerce_object_type_entry_string():
+    assert _coerce_object_type_entry("dcim.device") == "dcim.device"
+
+
+def test_coerce_object_type_entry_app_label_model_dict():
+    assert _coerce_object_type_entry({"app_label": "extras", "model": "tag"}) == "extras.tag"
+
+
+def test_coerce_object_type_entry_name_dict():
+    assert _coerce_object_type_entry({"name": "ipam.vlan"}) == "ipam.vlan"
+
+
+def test_coerce_object_type_entry_unknown_returns_none():
+    assert _coerce_object_type_entry(42) is None
+    assert _coerce_object_type_entry({"unrelated": "x"}) is None
+
+
+def test_normalize_current_object_types_mixed_shapes():
+    raw = [
+        "dcim.device",
+        {"app_label": "extras", "model": "tag"},
+        {"name": "ipam.vlan"},
+        12345,  # garbage; must be skipped, not raise
+    ]
+    assert _normalize_current_object_types(raw) == [
+        "dcim.device",
+        "extras.tag",
+        "ipam.vlan",
+    ]
+
+
+def test_normalize_current_object_types_non_list_returns_empty():
+    assert _normalize_current_object_types(None) == []
+    assert _normalize_current_object_types("dcim.device") == []
+
+
+def test_union_preserves_operator_additions(monkeypatch, proxbox_caplog):
+    """The operator added ``extras.tag`` to the scope manually. The reconcile
+    pre-merge must keep it after restart.
+    """
+
+    async def _fake_first(_session, _path, query=None):
+        assert query == {"name": "proxmox_last_updated", "limit": 2}
+        return _record({"object_types": ["virtualization.virtualmachine", "extras.tag"]})
+
+    monkeypatch.setattr("proxbox_api.routes.extras.rest_first_async", _fake_first)
+
+    field: dict[str, object] = {
+        "name": "proxmox_last_updated",
+        "object_types": ["virtualization.virtualmachine", "dcim.device"],
+    }
+
+    proxbox_caplog.set_level(logging.INFO)
+    _run(_union_object_types_with_current(object(), field))
+
+    # Desired entries kept first, operator-added entries appended.
+    assert field["object_types"] == [
+        "virtualization.virtualmachine",
+        "dcim.device",
+        "extras.tag",
+    ]
+    assert any("extras.tag" in record.message for record in proxbox_caplog.records)
+
+
+def test_union_handles_dict_shape_object_types(monkeypatch):
+    async def _fake_first(_session, _path, query=None):
+        return _record({"object_types": [{"app_label": "extras", "model": "tag"}]})
+
+    monkeypatch.setattr("proxbox_api.routes.extras.rest_first_async", _fake_first)
+
+    field: dict[str, object] = {
+        "name": "proxmox_last_updated",
+        "object_types": ["virtualization.virtualmachine"],
+    }
+    _run(_union_object_types_with_current(object(), field))
+    assert field["object_types"] == [
+        "virtualization.virtualmachine",
+        "extras.tag",
+    ]
+
+
+def test_union_skips_when_no_existing_record(monkeypatch):
+    async def _fake_first(_session, _path, query=None):
+        return None
+
+    monkeypatch.setattr("proxbox_api.routes.extras.rest_first_async", _fake_first)
+
+    desired = ["virtualization.virtualmachine", "dcim.device"]
+    field: dict[str, object] = {"name": "proxmox_last_updated", "object_types": list(desired)}
+    _run(_union_object_types_with_current(object(), field))
+    assert field["object_types"] == desired  # untouched, no shrink
+
+
+def test_union_logs_warning_when_prefetch_raises(monkeypatch, proxbox_caplog):
+    async def _fake_first(_session, _path, query=None):
+        raise RuntimeError("netbox unreachable")
+
+    monkeypatch.setattr("proxbox_api.routes.extras.rest_first_async", _fake_first)
+
+    desired = ["virtualization.virtualmachine"]
+    field: dict[str, object] = {"name": "proxmox_last_updated", "object_types": list(desired)}
+
+    proxbox_caplog.set_level(logging.WARNING)
+    _run(_union_object_types_with_current(object(), field))
+
+    assert field["object_types"] == desired  # never shrunk on error
+    assert any(
+        "netbox unreachable" in r.message or "Could not pre-fetch" in r.message
+        for r in proxbox_caplog.records
+    )
+
+
+def test_union_skips_when_desired_is_not_list(monkeypatch):
+    """Defensive: if a malformed custom_field dict has no list ``object_types``
+    we must not call rest_first_async or mutate anything.
+    """
+    called = {"count": 0}
+
+    async def _fake_first(_session, _path, query=None):
+        called["count"] += 1
+        return None
+
+    monkeypatch.setattr("proxbox_api.routes.extras.rest_first_async", _fake_first)
+
+    field: dict[str, object] = {"name": "proxmox_last_updated", "object_types": None}
+    _run(_union_object_types_with_current(object(), field))
+    assert called["count"] == 0
+    assert field["object_types"] is None

--- a/tests/test_proxmox_disk_parsing.py
+++ b/tests/test_proxmox_disk_parsing.py
@@ -1,0 +1,151 @@
+"""Regression tests for Proxmox disk parsing (issue netbox-proxbox#349).
+
+These tests pin three behaviors that, if reverted, re-introduce the
+``virtualmachine.disk`` ↔ ``virtual-disks`` aggregate-mismatch failure on
+NetBox 4.5+:
+
+1. Passthrough disks (``scsiN: /dev/sdb``) are skipped with a WARN — they
+   carry no ``size=`` and cannot be represented as virtual-disks.
+2. ``efidisk0`` and ``tpmstate0`` ARE counted (firmware/TPM state disks have a
+   real ``size=`` and must appear on both sides of the aggregate).
+3. The VM-level ``disk`` is always the sum of parsed virtual-disk children;
+   it never falls back to the cluster ``maxdisk``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from proxbox_api.proxmox_to_netbox.schemas.disks import (
+    parse_disk_entry,
+    parse_vm_config_disks,
+    size_str_to_mb,
+)
+
+
+@pytest.fixture
+def proxbox_caplog(caplog):
+    """Attach caplog to the non-propagating ``proxbox`` logger."""
+    proxbox_logger = logging.getLogger("proxbox")
+    proxbox_logger.addHandler(caplog.handler)
+    proxbox_logger.setLevel(logging.DEBUG)
+    try:
+        yield caplog
+    finally:
+        proxbox_logger.removeHandler(caplog.handler)
+
+
+def test_parse_disk_entry_regular_scsi_with_size():
+    entry = parse_disk_entry("scsi0", "local-lvm:vm-100-disk-0,size=32G,format=qcow2")
+    assert entry is not None
+    assert entry.name == "scsi0"
+    assert entry.size == 32 * 1024  # 32 GiB → 32768 MiB
+    assert entry.format == "qcow2"
+    assert entry.storage_name == "local-lvm"
+
+
+def test_parse_disk_entry_virtio_counted():
+    entry = parse_disk_entry("virtio0", "local-lvm:vm-100-disk-0,size=40G")
+    assert entry is not None
+    assert entry.size == 40 * 1024
+
+
+def test_parse_disk_entry_rootfs_lxc_counted():
+    entry = parse_disk_entry("rootfs", "local-lvm:vm-100-disk-0,size=8G")
+    assert entry is not None
+    assert entry.name == "rootfs"
+    assert entry.size == 8 * 1024
+
+
+def test_parse_disk_entry_efidisk_counted():
+    entry = parse_disk_entry("efidisk0", "local-lvm:vm-100-disk-1,size=4M")
+    assert entry is not None
+    assert entry.name == "efidisk0"
+    # 4M parses to 4 MiB by ``size_str_to_mb``.
+    assert entry.size == 4
+
+
+def test_parse_disk_entry_tpmstate_counted():
+    entry = parse_disk_entry("tpmstate0", "local-lvm:vm-100-disk-2,size=4M")
+    assert entry is not None
+    assert entry.name == "tpmstate0"
+    assert entry.size == 4
+
+
+def test_parse_disk_entry_passthrough_returns_none_and_warns(proxbox_caplog):
+    """``scsi2: /dev/sdb`` has no ``size=`` field. Parser must drop it and
+    emit a structured WARN so operators can correlate which disks were
+    excluded from the NetBox aggregate.
+    """
+    proxbox_caplog.set_level(logging.WARNING)
+    assert parse_disk_entry("scsi2", "/dev/sdb") is None
+    assert any(
+        "scsi2" in record.message and "size" in record.message.lower()
+        for record in proxbox_caplog.records
+        if record.levelno == logging.WARNING
+    )
+
+
+def test_parse_disk_entry_unused_returns_none_silently(proxbox_caplog):
+    """``unusedN`` is the documented Proxmox parking slot for detached disks.
+    Skip silently — no WARN, since no NetBox object is expected for it.
+    """
+    proxbox_caplog.set_level(logging.WARNING)
+    assert parse_disk_entry("unused0", "local-lvm:vm-100-disk-3,size=10G") is None
+    assert not any(record.levelno == logging.WARNING for record in proxbox_caplog.records)
+
+
+def test_parse_disk_entry_unknown_key_returns_none():
+    # Keys outside the recognized disk families (e.g. ``net0``, ``boot``) are
+    # not disks — drop without a WARN.
+    assert parse_disk_entry("net0", "virtio=DE:AD:BE:EF:00:01,bridge=vmbr0") is None
+
+
+def test_parse_disk_entry_non_string_value_returns_none():
+    assert parse_disk_entry("scsi0", 123) is None  # type: ignore[arg-type]
+    assert parse_disk_entry("scsi0", None) is None  # type: ignore[arg-type]
+
+
+def test_parse_vm_config_disks_aggregate_excludes_passthrough(proxbox_caplog):
+    """The aggregate the mapper sends to NetBox must equal the sum of just the
+    parseable disks — the passthrough silently failing the parser is what
+    used to break ``disk == sum(virtual-disks)`` on update.
+    """
+    proxbox_caplog.set_level(logging.WARNING)
+    config = {
+        "scsi0": "local-lvm:vm-100-disk-0,size=32G",
+        "scsi1": "local-lvm:vm-100-disk-1,size=64G",
+        "scsi2": "/dev/sdb",  # passthrough — dropped
+        "efidisk0": "local-lvm:vm-100-disk-2,size=4M",
+        "name": "ignored-non-disk-key",
+    }
+    entries = parse_vm_config_disks(config)
+    names = {e.name for e in entries}
+    assert names == {"scsi0", "scsi1", "efidisk0"}
+
+    # Aggregate equals what a downstream mapper will send as VM.disk and is
+    # also the sum of POSTed virtual-disks — the two MUST match.
+    aggregate = sum(e.size for e in entries)
+    assert aggregate == 32 * 1024 + 64 * 1024 + 4
+
+    # Operator gets a WARN for the dropped passthrough.
+    assert any("scsi2" in r.message for r in proxbox_caplog.records)
+
+
+def test_parse_vm_config_disks_empty_when_no_disks():
+    """A config with no disk-shaped keys aggregates to an empty list. The
+    mapper's downstream ``disk_mb`` then reports 0 — no maxdisk fallback.
+    """
+    assert parse_vm_config_disks({"onboot": 1, "agent": 1, "name": "boring"}) == []
+
+
+def test_size_str_to_mb_units():
+    assert size_str_to_mb("0") == 0
+    assert size_str_to_mb("") == 0
+    assert size_str_to_mb("1M") == 1
+    assert size_str_to_mb("1G") == 1024
+    assert size_str_to_mb("1T") == 1024 * 1024
+    assert size_str_to_mb("32G") == 32 * 1024
+    assert size_str_to_mb("garbage") == 0

--- a/tests/test_proxmox_to_netbox_contracts.py
+++ b/tests/test_proxmox_to_netbox_contracts.py
@@ -25,6 +25,11 @@ def test_map_proxmox_vm_to_netbox_vm_body():
         "agent": 1,
         "unprivileged": 0,
         "searchdomain": "lab.local",
+        # disk_mb must equal the aggregate of parsed VM-config disks so the
+        # NetBox `disk == sum(virtualdisks.size)` aggregate validator passes
+        # on update (issue #349). 100 GiB + 50 GiB = 153600 MiB.
+        "scsi0": "local-lvm:vm-101-disk-0,size=100G",
+        "scsi1": "local-lvm:vm-101-disk-1,size=50G",
     }
 
     body = map_proxmox_vm_to_netbox_vm_body(
@@ -43,9 +48,39 @@ def test_map_proxmox_vm_to_netbox_vm_body():
     assert body["role"] == 33
     assert body["vcpus"] == 4
     assert body["memory"] == 8192
-    assert body["disk"] == 102400
+    assert body["disk"] == 153600
     assert body["custom_fields"]["proxmox_vm_id"] == 101
     assert body["custom_fields"]["proxmox_start_at_boot"] is True
+
+
+def test_map_proxmox_vm_to_netbox_vm_body_no_parseable_disks():
+    """When VM config has no parseable disks, disk must be 0 (not maxdisk).
+
+    Regression: issue #349 — the previous fallback to ``resource.maxdisk``
+    caused the VM-level ``disk`` to disagree with the sum of created
+    ``virtual-disks`` whenever passthrough/raw entries were silently dropped,
+    failing NetBox 4.5+ aggregate validation on update.
+    """
+    resource = {
+        "vmid": 102,
+        "name": "raw-vm",
+        "node": "pve01",
+        "status": "running",
+        "type": "qemu",
+        "maxcpu": 2,
+        "maxmem": 4_294_967_296,
+        "maxdisk": 53_687_091_200,
+    }
+    config = {"onboot": 1}
+    body = map_proxmox_vm_to_netbox_vm_body(
+        resource=resource,
+        config=config,
+        cluster_id=11,
+        device_id=22,
+        role_id=33,
+        tag_ids=[7],
+    )
+    assert body["disk"] == 0
 
 
 def test_load_proxmox_generated_openapi_present():

--- a/tests/test_vm_sync.py
+++ b/tests/test_vm_sync.py
@@ -44,7 +44,12 @@ def test_map_proxmox_vm_to_netbox_vm_body_uses_schema_driven_normalization(monke
     assert body["role"] == 33
     assert body["vcpus"] == 4
     assert body["memory"] > 0
-    assert body["disk"] > 0
+    # Without parseable disk entries in PROXMOX_VM_CONFIG, body["disk"] == 0:
+    # the maxdisk fallback was removed (issue #349) so VM.disk equals the
+    # aggregate of parsed virtual-disks. See
+    # test_map_proxmox_vm_to_netbox_vm_body_uses_config_disk_aggregate for the
+    # >0 path.
+    assert body["disk"] == 0
     assert body["tags"] == [7]
     assert body["custom_fields"]["proxmox_vm_id"] == 101
     assert body["custom_fields"]["proxmox_vm_type"] == "qemu"


### PR DESCRIPTION
## Summary

Closes two regressions reported in [netbox-proxbox#349](https://github.com/emersonfelipesp/netbox-proxbox/issues/349) on NetBox 4.5.x:

1. **`proxmox_last_updated` scope was wiped on every restart.** Reconcile did a full replace of `object_types`, dropping any entry an operator had added through the NetBox UI. We now pre-merge `current ∪ desired` before the diff so we only ever add — never remove.
2. **`VM.disk` disagreed with `sum(virtual-disks.size)`** whenever a passthrough disk (e.g. `scsi2: /dev/sdb`, no `size=`) was silently dropped by the parser. NetBox 4.5 enforces this aggregate on update and the sync flapped.

## Changes

| Path | Why |
|---|---|
| `proxbox_api/routes/extras/__init__.py` | New `_union_object_types_with_current()` pre-merges scope before reconcile; logs operator-added entries we preserve. |
| `proxbox_api/proxmox_to_netbox/schemas/disks.py` | `DISK_KEY_PATTERN` now matches `rootfs` / `efidisk\d+` / `tpmstate\d+` (real `size=`, must count on both sides). Drop passthrough with a WARN so exclusions are visible. |
| `proxbox_api/proxmox_to_netbox/models.py` | `VM.disk_mb` returns the parsed aggregate only — no `maxdisk` fallback. Clamp to NetBox's 32-bit max with a WARN. |
| `proxbox_api/services/sync/individual/virtual_disk_sync.py` | Route disk size through `size_str_to_mb` so `"32G"` parses correctly (was `int(...) // 1_000_000` and silently produced 0). |
| `tests/test_custom_field_object_types_union.py` (new) | 11 tests covering coerce/normalize/union/no-existing/error/non-list paths. |
| `tests/test_proxmox_disk_parsing.py` (new) | 12 tests covering scsi/virtio/rootfs/efidisk/tpmstate/passthrough/unused/aggregate. |
| `tests/test_proxmox_to_netbox_contracts.py`, `tests/test_vm_sync.py` | Contract updates: `VM.disk == sum(virtual-disks)`, asserts the no-fallback path. |

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run python -m compileall proxbox_api tests` — clean
- [x] `uv run python -c "import proxbox_api.main"` — clean
- [x] `uv run pytest tests --ignore=tests/e2e` — **4169 passed** (1001s)
- [x] New focused suites: 11/11 + 12/12 passing
- [ ] Reporter validation in their NetBox 4.5.9 environment

## Notes

- The plan and diagnosis are documented in [issue #349 comment](https://github.com/emersonfelipesp/netbox-proxbox/issues/349#issuecomment-4373465356).
- Out of scope here (deferred): resolving missing `size=` from Proxmox storage content listing — for now, all-passthrough VMs surface as `disk=0` with a structured WARN per dropped disk, which is a clear actionable signal rather than a hard NetBox rejection.
- Backport to the v0.0.7 line is left as a follow-up cherry-pick if the maintainer wants it.