### PR TITLE
feat(#365): exclude tenant from VM patchable fields

### DIFF
--- a/proxbox_api/services/sync/vm_helpers.py
+++ b/proxbox_api/services/sync/vm_helpers.py
@@ -16,13 +16,18 @@ def _compute_vm_patchable_fields(
     *,
     supports_virtual_machine_type_field: bool = True,
 ) -> set[str]:
-    """Build the patchable_fields allowlist for virtual machine reconciliation."""
+    """Build the patchable_fields allowlist for virtual machine reconciliation.
+
+    `tenant` is intentionally excluded so that the netbox-proxbox plugin's
+    VM-name-regex tenant resolver (issue #365) can write `vm.tenant` after
+    create without being stomped on every re-sync. proxbox-api still sets
+    tenant on initial create via the create body, but never patches it.
+    """
     fields: set[str] = {
         "name",
         "cluster",
         "device",
         "site",
-        "tenant",
         "vcpus",
         "memory",
         "disk",

--- a/tests/test_patchable_fields.py
+++ b/tests/test_patchable_fields.py
@@ -337,12 +337,13 @@ def test_vm_patchable_defaults_include_all_overwriteable_keys() -> None:
 
     fields = _compute_vm_patchable_fields(SyncOverwriteFlags())
 
+    # `tenant` is intentionally excluded (issue #365). See
+    # test_vm_patchable_never_includes_tenant_* below.
     assert fields == {
         "name",
         "cluster",
         "device",
         "site",
-        "tenant",
         "vcpus",
         "memory",
         "disk",
@@ -406,3 +407,51 @@ def test_vm_patchable_drops_key_when_schema_flag_false(flag_name: str, missing_k
 
     assert missing_key not in fields
     assert {"name", "cluster", "device", "vcpus", "memory", "disk", "status"}.issubset(fields)
+
+
+# ---------------------------------------------------------------------------
+# Issue #365 — Plugin owns tenant assignment by VM-name regex. proxbox-api
+# MUST NOT include `tenant` in the patchable allowlist or the create body,
+# otherwise the plugin's tenant write would be stomped on every re-sync.
+# ---------------------------------------------------------------------------
+
+
+def test_vm_patchable_never_includes_tenant_default_flags() -> None:
+    from proxbox_api.services.sync.vm_helpers import _compute_vm_patchable_fields
+
+    assert "tenant" not in _compute_vm_patchable_fields(SyncOverwriteFlags())
+
+
+def test_vm_patchable_never_includes_tenant_legacy_none() -> None:
+    from proxbox_api.services.sync.vm_helpers import _compute_vm_patchable_fields
+
+    assert "tenant" not in _compute_vm_patchable_fields(None)
+
+
+@pytest.mark.parametrize(
+    "flag_name",
+    [
+        "overwrite_vm_type",
+        "overwrite_vm_role",
+        "overwrite_vm_tags",
+        "overwrite_vm_description",
+        "overwrite_vm_custom_fields",
+    ],
+)
+def test_vm_patchable_never_includes_tenant_with_any_flag_false(flag_name: str) -> None:
+    from proxbox_api.services.sync.vm_helpers import _compute_vm_patchable_fields
+
+    assert "tenant" not in _compute_vm_patchable_fields(SyncOverwriteFlags(**{flag_name: False}))
+
+
+def test_vm_create_body_accepts_tenant_for_initial_create() -> None:
+    """CreateBody allows `tenant` so proxbox-api can set it once on create.
+
+    The plugin's regex resolver (issue #365) only fires post-create and
+    never overwrites an existing `vm.tenant`, so initial create-time
+    assignment from the Proxmox endpoint config is safe.
+    """
+    from proxbox_api.proxmox_to_netbox.models import NetBoxVirtualMachineCreateBody
+
+    body = NetBoxVirtualMachineCreateBody(name="vm-1", status="active", tenant=42)
+    assert body.tenant == 42


### PR DESCRIPTION
## Summary

Pairs with [emersonfelipesp/netbox-proxbox#365](https://github.com/emersonfelipesp/netbox-proxbox/issues/365): the plugin owns VM tenant assignment via VM-name regex. proxbox-api must not patch `tenant` on re-syncs, otherwise the plugin's write would be stomped.

- Remove `"tenant"` from `_compute_vm_patchable_fields` in `proxbox_api/services/sync/vm_helpers.py`.
- `tenant` remains in `NetBoxVirtualMachineCreateBody` so proxbox-api can still set it once on initial create from the `ProxmoxEndpoint`'s configured tenant (handled by `_resolve_tenant`).
- After create, the plugin's regex resolver runs and never overwrites an existing `vm.tenant`.
- 7 regression tests in `tests/test_patchable_fields.py` pin the exclusion across default flags, legacy `None` flags, and every `overwrite_vm_*` flag combination, plus a positive test confirming the CreateBody accepts `tenant` for initial assignment.

## Test plan

- [ ] CI green
- [ ] `pytest tests/test_patchable_fields.py -v` passes locally (36 tests; 8 new for #365)
- [ ] Full suite green: `pytest tests/ --ignore=tests/e2e` (4318 passed locally)
- [ ] No downstream sync path passes `tenant` via `patchable_fields` (verified by grep + tests)
