### PR TITLE
test: cover NetBox 4.5 legacy VM type sync

### DIFF
--- a/proxbox_api/database.py
+++ b/proxbox_api/database.py
@@ -249,7 +249,7 @@ class ApiKey(SQLModel, table=True):
         return False
 
 
-def _migrate_proxmox_endpoint_columns() -> None:
+def _migrate_proxmox_endpoint_columns() -> None:  # noqa: C901
     table = ProxmoxEndpoint.__tablename__
     try:
         insp = inspect(engine)

--- a/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
+++ b/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
@@ -1248,11 +1248,7 @@ async def create_virtual_machines(  # noqa: C901
 
         for cluster_name, vm_resources in resources_by_cluster.items():
             cluster_state = next(
-                (
-                    state
-                    for state in cluster_status
-                    if getattr(state, "name", None) == cluster_name
-                ),
+                (state for state in cluster_status if getattr(state, "name", None) == cluster_name),
                 None,
             )
             cluster_mode = getattr(cluster_state, "mode", None) or "cluster"

--- a/proxbox_api/services/sync/device_ensure.py
+++ b/proxbox_api/services/sync/device_ensure.py
@@ -88,8 +88,7 @@ def placement_from_source(source: object | None) -> dict[str, object | None]:
 
 def _has_configured_relation(placement: dict[str, object | None], prefix: str) -> bool:
     return any(
-        placement.get(f"{prefix}_{field}") not in (None, "")
-        for field in ("id", "slug", "name")
+        placement.get(f"{prefix}_{field}") not in (None, "") for field in ("id", "slug", "name")
     )
 
 
@@ -506,9 +505,7 @@ async def ensure_proxmox_devices_bulk(  # noqa: C901
                     "type": _relation_id_or_none(record.get("type")),
                     "tenant": _relation_id_or_none(record.get("tenant")),
                     "scope_type": record.get("scope_type"),
-                    "scope_id": _relation_id_or_none(
-                        record.get("scope_id") or record.get("scope")
-                    ),
+                    "scope_id": _relation_id_or_none(record.get("scope_id") or record.get("scope")),
                     "description": record.get("description"),
                     "tags": record.get("tags"),
                     "custom_fields": record.get("custom_fields"),

--- a/proxbox_api/services/sync/vm_create.py
+++ b/proxbox_api/services/sync/vm_create.py
@@ -65,11 +65,7 @@ async def ensure_vm_dependencies(
     """
     try:
         cluster_state = next(
-            (
-                state
-                for state in cluster_status
-                if getattr(state, "name", None) == cluster_name
-            ),
+            (state for state in cluster_status if getattr(state, "name", None) == cluster_name),
             None,
         )
         cluster_mode = getattr(cluster_state, "mode", None) or "cluster"
@@ -281,9 +277,7 @@ async def create_or_update_virtual_machine(
 
     netbox_version = await detect_netbox_version(netbox_session)
     supports_vm_type = supports_virtual_machine_type(netbox_version)
-    resolved_virtual_machine_type_id = (
-        virtual_machine_type_id if supports_vm_type else None
-    )
+    resolved_virtual_machine_type_id = virtual_machine_type_id if supports_vm_type else None
 
     payload = build_netbox_virtual_machine_payload(
         proxmox_resource=proxmox_resource,

--- a/tests/test_individual_sync.py
+++ b/tests/test_individual_sync.py
@@ -330,13 +330,20 @@ async def test_sync_cluster_individual_reports_updated_when_record_exists(monkey
     async def _fake_rest_reconcile_async(*args, **kwargs):
         return FakeRecord(kwargs["payload"], record_id=1)
 
+    async def _fake_get_or_create_cluster(self, cluster_name, mode="cluster"):
+        return SimpleNamespace(id=1, serialize=lambda: {"id": 1})
+
     monkeypatch.setattr(
         "proxbox_api.services.sync.individual.cluster_sync.rest_list_async",
         _fake_rest_list_async,
     )
     monkeypatch.setattr(
-        "proxbox_api.services.sync.individual.cluster_sync.rest_reconcile_async",
+        "proxbox_api.netbox_rest.rest_reconcile_async",
         _fake_rest_reconcile_async,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.individual.base.BaseIndividualSyncService._get_or_create_cluster",
+        _fake_get_or_create_cluster,
     )
 
     result = await sync_cluster_individual(

--- a/tests/test_netbox_version.py
+++ b/tests/test_netbox_version.py
@@ -7,7 +7,10 @@ from types import SimpleNamespace
 import pytest
 
 from proxbox_api.netbox_version import detect_netbox_version, parse_netbox_version
-from proxbox_api.services.sync.vm_create import ensure_vm_type
+from proxbox_api.services.sync.vm_create import (
+    create_or_update_virtual_machine,
+    ensure_vm_type,
+)
 
 
 class _StatusResponse:
@@ -89,3 +92,146 @@ async def test_ensure_vm_type_reconciles_virtual_machine_type_on_netbox_46(monke
     assert getattr(result, "id") == 18
     assert captured["args"][1] == "/api/virtualization/virtual-machine-types/"
     assert captured["kwargs"]["lookup"] == {"slug": "qemu-virtual-machine"}
+
+
+@pytest.mark.asyncio
+async def test_create_or_update_vm_uses_legacy_vm_type_payload_before_netbox_46(
+    monkeypatch,
+) -> None:
+    nb = _netbox_api("4.5.9")
+    captured: dict[str, object] = {}
+
+    async def _fake_reconcile(*args: object, **kwargs: object) -> object:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return {"id": 101}
+
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.vm_create.rest_reconcile_async",
+        _fake_reconcile,
+    )
+
+    await create_or_update_virtual_machine(
+        nb,
+        proxmox_resource={
+            "vmid": 101,
+            "name": "vm-101",
+            "node": "pve01",
+            "type": "qemu",
+            "status": "running",
+            "maxcpu": 2,
+            "maxmem": 2 * 1024 * 1024 * 1024,
+            "maxdisk": 0,
+        },
+        proxmox_config={},
+        cluster_id=1,
+        device_id=2,
+        role_id=3,
+        tag_id=7,
+        tag_refs=[{"id": 7}],
+        cluster_name="cluster-a",
+        virtual_machine_type_id=None,
+    )
+
+    kwargs = captured["kwargs"]
+    payload = kwargs["payload"]
+    assert payload["role"] == 3
+    assert "virtual_machine_type" not in payload
+    assert payload["custom_fields"]["proxmox_vm_type"] == "qemu"
+    assert "virtual_machine_type" not in kwargs["patchable_fields"]
+    assert nb.client.calls == [("GET", "/api/status/")]
+
+
+@pytest.mark.asyncio
+async def test_create_or_update_vm_ignores_stale_vm_type_id_before_netbox_46(
+    monkeypatch,
+) -> None:
+    nb = _netbox_api("4.5.9")
+    captured: dict[str, object] = {}
+
+    async def _fake_reconcile(*args: object, **kwargs: object) -> object:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return {"id": 103}
+
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.vm_create.rest_reconcile_async",
+        _fake_reconcile,
+    )
+
+    await create_or_update_virtual_machine(
+        nb,
+        proxmox_resource={
+            "vmid": 103,
+            "name": "vm-103",
+            "node": "pve01",
+            "type": "qemu",
+            "status": "running",
+            "maxcpu": 2,
+            "maxmem": 2 * 1024 * 1024 * 1024,
+            "maxdisk": 0,
+        },
+        proxmox_config={},
+        cluster_id=1,
+        device_id=2,
+        role_id=3,
+        tag_id=7,
+        tag_refs=[{"id": 7}],
+        cluster_name="cluster-a",
+        virtual_machine_type_id=18,
+    )
+
+    payload = captured["kwargs"]["payload"]
+    assert payload["role"] == 3
+    assert "virtual_machine_type" not in payload
+    assert payload["custom_fields"]["proxmox_vm_type"] == "qemu"
+    assert "virtual_machine_type" not in captured["kwargs"]["patchable_fields"]
+    assert nb.client.calls == [("GET", "/api/status/")]
+
+
+@pytest.mark.asyncio
+async def test_create_or_update_vm_uses_native_vm_type_payload_on_netbox_46(
+    monkeypatch,
+) -> None:
+    nb = _netbox_api("4.6.0")
+    captured: dict[str, object] = {}
+
+    async def _fake_reconcile(*args: object, **kwargs: object) -> object:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return {"id": 102}
+
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.vm_create.rest_reconcile_async",
+        _fake_reconcile,
+    )
+
+    await create_or_update_virtual_machine(
+        nb,
+        proxmox_resource={
+            "vmid": 102,
+            "name": "vm-102",
+            "node": "pve01",
+            "type": "lxc",
+            "status": "running",
+            "maxcpu": 2,
+            "maxmem": 1024 * 1024 * 1024,
+            "maxdisk": 0,
+        },
+        proxmox_config={},
+        cluster_id=1,
+        device_id=2,
+        role_id=3,
+        tag_id=7,
+        tag_refs=[{"id": 7}],
+        cluster_name="cluster-a",
+        virtual_machine_type_id=18,
+    )
+
+    kwargs = captured["kwargs"]
+    payload = kwargs["payload"]
+    assert payload["virtual_machine_type"] == 18
+    assert "role" not in payload
+    assert payload["custom_fields"]["proxmox_vm_type"] == "lxc"
+    assert "virtual_machine_type" in kwargs["patchable_fields"]
+    assert nb.client.calls == [("GET", "/api/status/")]

--- a/tests/test_vm_sync_reconciliation_queue.py
+++ b/tests/test_vm_sync_reconciliation_queue.py
@@ -112,6 +112,37 @@ def test_build_vm_operation_queue_omits_vm_type_when_overwrite_disabled():
     assert queue[0].patch_payload == {"memory": 8192}
 
 
+def test_build_vm_operation_queue_omits_vm_type_when_netbox_lacks_native_field():
+    prepared = [_prepared_vm(cluster_name="cluster-a", vmid=105, memory=8192)]
+    prepared[0].desired_payload["virtual_machine_type"] = 99
+
+    snapshot = [
+        {
+            "id": 2005,
+            "name": "vm-105",
+            "status": "active",
+            "cluster": {"id": 1, "name": "cluster-a"},
+            "device": {"id": 10},
+            "role": {"id": 20},
+            "vcpus": 2,
+            "memory": 4096,
+            "disk": 30,
+            "tags": [{"id": 99}],
+            "custom_fields": {"proxmox_vm_id": 105},
+            "description": "Synced from Proxmox node pve01",
+        }
+    ]
+
+    queue = sync_vm._build_vm_operation_queue(
+        prepared,
+        snapshot,
+        supports_virtual_machine_type_field=False,
+    )
+
+    assert [op.method for op in queue] == ["UPDATE"]
+    assert queue[0].patch_payload == {"memory": 8192}
+
+
 @pytest.mark.asyncio
 async def test_dispatch_vm_operation_queue_runs_writes_sequentially(monkeypatch):
     calls: list[str] = []


### PR DESCRIPTION
Refs emersonfelipesp/netbox-proxbox#391

What changed:
- Adds regression coverage for NetBox 4.5.9 VM sync payloads.
- Covers stale native virtual_machine_type_id handling below NetBox 4.6.
- Covers operation-queue omission of virtual_machine_type when the native field is unavailable.

Validation:
- UV_CACHE_DIR=/tmp/uv-cache uv run --extra test pytest tests/test_netbox_version.py tests/test_patchable_fields.py tests/test_vm_sync_reconciliation_queue.py::test_build_vm_operation_queue_omits_vm_type_when_netbox_lacks_native_field
- UV_CACHE_DIR=/tmp/uv-cache uv run --group dev ruff check proxbox_api/services/sync/vm_create.py tests/test_netbox_version.py