### PR TITLE
ci(docker-hub-publish): pass PROXBOX_ENCRYPTION_KEY to v0.0.10+ smoke tests

### DIFF
--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -42,6 +42,11 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  # Required since v0.0.10: proxbox-api refuses to start without an
+  # encryption key (or PROXBOX_ALLOW_PLAINTEXT_CREDENTIALS=1). Use a
+  # constant CI-only key so smoke containers go through the same code
+  # path operators use in production.
+  PROXBOX_ENCRYPTION_KEY: proxbox-ci-only-encryption-key-not-a-secret
 
 jobs:
   # Sequential local test (manual); no registry login or push.
@@ -143,6 +148,7 @@ jobs:
       - name: Run tests in raw image
         run: |
           docker run --rm \
+            -e PROXBOX_ENCRYPTION_KEY \
             -w /workspace \
             -v /tmp/docker-tests.sh:/tmp/docker-tests.sh \
             -v "${{ github.workspace }}:/workspace" \
@@ -156,6 +162,7 @@ jobs:
           docker run -d --name proxbox-smoke-raw \
             -p 127.0.0.1:18080:8000 \
             -e PROXBOX_SKIP_NETBOX_BOOTSTRAP=1 \
+            -e PROXBOX_ENCRYPTION_KEY \
             emersonfelipesp/proxbox-api:${{ env.IMAGE_TAG }}-raw-pre
           for i in $(seq 1 40); do
             if curl -fsS --max-time 5 http://127.0.0.1:18080/ >/dev/null 2>&1; then
@@ -184,6 +191,7 @@ jobs:
       - name: Run tests in nginx image
         run: |
           docker run --rm \
+            -e PROXBOX_ENCRYPTION_KEY \
             -w /workspace \
             -v /tmp/docker-tests.sh:/tmp/docker-tests.sh \
             -v "${{ github.workspace }}:/workspace" \
@@ -197,6 +205,7 @@ jobs:
           docker run -d --name proxbox-smoke-nginx \
             -p 127.0.0.1:18443:8000 \
             -e PROXBOX_SKIP_NETBOX_BOOTSTRAP=1 \
+            -e PROXBOX_ENCRYPTION_KEY \
             emersonfelipesp/proxbox-api:${{ env.IMAGE_TAG }}-nginx-pre
           for i in $(seq 1 40); do
             if curl -kfsS --max-time 5 https://127.0.0.1:18443/ >/dev/null 2>&1; then
@@ -225,6 +234,7 @@ jobs:
       - name: Run tests in granian image
         run: |
           docker run --rm \
+            -e PROXBOX_ENCRYPTION_KEY \
             -w /workspace \
             -v /tmp/docker-tests.sh:/tmp/docker-tests.sh \
             -v "${{ github.workspace }}:/workspace" \
@@ -238,6 +248,7 @@ jobs:
           docker run -d --name proxbox-smoke-granian \
             -p 127.0.0.1:18444:8000 \
             -e PROXBOX_SKIP_NETBOX_BOOTSTRAP=1 \
+            -e PROXBOX_ENCRYPTION_KEY \
             emersonfelipesp/proxbox-api:${{ env.IMAGE_TAG }}-granian-pre
           for i in $(seq 1 40); do
             if curl -kfsS --max-time 5 https://127.0.0.1:18444/ >/dev/null 2>&1; then
@@ -340,6 +351,7 @@ jobs:
           docker run -d --name proxbox-smoke-raw \
             -p 127.0.0.1:18080:8000 \
             -e PROXBOX_SKIP_NETBOX_BOOTSTRAP=1 \
+            -e PROXBOX_ENCRYPTION_KEY \
             emersonfelipesp/proxbox-api:${{ env.IMAGE_TAG }}-raw-pre
           for i in $(seq 1 40); do
             if curl -fsS --max-time 5 http://127.0.0.1:18080/ >/dev/null 2>&1; then
@@ -375,6 +387,7 @@ jobs:
             docker run -d --name "$NAME" \
               -p 127.0.0.1:18080:8000 \
               -e PROXBOX_SKIP_NETBOX_BOOTSTRAP=1 \
+              -e PROXBOX_ENCRYPTION_KEY \
               emersonfelipesp/proxbox-api:"$TAG"
             ok=0
             for i in $(seq 1 40); do
@@ -481,6 +494,7 @@ jobs:
           docker run -d --name proxbox-smoke-nginx \
             -p 127.0.0.1:18443:8000 \
             -e PROXBOX_SKIP_NETBOX_BOOTSTRAP=1 \
+            -e PROXBOX_ENCRYPTION_KEY \
             emersonfelipesp/proxbox-api:${{ env.IMAGE_TAG }}-nginx-pre
           for i in $(seq 1 40); do
             if curl -kfsS --max-time 5 https://127.0.0.1:18443/ >/dev/null 2>&1; then
@@ -516,6 +530,7 @@ jobs:
             docker run -d --name "$NAME" \
               -p 127.0.0.1:18443:8000 \
               -e PROXBOX_SKIP_NETBOX_BOOTSTRAP=1 \
+              -e PROXBOX_ENCRYPTION_KEY \
               emersonfelipesp/proxbox-api:"$TAG"
             ok=0
             for i in $(seq 1 40); do
@@ -622,6 +637,7 @@ jobs:
           docker run -d --name proxbox-smoke-granian \
             -p 127.0.0.1:18444:8000 \
             -e PROXBOX_SKIP_NETBOX_BOOTSTRAP=1 \
+            -e PROXBOX_ENCRYPTION_KEY \
             emersonfelipesp/proxbox-api:${{ env.IMAGE_TAG }}-granian-pre
           for i in $(seq 1 40); do
             if curl -kfsS --max-time 5 https://127.0.0.1:18444/ >/dev/null 2>&1; then
@@ -657,6 +673,7 @@ jobs:
             docker run -d --name "$NAME" \
               -p 127.0.0.1:18444:8000 \
               -e PROXBOX_SKIP_NETBOX_BOOTSTRAP=1 \
+              -e PROXBOX_ENCRYPTION_KEY \
               emersonfelipesp/proxbox-api:"$TAG"
             ok=0
             for i in $(seq 1 40); do

--- a/.github/workflows/release-docker-verify.yml
+++ b/.github/workflows/release-docker-verify.yml
@@ -11,6 +11,13 @@ on:
         required: true
         type: string
 
+env:
+  # Required since v0.0.10: proxbox-api refuses to start without an
+  # encryption key (or PROXBOX_ALLOW_PLAINTEXT_CREDENTIALS=1). Use a
+  # constant CI-only key so released images go through the same code
+  # path operators use in production.
+  PROXBOX_ENCRYPTION_KEY: proxbox-ci-only-encryption-key-not-a-secret
+
 jobs:
   verify-image:
     name: verify Docker images on release
@@ -59,6 +66,7 @@ jobs:
           docker run -d --name proxbox-release-raw \
             -p 127.0.0.1:18080:8000 \
             -e PROXBOX_SKIP_NETBOX_BOOTSTRAP=1 \
+            -e PROXBOX_ENCRYPTION_KEY \
             emersonfelipesp/proxbox-api:"$TAG"
           for i in $(seq 1 40); do
             if curl -fsS --max-time 5 http://127.0.0.1:18080/ >/dev/null 2>&1; then
@@ -78,6 +86,7 @@ jobs:
           docker run -d --name proxbox-release-nginx \
             -p 127.0.0.1:18443:8000 \
             -e PROXBOX_SKIP_NETBOX_BOOTSTRAP=1 \
+            -e PROXBOX_ENCRYPTION_KEY \
             emersonfelipesp/proxbox-api:"${TAG}-nginx"
           for i in $(seq 1 40); do
             if curl -kfsS --max-time 5 https://127.0.0.1:18443/ >/dev/null 2>&1; then
@@ -97,6 +106,7 @@ jobs:
           docker run -d --name proxbox-release-granian \
             -p 127.0.0.1:18444:8000 \
             -e PROXBOX_SKIP_NETBOX_BOOTSTRAP=1 \
+            -e PROXBOX_ENCRYPTION_KEY \
             emersonfelipesp/proxbox-api:"${TAG}-granian"
           for i in $(seq 1 40); do
             if curl -kfsS --max-time 5 https://127.0.0.1:18444/ >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- Fixes the root cause of the missing `emersonfelipesp/proxbox-api:0.0.10` Docker Hub image. The v0.0.10 release run (id `25348959706`) failed at the Docker publish step because `proxbox-api >= 0.0.10` refuses to start without `PROXBOX_ENCRYPTION_KEY` (or `PROXBOX_ALLOW_PLAINTEXT_CREDENTIALS=1`).
- Commit `6dcda82` already added the same fix to `ci.yml` but missed `docker-hub-publish.yml` and `release-docker-verify.yml`.
- Adds the workflow-level `PROXBOX_ENCRYPTION_KEY` env block and propagates `-e PROXBOX_ENCRYPTION_KEY` to every `docker run` that boots a `proxbox-api` container in those two workflows.

## Files changed

- `.github/workflows/docker-hub-publish.yml`: workflow env + 12 docker invocations (9 smoke startups + 3 `docker-tests.sh` runs).
- `.github/workflows/release-docker-verify.yml`: workflow env + 3 published-image smoke startups (raw / nginx / granian).

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open(...))"` — both workflow files parse cleanly.
- [x] grep sweep confirms every proxbox-api `docker run` is paired with `-e PROXBOX_ENCRYPTION_KEY` (NetBox / Postgres / Redis / proxmox-mock containers do not need the key).
- [ ] After merge, dispatch `Docker images` workflow with `source_ref=v0.0.10` and `mode=publish` to push the missing v0.0.10 image set to Docker Hub.
- [ ] After v0.0.10 lands on Docker Hub, the `release-docker-verify.yml` and downstream `netbox-proxbox` `e2e-docker.yml` / `docs-screenshots.yml` runs go green.