### PR TITLE
fix(ipam): strip IPv6 zone IDs and skip link-local before NetBox writes

### DIFF
--- a/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
+++ b/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
@@ -2782,6 +2782,14 @@ async def create_only_vm_ip_addresses(  # noqa: C901
                     from proxbox_api.services.sync.network import build_vm_interface_ip_payload
                     from proxbox_api.services.sync.vm_helpers import all_guest_agent_ips
 
+                    raw_guest_ip_count = 0
+                    if isinstance(guest_iface, dict):
+                        raw_guest_ip_count = sum(
+                            1
+                            for addr in (guest_iface.get("ip_addresses") or [])
+                            if isinstance(addr, dict)
+                        )
+
                     all_ips_for_iface: list[str] = []
                     if guest_iface:
                         all_ips_for_iface = all_guest_agent_ips(
@@ -2789,6 +2797,26 @@ async def create_only_vm_ip_addresses(  # noqa: C901
                             ignore_ipv6_link_local_addresses,
                             primary_ip_preference=primary_ip_preference,
                         )
+
+                    skipped_guest_ips = max(0, raw_guest_ip_count - len(all_ips_for_iface))
+                    if skipped_guest_ips and isinstance(websocket, WebSocketSSEBridge):
+                        try:
+                            await websocket.emit_phase_summary(
+                                phase="vm-ip-addresses",
+                                skipped=skipped_guest_ips,
+                                message=(
+                                    f"Skipped {skipped_guest_ips} link-local/zone-scoped/"
+                                    f"loopback IPs on {vm_name}.{resolved_name}"
+                                ),
+                            )
+                        except Exception as emit_exc:
+                            logger.debug(
+                                "emit_phase_summary failed for VM %s interface %s: %s",
+                                vm_name,
+                                resolved_name,
+                                emit_exc,
+                            )
+
                     if not all_ips_for_iface:
                         config_ip = config_dict.get("ip")
                         if config_ip and str(config_ip) != "dhcp":
@@ -2809,7 +2837,10 @@ async def create_only_vm_ip_addresses(  # noqa: C901
                                 tag_refs,
                                 now,
                                 dns_name=vm_dns_name,
+                                ignore_ipv6_link_local=ignore_ipv6_link_local_addresses,
                             )
+                            if payload is None:
+                                continue
                             ip_payloads.append(payload)
 
                             # Track first IP for primary assignment

--- a/proxbox_api/services/sync/network.py
+++ b/proxbox_api/services/sync/network.py
@@ -22,6 +22,7 @@ from proxbox_api.proxmox_to_netbox.models import (
 )
 from proxbox_api.schemas.sync import SyncOverwriteFlags
 from proxbox_api.services.sync.vm_helpers import (
+    _is_skippable_ip,
     all_guest_agent_ips,
     normalized_mac,
     preferred_primary_ip_order,
@@ -234,21 +235,34 @@ def build_vm_interface_ip_payload(
     tag_refs: list[dict],
     now: datetime,
     dns_name: str | None = None,
-) -> dict:
+    ignore_ipv6_link_local: bool = True,
+) -> dict | None:
     """Build a VM interface IP payload dict for bulk operations (no NetBox writes).
 
+    Strips the IPv6 zone-ID suffix (``%eth0``) from ``address`` and returns
+    ``None`` when the address is empty, unparseable, loopback, or — when the
+    toggle is on — IPv6 link-local. Defends the bulk-reconcile path against
+    raw config-fallback IPs that bypass ``all_guest_agent_ips``.
+
     Args:
-        address: IP address with CIDR (e.g., "192.168.1.10/24")
+        address: IP address with optional CIDR (e.g., ``"192.168.1.10/24"``)
         interface_id: Interface ID
         tag_refs: List of tag references
         now: Current datetime for custom fields
         dns_name: Guest hostname to set as IPAM dns_name; empty/None becomes ""
+        ignore_ipv6_link_local: When True (default), skip ``fe80::/10`` hosts
 
     Returns:
-        Payload dict for bulk reconciliation
+        Payload dict for bulk reconciliation, or ``None`` if the address
+        should be skipped.
     """
+    host, _, prefix_part = str(address or "").partition("/")
+    skip, cleaned = _is_skippable_ip(host, ignore_ipv6_link_local=ignore_ipv6_link_local)
+    if skip or cleaned is None:
+        return None
+    cleaned_address = f"{cleaned}/{prefix_part}" if prefix_part else cleaned
     return {
-        "address": address,
+        "address": cleaned_address,
         "assigned_object_type": "virtualization.vminterface",
         "assigned_object_id": interface_id,
         "status": "active",
@@ -658,13 +672,26 @@ async def _resolve_vm_interface_ips(  # noqa: C901
     primary_ip_preference: str = "ipv4",
     tag_slug: str = "proxbox",
     dns_name: str | None = None,
+    bridge: object | None = None,
+    vm_name: str | None = None,
 ) -> list[tuple[int | None, str]]:
     """Create or update ALL IPs attached to a VM interface, then clean up stale ones.
 
     Returns list of (ip_id, ip_address) tuples for all synced IPs.
+
+    When ``bridge`` is provided and any guest-agent IPs were dropped by
+    ``_is_skippable_ip`` (link-local under the toggle, loopback, or
+    unparseable after zone-ID stripping), emits a single aggregated
+    ``phase_summary`` SSE frame for this interface.
     """
     if not create_ip or interface_id is None:
         return []
+
+    raw_guest_ip_count = 0
+    if isinstance(guest_iface, dict):
+        raw_guest_ip_count = sum(
+            1 for addr in (guest_iface.get("ip_addresses") or []) if isinstance(addr, dict)
+        )
 
     all_ips: list[str] = []
     if guest_iface:
@@ -673,6 +700,25 @@ async def _resolve_vm_interface_ips(  # noqa: C901
             ignore_ipv6_link_local,
             primary_ip_preference=primary_ip_preference,
         )
+
+    skipped_guest_ips = max(0, raw_guest_ip_count - len(all_ips))
+    if skipped_guest_ips and bridge is not None and hasattr(bridge, "emit_phase_summary"):
+        target = f"{vm_name}.{interface_name}" if vm_name else interface_name
+        try:
+            await bridge.emit_phase_summary(
+                phase="vm-ip-addresses",
+                skipped=skipped_guest_ips,
+                message=(
+                    f"Skipped {skipped_guest_ips} link-local/zone-scoped/loopback IPs on {target}"
+                ),
+            )
+        except Exception as emit_exc:
+            logger.debug(
+                "emit_phase_summary failed for interface %s: %s",
+                interface_name,
+                emit_exc,
+            )
+
     if not all_ips:
         config_ip = interface_config.get("ip")
         if config_ip and config_ip != "dhcp":
@@ -690,6 +736,11 @@ async def _resolve_vm_interface_ips(  # noqa: C901
     for ip_addr in all_ips:
         if ip_addr == "dhcp":
             continue
+        host, _, prefix_part = str(ip_addr).partition("/")
+        skip, cleaned_host = _is_skippable_ip(host, ignore_ipv6_link_local=ignore_ipv6_link_local)
+        if skip or cleaned_host is None:
+            continue
+        ip_addr = f"{cleaned_host}/{prefix_part}" if prefix_part else cleaned_host
         try:
             ip_record = await rest_reconcile_async(
                 nb,

--- a/proxbox_api/services/sync/vm_helpers.py
+++ b/proxbox_api/services/sync/vm_helpers.py
@@ -113,25 +113,47 @@ def parse_key_value_string(value: object) -> dict[str, str]:
     return parsed
 
 
+def _is_skippable_ip(ip_text: str, ignore_ipv6_link_local: bool = True) -> tuple[bool, str | None]:
+    """Decide whether an IP should be skipped before reaching NetBox IPAM.
+
+    Strips the IPv6 zone-ID suffix (``%eth0``, ``%vmbr0``...) unconditionally,
+    since NetBox IPAM rejects zone-scoped addresses with a 400. Then checks
+    whether the address is empty, unparseable, loopback, or (when the toggle
+    is on) IPv6 link-local.
+
+    Returns ``(True, None)`` when the address should be skipped, and
+    ``(False, cleaned)`` with the canonical compressed form when it should
+    be kept.
+    """
+    cleaned = str(ip_text or "").strip()
+    if not cleaned:
+        return (True, None)
+    cleaned = cleaned.split("%", 1)[0]
+    if not cleaned:
+        return (True, None)
+    try:
+        parsed = ip_address(cleaned)
+    except ValueError:
+        return (True, None)
+    if parsed.is_loopback:
+        return (True, None)
+    if ignore_ipv6_link_local and parsed.is_link_local:
+        return (True, None)
+    return (False, parsed.compressed)
+
+
 def guest_agent_ip_with_prefix(
     addr: dict[str, object], ignore_ipv6_link_local: bool = True
 ) -> str | None:
     """Extract and format guest agent IP with prefix."""
     ip_text = str(addr.get("ip_address") or "").strip()
-    if not ip_text:
-        return None
-    try:
-        parsed = ip_address(ip_text)
-    except ValueError:
-        return None
-    if parsed.is_loopback:
-        return None
-    if ignore_ipv6_link_local and parsed.is_link_local:
+    skip, cleaned = _is_skippable_ip(ip_text, ignore_ipv6_link_local=ignore_ipv6_link_local)
+    if skip or cleaned is None:
         return None
     prefix = addr.get("prefix")
     if isinstance(prefix, int) and 0 <= prefix <= 128:
-        return f"{parsed.compressed}/{prefix}"
-    return parsed.compressed
+        return f"{cleaned}/{prefix}"
+    return cleaned
 
 
 def best_guest_agent_ip(

--- a/tests/test_dns_name_propagation.py
+++ b/tests/test_dns_name_propagation.py
@@ -35,6 +35,191 @@ def test_build_vm_interface_ip_payload_defaults_dns_name_to_empty_string():
     assert payload["dns_name"] == ""
 
 
+def test_build_vm_interface_ip_payload_strips_zone_id():
+    """A zone-scoped global IPv6 reaches NetBox without the %eth0 suffix."""
+    payload = build_vm_interface_ip_payload(
+        address="2001:db8::1%eth0/64",
+        interface_id=42,
+        tag_refs=[],
+        now=datetime(2026, 5, 7, tzinfo=timezone.utc),
+    )
+    assert payload is not None
+    assert payload["address"] == "2001:db8::1/64"
+
+
+def test_build_vm_interface_ip_payload_drops_link_local():
+    """fe80::… is dropped (returns None) when the toggle is on (default)."""
+    payload = build_vm_interface_ip_payload(
+        address="fe80::1%eth0/64",
+        interface_id=42,
+        tag_refs=[],
+        now=datetime(2026, 5, 7, tzinfo=timezone.utc),
+    )
+    assert payload is None
+
+
+def test_build_vm_interface_ip_payload_keeps_link_local_when_opted_in():
+    """Operator opt-in keeps fe80::… (zone-stripped) for diagnostic VMs."""
+    payload = build_vm_interface_ip_payload(
+        address="fe80::1%eth0/64",
+        interface_id=42,
+        tag_refs=[],
+        now=datetime(2026, 5, 7, tzinfo=timezone.utc),
+        ignore_ipv6_link_local=False,
+    )
+    assert payload is not None
+    assert payload["address"] == "fe80::1/64"
+
+
+def test_build_vm_interface_ip_payload_drops_loopback():
+    """Loopback addresses are always skipped, with or without prefix."""
+    assert (
+        build_vm_interface_ip_payload(
+            address="127.0.0.1/8",
+            interface_id=42,
+            tag_refs=[],
+            now=datetime(2026, 5, 7, tzinfo=timezone.utc),
+        )
+        is None
+    )
+
+
+def test_resolve_vm_interface_ips_emits_phase_summary_for_skipped_ips():
+    """fe80::1%eth0 in guest agent yields a phase_summary with skipped=1."""
+
+    async def _run() -> tuple[list[dict], list[tuple[str, dict]]]:
+        from proxbox_api.utils.streaming import WebSocketSSEBridge
+
+        bridge = WebSocketSSEBridge()
+        seen_payloads: list[dict] = []
+
+        async def _fake_reconcile(*args, **kwargs):
+            seen_payloads.append(kwargs["payload"])
+            return {"id": len(seen_payloads)}
+
+        with (
+            patch(
+                "proxbox_api.services.sync.network.rest_reconcile_async",
+                new=AsyncMock(side_effect=_fake_reconcile),
+            ),
+            patch(
+                "proxbox_api.services.sync.network.cleanup_stale_ips_for_interface",
+                new=AsyncMock(return_value=0),
+            ),
+        ):
+            await _resolve_vm_interface_ips(
+                nb=object(),
+                interface_config={},
+                guest_iface={
+                    "ip_addresses": [
+                        {
+                            "ip_address": "fe80::1%eth0",
+                            "prefix": 64,
+                            "ip_address_type": "ipv6",
+                        },
+                        {
+                            "ip_address": "2001:db8::1%eth0",
+                            "prefix": 64,
+                            "ip_address_type": "ipv6",
+                        },
+                        {
+                            "ip_address": "192.0.2.1",
+                            "prefix": 24,
+                            "ip_address_type": "ipv4",
+                        },
+                    ]
+                },
+                tag_refs=[],
+                interface_id=42,
+                interface_name="ens18",
+                now=datetime(2026, 5, 7, tzinfo=timezone.utc),
+                create_ip=True,
+                bridge=bridge,
+                vm_name="vm-100",
+            )
+
+        await bridge.close()
+        frames: list[tuple[str, dict]] = []
+        async for raw in bridge.iter_sse():
+            lines = [line for line in raw.strip().splitlines() if line]
+            event = lines[0].replace("event: ", "", 1)
+            import json
+
+            data = json.loads(lines[1].replace("data: ", "", 1))
+            frames.append((event, data))
+        return seen_payloads, frames
+
+    payloads, frames = asyncio.run(_run())
+
+    posted_addresses = {p["address"] for p in payloads}
+    assert posted_addresses == {"2001:db8::1/64", "192.0.2.1/24"}
+
+    summaries = [
+        data
+        for event, data in frames
+        if event == "phase_summary" and data.get("phase") == "vm-ip-addresses"
+    ]
+    assert len(summaries) == 1
+    assert summaries[0]["result"]["skipped"] == 1
+    assert "vm-100.ens18" in summaries[0].get("message", "")
+
+
+def test_resolve_vm_interface_ips_no_summary_when_nothing_skipped():
+    """If no IPs are filtered out, no phase_summary frame is emitted."""
+
+    async def _run() -> list[tuple[str, dict]]:
+        from proxbox_api.utils.streaming import WebSocketSSEBridge
+
+        bridge = WebSocketSSEBridge()
+
+        async def _fake_reconcile(*args, **kwargs):
+            return {"id": 1}
+
+        with (
+            patch(
+                "proxbox_api.services.sync.network.rest_reconcile_async",
+                new=AsyncMock(side_effect=_fake_reconcile),
+            ),
+            patch(
+                "proxbox_api.services.sync.network.cleanup_stale_ips_for_interface",
+                new=AsyncMock(return_value=0),
+            ),
+        ):
+            await _resolve_vm_interface_ips(
+                nb=object(),
+                interface_config={},
+                guest_iface={
+                    "ip_addresses": [
+                        {
+                            "ip_address": "192.0.2.1",
+                            "prefix": 24,
+                            "ip_address_type": "ipv4",
+                        },
+                    ]
+                },
+                tag_refs=[],
+                interface_id=42,
+                interface_name="ens18",
+                now=datetime(2026, 5, 7, tzinfo=timezone.utc),
+                create_ip=True,
+                bridge=bridge,
+            )
+
+        await bridge.close()
+        frames: list[tuple[str, dict]] = []
+        async for raw in bridge.iter_sse():
+            import json
+
+            lines = [line for line in raw.strip().splitlines() if line]
+            event = lines[0].replace("event: ", "", 1)
+            data = json.loads(lines[1].replace("data: ", "", 1))
+            frames.append((event, data))
+        return frames
+
+    frames = asyncio.run(_run())
+    assert not [event for event, _ in frames if event == "phase_summary"]
+
+
 def test_bulk_reconcile_vm_interface_ips_gates_dns_name_with_overwrite_flag():
     async def _run(flag_value: bool) -> frozenset[str]:
         captured: dict[str, frozenset[str]] = {}

--- a/tests/test_qemu_guest_agent_helpers.py
+++ b/tests/test_qemu_guest_agent_helpers.py
@@ -5,8 +5,14 @@ from __future__ import annotations
 import asyncio
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 from proxbox_api.services.proxmox_helpers import get_qemu_guest_agent_network_interfaces
-from proxbox_api.services.sync.vm_helpers import all_guest_agent_ips
+from proxbox_api.services.sync.vm_helpers import (
+    _is_skippable_ip,
+    all_guest_agent_ips,
+    guest_agent_ip_with_prefix,
+)
 
 
 class _FakeNestedResource:
@@ -272,3 +278,65 @@ def test_cleanup_stale_ips_returns_zero_when_no_existing():
             assert count == 0
 
     asyncio.run(_run())
+
+
+@pytest.mark.parametrize(
+    "raw, ignore_ll, expected",
+    [
+        # Empty / garbage → skip
+        ("", True, (True, None)),
+        ("   ", True, (True, None)),
+        ("not-an-ip", True, (True, None)),
+        ("%eth0", True, (True, None)),
+        # Loopback → always skip
+        ("127.0.0.1", True, (True, None)),
+        ("::1", True, (True, None)),
+        # Link-local with toggle on → skip (issue acceptance)
+        ("fe80::1", True, (True, None)),
+        ("fe80::1%eth0", True, (True, None)),
+        # Link-local with toggle off → keep, zone stripped
+        ("fe80::1%eth0", False, (False, "fe80::1")),
+        # Global IPv6 with zone-ID → keep, zone stripped (issue acceptance)
+        ("2001:db8::1%eth0", True, (False, "2001:db8::1")),
+        ("2001:db8::1%vmbr0", True, (False, "2001:db8::1")),
+        ("2001:db8::1", True, (False, "2001:db8::1")),
+        # IPv4 → keep (issue acceptance)
+        ("192.0.2.1", True, (False, "192.0.2.1")),
+        # Whitespace tolerance
+        ("  2001:db8::1%eth0  ", True, (False, "2001:db8::1")),
+    ],
+)
+def test_is_skippable_ip_matrix(raw, ignore_ll, expected):
+    """Pin the four acceptance-criteria cases plus edge cases for the helper."""
+    assert _is_skippable_ip(raw, ignore_ipv6_link_local=ignore_ll) == expected
+
+
+def test_guest_agent_ip_with_prefix_strips_zone_id():
+    """A global IPv6 with %eth0 must reach NetBox as zone-stripped CIDR."""
+    addr = {"ip_address": "2001:db8::1%eth0", "prefix": 64}
+    assert guest_agent_ip_with_prefix(addr) == "2001:db8::1/64"
+
+
+def test_guest_agent_ip_with_prefix_skips_link_local_with_zone():
+    """fe80::…%eth0 is dropped when the toggle is on (default)."""
+    addr = {"ip_address": "fe80::1%eth0", "prefix": 64}
+    assert guest_agent_ip_with_prefix(addr) is None
+
+
+def test_guest_agent_ip_with_prefix_keeps_link_local_when_toggle_off():
+    """fe80::…%eth0 is kept (zone stripped) when the operator opts in."""
+    addr = {"ip_address": "fe80::1%eth0", "prefix": 64}
+    assert guest_agent_ip_with_prefix(addr, ignore_ipv6_link_local=False) == "fe80::1/64"
+
+
+def test_all_guest_agent_ips_skips_link_local_and_strips_zone():
+    """Full acceptance scenario: fe80::1%eth0 + 2001:db8::1%eth0 + 192.0.2.1."""
+    guest_iface = {
+        "ip_addresses": [
+            {"ip_address": "fe80::1%eth0", "prefix": 64, "ip_address_type": "ipv6"},
+            {"ip_address": "2001:db8::1%eth0", "prefix": 64, "ip_address_type": "ipv6"},
+            {"ip_address": "192.0.2.1", "prefix": 24, "ip_address_type": "ipv4"},
+        ]
+    }
+    result = all_guest_agent_ips(guest_iface)
+    assert sorted(result) == sorted(["2001:db8::1/64", "192.0.2.1/24"])


### PR DESCRIPTION
Closes emersonfelipesp/netbox-proxbox#361.

## Summary
- Adds `proxbox_api/services/sync/vm_helpers.py::_is_skippable_ip` — a single decision point that strips the IPv6 zone-ID suffix (`%eth0`, `%vmbr0`, …) unconditionally and returns `(skip?, cleaned_address)` for empty / unparseable / loopback / (toggleable) link-local input.
- Routes both reconciler entrypoints through it: the function-style `guest_agent_ip_with_prefix` and the bulk-path `build_vm_interface_ip_payload`. NetBox IPAM no longer sees `%<iface>` zone-scoped addresses, and `fe80::/10` is dropped when `ignore_ipv6_link_local` is on (default).
- Emits exactly one aggregated `WebSocketSSEBridge.emit_phase_summary(phase="vm-ip-addresses", skipped=N, message=…)` frame per VM-interface whenever at least one IP is filtered out, so operators have observability without per-IP noise. No new SSE frame type — the existing typed `phase_summary` channel carries the count in `result.skipped`.

## Behavior matrix (`_is_skippable_ip`)
| Input                | `ignore_ipv6_link_local=True`                | `False`                       |
| -------------------- | -------------------------------------------- | ----------------------------- |
| `""` / garbage       | `(True, None)`                               | `(True, None)`                |
| `127.0.0.1` / `::1`  | `(True, None)` (loopback always skipped)     | `(True, None)`                |
| `fe80::1`            | `(True, None)`                               | `(False, "fe80::1")`          |
| `fe80::1%eth0`       | `(True, None)` (zone stripped before check)  | `(False, "fe80::1")`          |
| `2001:db8::1%eth0`   | `(False, "2001:db8::1")`                     | `(False, "2001:db8::1")`      |
| `192.0.2.1`          | `(False, "192.0.2.1")`                       | `(False, "192.0.2.1")`        |

## Tests
- Parametrized matrix `test_is_skippable_ip_matrix` pinning every row.
- `test_guest_agent_ip_with_prefix_strips_zone_id` / `_skips_link_local_with_zone` / `_keeps_link_local_when_toggle_off`.
- `test_build_vm_interface_ip_payload_strips_zone_id` / `_drops_link_local` / `_keeps_link_local_when_opted_in` / `_drops_loopback`.
- End-to-end: `test_resolve_vm_interface_ips_emits_phase_summary_for_skipped_ips` asserts that a guest reporting `fe80::1%eth0` + `2001:db8::1%eth0` + `192.0.2.1` POSTs exactly `{2001:db8::1/64, 192.0.2.1/24}` and emits one `phase_summary` with `result.skipped == 1` and `vm-100.ens18` in the message. Negative companion confirms no summary fires when nothing is filtered.

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run python -m compileall proxbox_api tests`
- [x] `uv run pytest tests/test_qemu_guest_agent_helpers.py tests/test_dns_name_propagation.py -vv` — 40/40 passed
- [x] `uv run pytest tests` — 4284 passed, 10 skipped

## Plugin side
`netbox-proxbox` needs **no code change**: the `ignore_ipv6_link_local` toggle, the query-param plumbing, and the SSE forwarder are already in place. The aggregated `phase_summary` frame flows through the existing forwarder unchanged.

No version bump on either repo (targets `proxbox-api v0.0.11` + `netbox-proxbox v0.0.15`).