### PR TITLE
feat(#368): deterministic VM name collision resolver + duplicate_name_resolved SSE

### DIFF
--- a/docs/pt-BR/sync/name-collision-resolver.md
+++ b/docs/pt-BR/sync/name-collision-resolver.md
@@ -1,0 +1,107 @@
+# Resolvedor de Colisões de Nome de VM
+
+O modelo `virtualization.VirtualMachine` do NetBox impõe unicidade em
+`(cluster, tenant, name)` com `nulls_distinct=False`. Quando o proxbox-api
+sincroniza duas VMs Proxmox que compartilham o mesmo `name` e caem no mesmo
+cluster NetBox, o NetBox rejeita o segundo `POST` com erro `400`.
+
+O resolvedor atribui sufixos determinísticos ``" (N)"`` para que ambos os
+registros coexistam e detecta renomeações manuais para que um registro
+NetBox editado pelo operador não seja sobrescrito silenciosamente na
+próxima sincronização.
+
+## Localização
+
+`proxbox_api/services/name_collision.py`
+
+- `NameResolution` — dataclass congelada retornada pelo resolvedor.
+- `_pick_suffix(candidate, used)` — função pura que escolhe o menor sufixo
+  livre ``" (N)"`` (ou retorna o nome puro quando não há colisão).
+- `resolve_unique_vm_name(...)` — entrada assíncrona usada tanto pelo
+  caminho de sincronização em lote (`sync_vm.py`) quanto pelo caminho
+  individual (`services/sync/individual/vm_sync.py`).
+
+A correspondência de nomes é insensível a maiúsculas/minúsculas via
+`str.casefold`. O `resolved_name` retornado preserva a caixa do candidato.
+
+## Quando o resolvedor executa
+
+### Sincronização em lote (`/full-update`)
+
+Em `_run_full_update_vm_batch`, imediatamente após o carregamento do
+snapshot NetBox e antes da construção da fila de operações. O pré-passo:
+
+1. Agrupa as VMs preparadas por id de cluster NetBox.
+2. Dentro de cada cluster, ordena as VMs por
+   `(proxmox_cluster_name.casefold(), proxmox_vmid)` para que a VM de menor
+   VMID mantenha o nome puro entre re-execuções.
+3. Constrói `used_names_in_cluster` a partir do snapshot, removendo o
+   registro atualmente associado a cada VMID (para que a mesma VM possa
+   manter seu nome na re-sincronização sem colidir consigo mesma).
+4. Chama `resolve_unique_vm_name(...)` por VM e altera
+   `prepared.desired_payload["name"]` quando um sufixo ou renomeação de
+   operador é aplicado.
+5. Emite `WebSocketSSEBridge.emit_duplicate_name_resolved(...)` para cada
+   VM renomeada.
+
+### Sincronização individual (`/sync/virtual-machines/{vmid}`)
+
+`sync_vm_individual` emite um único
+`GET /api/virtualization/virtual-machines/?cluster_id=<id>&limit=0`,
+constrói o conjunto `used_names_in_cluster` e o mapa
+`existing_vm_by_vmid`, chama `resolve_unique_vm_name(...)` e ajusta o
+campo `name` do payload antes da reconciliação.
+
+## Detecção de renomeação manual
+
+Se o NetBox tem uma `VirtualMachine` com
+`custom_fields.proxmox_vm_id` igual ao VMID em sincronização **e** cujo
+`name` atual não é o candidato puro nem um sufixo algorítmico
+(`gateway (2)`, `gateway (3)`…), o resolvedor retorna o nome do operador
+com `operator_renamed=True`. O chamador emite o frame
+`duplicate_name_resolved` com `operator_renamed: true` e não renomeia.
+
+Nomes de operador que parecem algorítmicos (por exemplo, `gateway (2)`
+digitado manualmente) não podem ser distinguidos da saída do resolvedor e
+serão tratados como nomes atribuídos pelo resolvedor em sincronizações
+subsequentes.
+
+## Limites
+
+- **Por cluster NetBox.** Duas VMs em clusters NetBox distintos não
+  colidem estruturalmente e ficam com o nome puro — mesmo que os rótulos
+  de cluster Proxmox sejam diferentes. Isso espelha a unicidade
+  estrutural do NetBox.
+- **Identificador estável.** `custom_fields.proxmox_vm_id` é o vínculo
+  cruzado durável. O resolvedor pode inverter qual VM mantém o nome puro
+  se os nomes de cluster Proxmox forem reordenados, mas o vínculo por
+  VMID permanece.
+- **Registros legados.** Uma VM NetBox sem o campo customizado
+  `proxmox_vm_id` não pode ser correlacionada por VMID; o resolvedor a
+  trata como um registro não-Proxbox e não a considerará uma renomeação
+  manual.
+
+## Forma do frame SSE
+
+```json
+{
+  "event": "duplicate_name_resolved",
+  "cluster": "cluster-a",
+  "original_name": "gateway",
+  "resolved_name": "gateway (2)",
+  "vmid": 101,
+  "suffix_index": 2,
+  "operator_renamed": false
+}
+```
+
+Autoridade do schema:
+
+- `proxbox_api.schemas.stream_messages.DuplicateNameResolvedMessage`
+- builder: `build_duplicate_name_resolved_message`
+- emissor: `WebSocketSSEBridge.emit_duplicate_name_resolved`
+
+O espelho do lado do netbox-proxbox é
+`netbox_proxbox.schemas.backend_proxy.SseDuplicateNameResolvedPayload`, e
+`contracts/proxbox_api_sse_schema.json` é fixado por
+`tests/test_sse_schema_mirror.py`.

--- a/docs/pt-BR/sync/workflows.md
+++ b/docs/pt-BR/sync/workflows.md
@@ -40,6 +40,7 @@ Comportamento principal:
 - Cria interfaces e IPs da VM quando possivel.
 - Escreve journal entries para auditoria.
 - No modo full-update, a criacao de VM nao faz writes de rede, porque as etapas dedicadas de interface e IP cuidam disso.
+- Nomes duplicados de VM dentro de um mesmo cluster NetBox sao resolvidos de forma deterministica antes da fila de operacoes. Veja [Resolvedor de Colisoes de Nome de VM](./name-collision-resolver.md).
 
 ### Modelo Assincrono com Ordem de Dependencias
 

--- a/docs/sync/name-collision-resolver.md
+++ b/docs/sync/name-collision-resolver.md
@@ -1,0 +1,118 @@
+# VM Name Collision Resolver
+
+NetBox's `virtualization.VirtualMachine` model enforces uniqueness on
+`(cluster, tenant, name)` with `nulls_distinct=False`. When proxbox-api
+synchronizes two Proxmox VMs that share a `name` and land in the same NetBox
+cluster, NetBox refuses the second `POST` with a `400` validation error.
+
+The name-collision resolver assigns deterministic ``" (N)"`` suffixes so both
+records can coexist, and detects operator renames so a manually-edited NetBox
+record is not silently overwritten on the next sync.
+
+## Where the resolver lives
+
+`proxbox_api/services/name_collision.py`
+
+- `NameResolution` — frozen dataclass returned by the resolver.
+- `_pick_suffix(candidate, used)` — pure helper that picks the smallest free
+  ``" (N)"`` suffix (or returns the bare name when no collision exists).
+- `resolve_unique_vm_name(...)` — async entrypoint used by both the bulk
+  sync path (`sync_vm.py`) and the individual sync path
+  (`services/sync/individual/vm_sync.py`).
+
+Name matching is case-insensitive via `str.casefold`. The returned
+`resolved_name` preserves the candidate's original casing for display.
+
+## When the resolver runs
+
+### Bulk sync (`/full-update`)
+
+In `_run_full_update_vm_batch`, immediately after the NetBox snapshot is
+loaded and before the operation queue is built. The pre-pass:
+
+1. Groups prepared VMs by NetBox cluster id.
+2. Within each cluster, sorts VMs by `(proxmox_cluster_name.casefold(),
+   proxmox_vmid)` so the lower-VMID VM keeps the bare name across re-runs.
+3. Builds `used_names_in_cluster` from the snapshot, filtered to remove the
+   record currently owned by each VMID (so the same VM can keep its name on
+   re-sync without colliding with itself).
+4. Calls `resolve_unique_vm_name(...)` per VM and mutates
+   `prepared.desired_payload["name"]` when a suffix or operator rename is
+   applied.
+5. Emits `WebSocketSSEBridge.emit_duplicate_name_resolved(...)` for each
+   renamed VM.
+
+### Individual sync (`/sync/virtual-machines/{vmid}`)
+
+`sync_vm_individual` issues one `GET
+/api/virtualization/virtual-machines/?cluster_id=<id>&limit=0`, builds a
+fresh `used_names_in_cluster` set and `existing_vm_by_vmid` map, calls
+`resolve_unique_vm_name(...)`, and patches the payload's `name` before the
+reconcile.
+
+## Operator-rename detection
+
+If NetBox has a `VirtualMachine` whose `custom_fields.proxmox_vm_id` matches
+the incoming VMID **and** whose current `name` is neither the bare candidate
+nor any algorithmic suffix of it (`gateway (2)`, `gateway (3)`, …), the
+resolver returns the operator's name with `operator_renamed=True`. The
+caller emits a `duplicate_name_resolved` warning frame with
+`operator_renamed: true` and skips the rename.
+
+Algorithmic-looking operator names (e.g. an operator who manually typed
+`gateway (2)`) cannot be distinguished from the resolver's own output and
+will be retained on subsequent syncs as if they were resolver-assigned.
+
+## Boundaries
+
+- **Per NetBox cluster.** Two VMs in different NetBox clusters do not
+  collide structurally and are left as bare names — even if their Proxmox
+  cluster labels differ. This matches NetBox's structural uniqueness.
+- **Stable identifier.** `custom_fields.proxmox_vm_id` is the durable
+  cross-reference. The resolver may flip which VM keeps the bare name if
+  Proxmox cluster names are re-ordered, but the VMID-keyed link survives.
+- **Legacy records.** A NetBox VM with no `proxmox_vm_id` custom field
+  cannot be matched by VMID; the resolver treats it as a non-Proxbox record
+  and will not consider it an operator rename.
+
+## SSE frame shape
+
+```json
+{
+  "event": "duplicate_name_resolved",
+  "cluster": "cluster-a",
+  "original_name": "gateway",
+  "resolved_name": "gateway (2)",
+  "vmid": 101,
+  "suffix_index": 2,
+  "operator_renamed": false
+}
+```
+
+Schema authority:
+
+- `proxbox_api.schemas.stream_messages.DuplicateNameResolvedMessage`
+- builder: `build_duplicate_name_resolved_message`
+- emitter: `WebSocketSSEBridge.emit_duplicate_name_resolved`
+
+The netbox-proxbox mirror is
+`netbox_proxbox.schemas.backend_proxy.SseDuplicateNameResolvedPayload`, and
+`contracts/proxbox_api_sse_schema.json` is pinned by
+`tests/test_sse_schema_mirror.py`.
+
+## Worked example
+
+Two Proxmox VMs named `gateway`, vmids `101` and `205`, both syncing into
+NetBox cluster `5`:
+
+| Pass | Order processed | Result |
+|---|---|---|
+| 1   | 101 first       | `gateway`     (suffix 1, no frame)        |
+| 1   | 205 second      | `gateway (2)` (suffix 2, frame emitted)   |
+| 2   | 101 first       | `gateway`     (idempotent, no frame)      |
+| 2   | 205 second      | `gateway (2)` (idempotent, frame emitted) |
+
+If an operator then renames the NetBox record for vmid `101` to
+`gateway-prod-a`, the next sync emits a frame with
+`operator_renamed=true, resolved_name="gateway-prod-a"` and leaves the
+record alone.

--- a/docs/sync/workflows.md
+++ b/docs/sync/workflows.md
@@ -40,6 +40,7 @@ Core behavior:
 - Creates VM interfaces and IP addresses when possible.
 - Writes journal entries for auditability.
 - In full-update mode, VM creation skips network writes so the dedicated VM interface and IP stages own that work.
+- Duplicate VM names within a single NetBox cluster are resolved deterministically before the operation queue is built. See [VM Name Collision Resolver](./name-collision-resolver.md).
 
 ### Dependency-Ordered Async Model
 

--- a/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
+++ b/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
@@ -45,6 +45,10 @@ from proxbox_api.routes.virtualization.virtual_machines.helpers import (
 )
 from proxbox_api.schemas.stream_messages import ErrorCategory, ItemOperation, SubstepStatus
 from proxbox_api.schemas.sync import SyncOverwriteFlags
+from proxbox_api.services.name_collision import (
+    NameResolution,
+    resolve_unique_vm_name,
+)
 from proxbox_api.services.proxmox_helpers import (
     fetch_qemu_guest_agent_network_interfaces,
     get_qemu_guest_agent_hostname,
@@ -256,6 +260,116 @@ def _resolve_vm_overwrites(
         description if description is not None else overwrite_flags.overwrite_vm_description,
         custom_fields if custom_fields is not None else overwrite_flags.overwrite_vm_custom_fields,
     )
+
+
+async def _resolve_vm_names_pre_pass(
+    prepared_vms: list[_PreparedVMState],
+    netbox_snapshot: list[dict[str, object]],
+    bridge: WebSocketSSEBridge | None,
+) -> list[NameResolution]:
+    """Apply deterministic name-collision resolution to ``prepared_vms``.
+
+    Mutates ``prepared.desired_payload["name"]`` in place for any VM that
+    collides with another VM in the same NetBox cluster or whose NetBox record
+    has been renamed by an operator. Emits ``duplicate_name_resolved`` SSE
+    frames via ``bridge`` for each renamed VM.
+
+    Determinism rule: within one NetBox cluster, VMs are processed sorted by
+    ``(proxmox_cluster_name.casefold(), proxmox_vmid)``. The first VM keeps
+    the bare name; subsequent VMs receive ``" (2)"``, ``" (3)"``, ...
+    """
+
+    by_vmid = _build_vm_index_by_proxmox_id(netbox_snapshot)
+    cluster_used_names: dict[int, set[str]] = {}
+    cluster_no_id_used_names: set[str] = set()
+    for record in netbox_snapshot:
+        cluster_id = _relation_id(record.get("cluster"))
+        name = record.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        if cluster_id is None:
+            continue
+        cluster_used_names.setdefault(cluster_id, set()).add(name)
+
+    grouped: dict[int | None, list[_PreparedVMState]] = {}
+    for prepared in prepared_vms:
+        cluster_id = _relation_id(prepared.desired_payload.get("cluster"))
+        grouped.setdefault(cluster_id, []).append(prepared)
+
+    def _sort_key(p: _PreparedVMState) -> tuple[str, int]:
+        try:
+            vmid = int(p.resource.get("vmid", 0) or 0)
+        except (TypeError, ValueError):
+            vmid = 0
+        return (p.cluster_name.casefold(), vmid)
+
+    resolutions: list[NameResolution] = []
+
+    for cluster_id, group in grouped.items():
+        if cluster_id is None:
+            used = cluster_no_id_used_names
+        else:
+            used = cluster_used_names.setdefault(cluster_id, set())
+
+        # Strip names owned by the VMIDs we're about to write — they'll be
+        # re-registered (possibly under a different name) by the resolver.
+        for prepared in group:
+            try:
+                vmid = int(prepared.resource.get("vmid", 0) or 0)
+            except (TypeError, ValueError):
+                vmid = 0
+            existing = by_vmid.get(vmid) if vmid else None
+            if existing is not None:
+                existing_name = existing.get("name")
+                if isinstance(existing_name, str) and existing_name in used:
+                    used.discard(existing_name)
+
+        for prepared in sorted(group, key=_sort_key):
+            try:
+                vmid = int(prepared.resource.get("vmid", 0) or 0)
+            except (TypeError, ValueError):
+                vmid = 0
+            candidate = str(prepared.desired_payload.get("name") or "")
+            if not candidate or vmid == 0:
+                continue
+
+            resolution = await resolve_unique_vm_name(
+                None,
+                netbox_cluster_id=cluster_id,
+                proxmox_cluster_name=prepared.cluster_name,
+                candidate=candidate,
+                proxmox_vmid=vmid,
+                used_names_in_cluster=used,
+                existing_vm_by_vmid=by_vmid,
+            )
+
+            if resolution.operator_renamed:
+                prepared.desired_payload["name"] = resolution.resolved_name
+            elif resolution.is_collision:
+                prepared.desired_payload["name"] = resolution.resolved_name
+
+            if resolution.is_collision or resolution.operator_renamed:
+                resolutions.append(resolution)
+                logger.info(
+                    "name_collision: cluster=%s vmid=%s %r -> %r (suffix=%s, operator=%s)",
+                    prepared.cluster_name,
+                    vmid,
+                    resolution.original_name,
+                    resolution.resolved_name,
+                    resolution.suffix_index,
+                    resolution.operator_renamed,
+                )
+                if bridge is not None:
+                    await bridge.emit_duplicate_name_resolved(
+                        cluster=prepared.cluster_name,
+                        original_name=resolution.original_name,
+                        resolved_name=resolution.resolved_name,
+                        vmid=vmid,
+                        suffix_index=resolution.suffix_index,
+                        operator_renamed=resolution.operator_renamed,
+                    )
+
+    return resolutions
 
 
 def _build_vm_operation_queue(
@@ -1539,6 +1653,7 @@ async def create_virtual_machines(  # noqa: C901
             return []
 
         netbox_snapshot = await _load_netbox_virtual_machine_snapshot(nb)
+        await _resolve_vm_names_pre_pass(prepared_vms, netbox_snapshot, bridge)
         operation_queue = _build_vm_operation_queue(
             prepared_vms,
             netbox_snapshot,

--- a/proxbox_api/schemas/stream_messages.py
+++ b/proxbox_api/schemas/stream_messages.py
@@ -25,6 +25,7 @@ class StreamMessageType(str, Enum):
     PHASE_SUMMARY = "phase_summary"
     ERROR_DETAIL = "error_detail"
     PROGRESS = "progress"
+    DUPLICATE_NAME_RESOLVED = "duplicate_name_resolved"
 
 
 class SubstepStatus(str, Enum):
@@ -150,6 +151,30 @@ class ErrorDetailMessage(ProxboxBaseModel):
     detail: str | None = Field(default=None, description="Technical error details")
     suggestion: str | None = Field(default=None, description="Suggested remediation")
     traceback: str | None = Field(default=None, description="Stack trace (debug mode only)")
+
+
+class DuplicateNameResolvedMessage(ProxboxBaseModel):
+    """Warning frame emitted when the name-collision resolver renames a VM.
+
+    A frame is emitted in two cases: (1) the resolver applied an algorithmic
+    " (N)" suffix because the candidate name was already taken in the target
+    NetBox cluster, or (2) the existing NetBox record was operator-renamed and
+    the sync skipped the rename. Consumers can surface a warning UI without
+    failing the sync.
+    """
+
+    event: str = Field(default="duplicate_name_resolved", description="Message event type")
+    cluster: str = Field(description="Proxmox cluster name (human label)")
+    original_name: str = Field(description="Candidate VM name from Proxmox")
+    resolved_name: str = Field(description="Final name written to NetBox")
+    vmid: int = Field(description="Proxmox VMID")
+    suffix_index: int = Field(
+        description="1 = no algorithmic suffix (operator-rename flow); 2+ = suffix applied",
+    )
+    operator_renamed: bool = Field(
+        default=False,
+        description="True when the NetBox record was already manually renamed by an operator",
+    )
 
 
 class StreamMessage(ProxboxBaseModel):
@@ -324,6 +349,26 @@ def build_error_detail_message(
         detail=detail,
         suggestion=suggestion,
         traceback=traceback,
+    )
+    return msg.model_dump(exclude_none=True)
+
+
+def build_duplicate_name_resolved_message(
+    cluster: str,
+    original_name: str,
+    resolved_name: str,
+    vmid: int,
+    suffix_index: int,
+    operator_renamed: bool = False,
+) -> dict[str, Any]:
+    """Build a `duplicate_name_resolved` warning frame."""
+    msg = DuplicateNameResolvedMessage(
+        cluster=cluster,
+        original_name=original_name,
+        resolved_name=resolved_name,
+        vmid=vmid,
+        suffix_index=suffix_index,
+        operator_renamed=operator_renamed,
     )
     return msg.model_dump(exclude_none=True)
 

--- a/proxbox_api/services/name_collision.py
+++ b/proxbox_api/services/name_collision.py
@@ -1,0 +1,147 @@
+"""VM name collision resolver.
+
+Deterministic helper for assigning NetBox-unique VM names within a single
+NetBox cluster. Two responsibilities:
+
+1.  Pick the smallest free ``" (N)"`` suffix for a candidate name given the
+    set of names already taken in the target NetBox cluster.
+2.  Detect operator renames: if NetBox already has a ``VirtualMachine`` whose
+    ``custom_fields.proxmox_vm_id`` matches the incoming VMID and whose
+    current ``name`` is neither the bare candidate nor any algorithmic suffix
+    of it, preserve the operator's name instead of renaming back.
+
+Name matching is case-insensitive (``str.casefold``) so we never produce two
+NetBox records that differ only by letter case in the same cluster. The
+returned ``resolved_name`` preserves the candidate's original casing for
+human-facing display.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from proxbox_api.logger import logger
+
+
+@dataclass(frozen=True)
+class NameResolution:
+    """Result of a name-collision lookup for one VM."""
+
+    resolved_name: str
+    original_name: str
+    suffix_index: int
+    is_collision: bool
+    operator_renamed: bool
+
+
+_SUFFIX_RE = re.compile(r"^(?P<base>.+?) \((?P<n>\d+)\)$")
+
+
+def _is_algorithmic_variant(name: str, candidate: str) -> bool:
+    """Return True if ``name`` is ``candidate`` or any ``candidate (N)`` form."""
+    name_cf = name.casefold()
+    cand_cf = candidate.casefold()
+    if name_cf == cand_cf:
+        return True
+    match = _SUFFIX_RE.match(name)
+    if not match:
+        return False
+    return match.group("base").casefold() == cand_cf
+
+
+def _pick_suffix(candidate: str, used_names_in_cluster: set[str]) -> tuple[str, int]:
+    """Return ``(resolved_name, suffix_index)`` for ``candidate``.
+
+    ``suffix_index == 1`` means no suffix was needed. ``2`` produces
+    ``"name (2)"``, ``3`` produces ``"name (3)"``, and so on. Matching against
+    ``used_names_in_cluster`` is case-insensitive; the resolved name preserves
+    the candidate's original casing.
+    """
+    used_cf = {n.casefold() for n in used_names_in_cluster}
+    if candidate.casefold() not in used_cf:
+        return candidate, 1
+    n = 2
+    while True:
+        proposed = f"{candidate} ({n})"
+        if proposed.casefold() not in used_cf:
+            return proposed, n
+        n += 1
+
+
+async def resolve_unique_vm_name(
+    nb: object,
+    *,
+    netbox_cluster_id: int | None,
+    proxmox_cluster_name: str,
+    candidate: str,
+    proxmox_vmid: int,
+    used_names_in_cluster: set[str],
+    existing_vm_by_vmid: dict[int, dict] | None = None,
+) -> NameResolution:
+    """Resolve a deterministic, NetBox-unique VM name within one NetBox cluster.
+
+    Parameters
+    ----------
+    nb:
+        NetBox client session. Unused when ``existing_vm_by_vmid`` is supplied;
+        kept in the signature so individual-sync callers can pass a session and
+        defer the lookup if they want.
+    netbox_cluster_id:
+        NetBox cluster id the VM will land in. ``None`` skips operator-rename
+        detection (cluster mapping not yet resolved).
+    proxmox_cluster_name:
+        Proxmox cluster label, used purely for SSE telemetry.
+    candidate:
+        Bare Proxmox VM name.
+    proxmox_vmid:
+        Proxmox VMID, used to look up the NetBox record for operator-rename
+        detection.
+    used_names_in_cluster:
+        Mutable set of names already claimed in the same NetBox cluster during
+        this sync pass. Callers must pre-populate it with NetBox-side names
+        (filtering out the record this VMID currently owns, if any) and the
+        helper registers the result before returning.
+    existing_vm_by_vmid:
+        Optional pre-built ``{vmid: vm_dict}`` map. When provided, the helper
+        consults it instead of touching ``nb``. Bulk callers always pass this
+        from the pre-loaded snapshot.
+
+    Returns
+    -------
+    NameResolution
+        ``operator_renamed`` is True iff the NetBox record at ``proxmox_vmid``
+        has a custom name that does not look algorithmic. In that case the
+        caller should emit a warning frame and skip the rename.
+    """
+    del nb  # operator-rename lookup uses the pre-built snapshot only
+
+    existing = (existing_vm_by_vmid or {}).get(proxmox_vmid)
+    operator_renamed = False
+    if existing is not None and netbox_cluster_id is not None:
+        existing_name = str(existing.get("name", ""))
+        if existing_name and not _is_algorithmic_variant(existing_name, candidate):
+            used_names_in_cluster.add(existing_name)
+            logger.info(
+                "name_collision: operator-renamed VM detected vmid=%s candidate=%r netbox_name=%r",
+                proxmox_vmid,
+                candidate,
+                existing_name,
+            )
+            return NameResolution(
+                resolved_name=existing_name,
+                original_name=candidate,
+                suffix_index=1,
+                is_collision=False,
+                operator_renamed=True,
+            )
+
+    resolved, idx = _pick_suffix(candidate, used_names_in_cluster)
+    used_names_in_cluster.add(resolved)
+    return NameResolution(
+        resolved_name=resolved,
+        original_name=candidate,
+        suffix_index=idx,
+        is_collision=idx > 1,
+        operator_renamed=operator_renamed,
+    )

--- a/proxbox_api/services/sync/individual/vm_sync.py
+++ b/proxbox_api/services/sync/individual/vm_sync.py
@@ -14,6 +14,7 @@ from proxbox_api.proxmox_to_netbox.models import (
     NetBoxVirtualMachineCreateBody,
 )
 from proxbox_api.schemas.sync import SyncOverwriteFlags
+from proxbox_api.services.name_collision import resolve_unique_vm_name
 from proxbox_api.services.proxmox_helpers import (
     get_vm_config_individual,
     get_vm_resource_individual,
@@ -51,6 +52,71 @@ def _as_bool(value: object) -> bool:
     if isinstance(value, str):
         return value.strip().lower() in {"1", "true", "yes", "on"}
     return False
+
+
+async def _apply_name_collision_resolution(
+    nb: object,
+    *,
+    cluster_id: int,
+    cluster_name: str,
+    vmid: int,
+    netbox_vm_payload: dict,
+) -> None:
+    """Resolve VM name collisions in-place on `netbox_vm_payload`.
+
+    Fetches existing VMs in the NetBox cluster, builds the used-name set and
+    vmid lookup, strips this VM's current name to keep idempotency, then
+    delegates to `resolve_unique_vm_name` and updates the payload's `name`
+    when a rename is needed.
+    """
+    cluster_vms = await rest_list_async(
+        nb,
+        "/api/virtualization/virtual-machines/",
+        query={"cluster_id": cluster_id, "limit": 0},
+    )
+    used_names_in_cluster: set[str] = set()
+    existing_vm_by_vmid: dict[int, dict] = {}
+    for vm in cluster_vms or []:
+        vm_dict = vm if isinstance(vm, dict) else getattr(vm, "__dict__", {})
+        vm_name = vm_dict.get("name") if isinstance(vm_dict, dict) else None
+        if isinstance(vm_name, str) and vm_name:
+            used_names_in_cluster.add(vm_name)
+        cf = vm_dict.get("custom_fields") if isinstance(vm_dict, dict) else None
+        if isinstance(cf, dict):
+            try:
+                raw_vmid = int(str(cf.get("proxmox_vm_id") or 0).strip())
+            except (TypeError, ValueError):
+                raw_vmid = 0
+            if raw_vmid:
+                existing_vm_by_vmid[raw_vmid] = vm_dict
+    if existing_vm_by_vmid.get(vmid):
+        current_name = existing_vm_by_vmid[vmid].get("name")
+        if isinstance(current_name, str):
+            used_names_in_cluster.discard(current_name)
+
+    candidate_name = str(netbox_vm_payload.get("name") or "")
+    if not candidate_name:
+        return
+    resolution = await resolve_unique_vm_name(
+        nb,
+        netbox_cluster_id=cluster_id,
+        proxmox_cluster_name=cluster_name,
+        candidate=candidate_name,
+        proxmox_vmid=vmid,
+        used_names_in_cluster=used_names_in_cluster,
+        existing_vm_by_vmid=existing_vm_by_vmid,
+    )
+    if resolution.resolved_name != candidate_name:
+        logger.info(
+            "name_collision (individual): cluster=%s vmid=%s %r -> %r (suffix=%s, operator=%s)",
+            cluster_name,
+            vmid,
+            resolution.original_name,
+            resolution.resolved_name,
+            resolution.suffix_index,
+            resolution.operator_renamed,
+        )
+        netbox_vm_payload["name"] = resolution.resolved_name
 
 
 def _build_netbox_vm_payload(
@@ -286,6 +352,14 @@ async def sync_vm_individual(
         )
         netbox_version = await detect_netbox_version(nb)
         supports_vm_type = supports_virtual_machine_type(netbox_version)
+
+        await _apply_name_collision_resolution(
+            nb,
+            cluster_id=cluster_id,
+            cluster_name=cluster_name,
+            vmid=vmid,
+            netbox_vm_payload=netbox_vm_payload,
+        )
 
         virtual_machine = await rest_reconcile_async(
             nb,

--- a/proxbox_api/utils/streaming.py
+++ b/proxbox_api/utils/streaming.py
@@ -12,6 +12,7 @@ from proxbox_api.schemas.stream_messages import (
     ItemOperation,
     SubstepStatus,
     build_discovery_message,
+    build_duplicate_name_resolved_message,
     build_error_detail_message,
     build_item_progress_message,
     build_phase_summary_message,
@@ -286,6 +287,35 @@ class WebSocketSSEBridge:
             traceback=traceback,
         )
         await self._queue.put(("error_detail", msg))
+
+    async def emit_duplicate_name_resolved(
+        self,
+        cluster: str,
+        original_name: str,
+        resolved_name: str,
+        vmid: int,
+        suffix_index: int,
+        operator_renamed: bool = False,
+    ) -> None:
+        """Emit a `duplicate_name_resolved` warning frame.
+
+        Args:
+            cluster: Proxmox cluster name (human label)
+            original_name: Candidate VM name from Proxmox
+            resolved_name: Final name written to NetBox
+            vmid: Proxmox VMID
+            suffix_index: 1 = no algorithmic suffix (operator-rename); 2+ = suffix applied
+            operator_renamed: True when the NetBox record was already manually renamed
+        """
+        msg = build_duplicate_name_resolved_message(
+            cluster=cluster,
+            original_name=original_name,
+            resolved_name=resolved_name,
+            vmid=vmid,
+            suffix_index=suffix_index,
+            operator_renamed=operator_renamed,
+        )
+        await self._queue.put(("duplicate_name_resolved", msg))
 
     # Legacy helper methods (preserved for compatibility)
 

--- a/tests/test_name_collision.py
+++ b/tests/test_name_collision.py
@@ -1,0 +1,173 @@
+"""Unit tests for the VM name collision resolver."""
+
+from __future__ import annotations
+
+import pytest
+
+from proxbox_api.services.name_collision import (
+    NameResolution,
+    _is_algorithmic_variant,
+    _pick_suffix,
+    resolve_unique_vm_name,
+)
+
+
+class TestPickSuffix:
+    def test_no_collision_keeps_bare_name(self):
+        assert _pick_suffix("gateway", set()) == ("gateway", 1)
+
+    def test_first_collision_appends_two(self):
+        assert _pick_suffix("gateway", {"gateway"}) == ("gateway (2)", 2)
+
+    def test_second_collision_appends_three(self):
+        assert _pick_suffix("gateway", {"gateway", "gateway (2)"}) == ("gateway (3)", 3)
+
+    def test_finds_first_free_index(self):
+        assert _pick_suffix(
+            "gateway",
+            {"gateway", "gateway (2)", "gateway (4)"},
+        ) == ("gateway (3)", 3)
+
+    def test_case_insensitive_match_preserves_candidate_casing(self):
+        resolved, idx = _pick_suffix("Gateway", {"gateway"})
+        assert resolved == "Gateway (2)"
+        assert idx == 2
+
+    def test_unicode_candidate(self):
+        assert _pick_suffix("máquina", {"MÁQUINA"}) == ("máquina (2)", 2)
+
+    def test_long_collision_chain_terminates(self):
+        used = {"vm" if i == 1 else f"vm ({i})" for i in range(1, 6)}
+        used.add("vm")
+        assert _pick_suffix("vm", used) == ("vm (6)", 6)
+
+
+class TestIsAlgorithmicVariant:
+    def test_bare_match_is_algorithmic(self):
+        assert _is_algorithmic_variant("gateway", "gateway") is True
+
+    def test_suffixed_match_is_algorithmic(self):
+        assert _is_algorithmic_variant("gateway (2)", "gateway") is True
+        assert _is_algorithmic_variant("gateway (10)", "gateway") is True
+
+    def test_case_insensitive(self):
+        assert _is_algorithmic_variant("Gateway (2)", "gateway") is True
+
+    def test_unrelated_name_not_algorithmic(self):
+        assert _is_algorithmic_variant("gateway-prod", "gateway") is False
+        assert _is_algorithmic_variant("gw", "gateway") is False
+
+    def test_non_integer_suffix_not_algorithmic(self):
+        assert _is_algorithmic_variant("gateway (prod)", "gateway") is False
+
+
+@pytest.mark.asyncio
+class TestResolveUniqueVmName:
+    async def test_no_collision_returns_bare_name(self):
+        used: set[str] = set()
+        resolution = await resolve_unique_vm_name(
+            None,
+            netbox_cluster_id=1,
+            proxmox_cluster_name="cluster-a",
+            candidate="gateway",
+            proxmox_vmid=100,
+            used_names_in_cluster=used,
+            existing_vm_by_vmid={},
+        )
+        assert isinstance(resolution, NameResolution)
+        assert resolution.resolved_name == "gateway"
+        assert resolution.suffix_index == 1
+        assert resolution.is_collision is False
+        assert resolution.operator_renamed is False
+        assert "gateway" in used
+
+    async def test_collision_appends_suffix(self):
+        used: set[str] = {"gateway"}
+        resolution = await resolve_unique_vm_name(
+            None,
+            netbox_cluster_id=1,
+            proxmox_cluster_name="cluster-a",
+            candidate="gateway",
+            proxmox_vmid=101,
+            used_names_in_cluster=used,
+            existing_vm_by_vmid={},
+        )
+        assert resolution.resolved_name == "gateway (2)"
+        assert resolution.suffix_index == 2
+        assert resolution.is_collision is True
+        assert resolution.operator_renamed is False
+        assert "gateway (2)" in used
+
+    async def test_operator_rename_is_preserved(self):
+        used: set[str] = set()
+        resolution = await resolve_unique_vm_name(
+            None,
+            netbox_cluster_id=1,
+            proxmox_cluster_name="cluster-a",
+            candidate="gateway",
+            proxmox_vmid=100,
+            used_names_in_cluster=used,
+            existing_vm_by_vmid={100: {"name": "gateway-prod"}},
+        )
+        assert resolution.resolved_name == "gateway-prod"
+        assert resolution.operator_renamed is True
+        assert resolution.is_collision is False
+        assert resolution.suffix_index == 1
+        assert "gateway-prod" in used
+
+    async def test_algorithmic_existing_name_not_treated_as_operator_rename(self):
+        used: set[str] = {"gateway"}
+        resolution = await resolve_unique_vm_name(
+            None,
+            netbox_cluster_id=1,
+            proxmox_cluster_name="cluster-a",
+            candidate="gateway",
+            proxmox_vmid=200,
+            used_names_in_cluster=used,
+            existing_vm_by_vmid={200: {"name": "gateway (2)"}},
+        )
+        assert resolution.operator_renamed is False
+        assert resolution.resolved_name == "gateway (2)"
+        assert resolution.suffix_index == 2
+        assert resolution.is_collision is True
+
+    async def test_idempotent_across_runs(self):
+        # First sync.
+        used1: set[str] = set()
+        first = await resolve_unique_vm_name(
+            None,
+            netbox_cluster_id=1,
+            proxmox_cluster_name="cluster-a",
+            candidate="gateway",
+            proxmox_vmid=100,
+            used_names_in_cluster=used1,
+            existing_vm_by_vmid={},
+        )
+        # Second sync — same input, caller still seeds used set from snapshot
+        # but excludes the record this VMID owns.
+        used2: set[str] = set()  # snapshot trimmed of self
+        second = await resolve_unique_vm_name(
+            None,
+            netbox_cluster_id=1,
+            proxmox_cluster_name="cluster-a",
+            candidate="gateway",
+            proxmox_vmid=100,
+            used_names_in_cluster=used2,
+            existing_vm_by_vmid={100: {"name": "gateway"}},
+        )
+        assert first.resolved_name == second.resolved_name == "gateway"
+        assert second.operator_renamed is False
+
+    async def test_no_cluster_skips_operator_rename(self):
+        used: set[str] = set()
+        resolution = await resolve_unique_vm_name(
+            None,
+            netbox_cluster_id=None,
+            proxmox_cluster_name="cluster-a",
+            candidate="gateway",
+            proxmox_vmid=100,
+            used_names_in_cluster=used,
+            existing_vm_by_vmid={100: {"name": "gateway-prod"}},
+        )
+        assert resolution.operator_renamed is False
+        assert resolution.resolved_name == "gateway"


### PR DESCRIPTION
## Summary

Implements deterministic VM name collision resolution and a typed `duplicate_name_resolved` SSE frame. Closes the proxbox-api half of emersonfelipesp/netbox-proxbox#368.

- New resolver in `proxbox_api/services/name_collision.py` (`NameResolution`, `_pick_suffix`, `_is_algorithmic_variant`, `resolve_unique_vm_name`). Case-insensitive matching, preserves candidate casing, respects operator renames via `custom_fields.proxmox_vm_id`.
- Bulk wire-in (`_resolve_vm_names_pre_pass`) in `routes/.../sync_vm.py`: groups prepared VMs by NetBox cluster id, sorts deterministically by `(cluster_name.casefold(), vmid)`, strips self-owned name from used set for idempotency, rewrites `desired_payload["name"]`, and emits one `duplicate_name_resolved` SSE frame per renamed VM.
- Individual wire-in via `_apply_name_collision_resolution` in `services/sync/individual/vm_sync.py`.
- SSE schema mirror prep on this side: `StreamMessageType.DUPLICATE_NAME_RESOLVED`, `DuplicateNameResolvedMessage`, `build_duplicate_name_resolved_message`, and `WebSocketSSEBridge.emit_duplicate_name_resolved`.
- Docs: `docs/sync/name-collision-resolver.md` + pt-BR mirror, cross-linked from `workflows.md`.

The netbox-proxbox companion PR adds the matching `SseEventType` enum, `SseDuplicateNameResolvedPayload`, contract entries, and the canary `_PAYLOAD_PAIRS` tuple.

## Test plan

- [x] `uv run ruff check` on touched files
- [x] `uv run ruff format --check` on touched files
- [x] `uv run python -m compileall proxbox_api tests`
- [x] `uv run ty check proxbox_api/types proxbox_api/utils/retry.py proxbox_api/schemas/sync.py`
- [x] `uv run --extra test pytest tests/test_name_collision.py tests/test_streaming_detailed_messages.py tests/test_vm_sync.py tests/test_individual_sync.py` — 46 passed
- [ ] Manual smoke against the live dev stack: trigger a sync with two same-named VMs in one cluster and confirm one becomes `gateway (2)`; verify `duplicate_name_resolved` frames appear in the SSE log