### PR TITLE
feat(#71): add GET /sync/active soft probe + in-flight sync registry

### DIFF
--- a/docs/api/http-reference.md
+++ b/docs/api/http-reference.md
@@ -246,6 +246,28 @@ See [Overwrite Flags](../sync/overwrite-flags.md) for the full matrix and defaul
 - `GET /full-update` - Runs device sync, storage sync, VM sync, task history sync, disk sync, backup sync, snapshot sync, node interface sync, VM interface sync, VM IP sync, replication sync, and backup routine sync.
 - `GET /full-update/stream` - SSE streaming variant.
 
+## Sync State Probe
+
+- `GET /sync/active` - Returns `{ active, started_at, id, kind, runs }` reporting whether this API replica currently has a `/full-update` or `/full-update/stream` request in flight. Use this to fast-fail a cron / single-exec invocation when a sync is already running.
+
+The registry is **process-local and memory-only**, so the probe answers for the worker that handles the request. With multiple uvicorn workers, callers may see disagreeing answers across workers; treat the response as advisory and keep the scheduling interval larger than the typical sync duration. The endpoint is covered by the standard `X-Proxbox-API-Key` middleware.
+
+Response shape:
+
+```json
+{
+  "active": true,
+  "started_at": "2026-05-12T17:53:28.122Z",
+  "id": "9b6c0408-...",
+  "kind": "full-update",
+  "runs": [
+    { "id": "9b6c0408-...", "kind": "full-update", "started_at": "2026-05-12T17:53:28.122Z" }
+  ]
+}
+```
+
+`started_at` / `id` / `kind` report the oldest in-flight run (FIFO). `runs` lists every registered run on the local replica for diagnostics.
+
 ## WebSocket
 
 - `GET /` - Basic counter WebSocket for connectivity checks.

--- a/proxbox_api/app/CLAUDE.md
+++ b/proxbox_api/app/CLAUDE.md
@@ -14,7 +14,8 @@ Application factory and lifecycle management for the `proxbox-api` FastAPI servi
 | `exceptions.py` | Registers exception handlers that convert `ProxboxException` into structured HTTP error responses. |
 | `cache_routes.py` | Cache control and invalidation API endpoints (`/cache/*`). |
 | `websockets.py` | WebSocket connection manager — tracks active connections and broadcasts sync progress messages. |
-| `full_update.py` | `POST /full-update` endpoint — orchestrates a full Proxmox-to-NetBox sync run with SSE or WebSocket streaming. |
+| `full_update.py` | `POST /full-update` endpoint — orchestrates a full Proxmox-to-NetBox sync run with SSE or WebSocket streaming. Each handler registers its `operation_id` via `sync_state` so `GET /sync/active` reflects in-flight work. |
+| `sync_state.py` | Process-local registry of in-flight sync runs. Exposes `register_active_sync` (async context manager), `acquire_active_sync` / `release_active_sync` (for non-`with` call sites), and `get_active_sync` / `is_active` for the `/sync/active` probe. |
 | `root_meta.py` | Root metadata router — version, health, and standalone-mode info endpoints. |
 | `netbox_session.py` | Helpers for retrieving the raw NetBox session outside of dependency injection. |
 | `__init__.py` | Re-exports `create_app` for import convenience. |

--- a/proxbox_api/app/factory.py
+++ b/proxbox_api/app/factory.py
@@ -41,6 +41,7 @@ from proxbox_api.routes.proxmox.ha import router as px_ha_router
 from proxbox_api.routes.proxmox.nodes import router as px_nodes_router
 from proxbox_api.routes.proxmox.replication import router as px_replication_router
 from proxbox_api.routes.proxmox.runtime_generated import register_generated_proxmox_routes
+from proxbox_api.routes.sync.active import router as sync_active_router
 from proxbox_api.routes.sync.individual import router as sync_individual_router
 from proxbox_api.routes.virtualization import router as virtualization_router
 from proxbox_api.routes.virtualization.virtual_machines import router as virtual_machines_router
@@ -402,5 +403,6 @@ def create_app() -> FastAPI:
     app.include_router(
         sync_individual_router, prefix="/sync/individual", tags=["sync / individual"]
     )
+    app.include_router(sync_active_router)
 
     return app

--- a/proxbox_api/app/full_update.py
+++ b/proxbox_api/app/full_update.py
@@ -9,6 +9,11 @@ import uuid
 from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
 
+from proxbox_api.app.sync_state import (
+    acquire_active_sync,
+    register_active_sync,
+    release_active_sync,
+)
 from proxbox_api.dependencies import (
     NetBoxSessionDep,
     ProxboxTagDep,
@@ -99,254 +104,258 @@ async def full_update_sync(  # noqa: C901
     set_operation_id(operation_id)
     logger.info("Starting full_update sync", extra={"operation_id": operation_id})
 
+    _active_entry = await acquire_active_sync(operation_id, kind="full-update")
     try:
-        sync_nodes = await create_proxmox_devices(
-            netbox_session=netbox_session,
-            clusters_status=cluster_status,
-            node=None,
-            tag=tag,
-            use_websocket=False,
-            overwrite_device_role=overwrite_flags.overwrite_device_role,
-            overwrite_device_type=overwrite_flags.overwrite_device_type,
-            overwrite_device_tags=overwrite_flags.overwrite_device_tags,
-            overwrite_flags=overwrite_flags,
-        )
-    except ProxboxException:
-        raise
-    except Exception as error:  # noqa: BLE001
-        logger.exception("Error while syncing nodes during full-update")
-        raise ProxboxException(
-            message="Error while syncing nodes.", python_exception=str(error)
-        ) from error
+        try:
+            sync_nodes = await create_proxmox_devices(
+                netbox_session=netbox_session,
+                clusters_status=cluster_status,
+                node=None,
+                tag=tag,
+                use_websocket=False,
+                overwrite_device_role=overwrite_flags.overwrite_device_role,
+                overwrite_device_type=overwrite_flags.overwrite_device_type,
+                overwrite_device_tags=overwrite_flags.overwrite_device_tags,
+                overwrite_flags=overwrite_flags,
+            )
+        except ProxboxException:
+            raise
+        except Exception as error:  # noqa: BLE001
+            logger.exception("Error while syncing nodes during full-update")
+            raise ProxboxException(
+                message="Error while syncing nodes.", python_exception=str(error)
+            ) from error
 
-    try:
-        sync_storage = await create_storages(
-            netbox_session=netbox_session,
-            pxs=pxs,
-            tag=tag,
-            use_websocket=False,
-            fetch_concurrency=fetch_max_concurrency if fetch_max_concurrency is not None else 8,
-            overwrite_flags=overwrite_flags,
-        )
-    except ProxboxException:
-        raise
-    except Exception as error:  # noqa: BLE001
-        logger.exception("Error while syncing storages during full-update")
-        raise ProxboxException(
-            message="Error while syncing storages.",
-            python_exception=str(error),
-        ) from error
+        try:
+            sync_storage = await create_storages(
+                netbox_session=netbox_session,
+                pxs=pxs,
+                tag=tag,
+                use_websocket=False,
+                fetch_concurrency=fetch_max_concurrency if fetch_max_concurrency is not None else 8,
+                overwrite_flags=overwrite_flags,
+            )
+        except ProxboxException:
+            raise
+        except Exception as error:  # noqa: BLE001
+            logger.exception("Error while syncing storages during full-update")
+            raise ProxboxException(
+                message="Error while syncing storages.",
+                python_exception=str(error),
+            ) from error
 
-    try:
-        sync_vms = await create_virtual_machines(
-            netbox_session=netbox_session,
-            pxs=pxs,
-            cluster_status=cluster_status,
-            cluster_resources=cluster_resources,
-            custom_fields=custom_fields,
-            tag=tag,
-            use_websocket=False,
-            sync_vm_network=False,
-            overwrite_vm_role=overwrite_flags.overwrite_vm_role,
-            overwrite_vm_type=overwrite_flags.overwrite_vm_type,
-            overwrite_vm_tags=overwrite_flags.overwrite_vm_tags,
-            overwrite_vm_description=overwrite_flags.overwrite_vm_description,
-            overwrite_vm_custom_fields=overwrite_flags.overwrite_vm_custom_fields,
-            overwrite_flags=overwrite_flags,
-        )
-    except ProxboxException:
-        raise
-    except Exception as error:  # noqa: BLE001
-        logger.exception("Error while syncing virtual machines during full-update")
-        raise ProxboxException(
-            message="Error while syncing virtual machines.",
-            python_exception=str(error),
-        ) from error
+        try:
+            sync_vms = await create_virtual_machines(
+                netbox_session=netbox_session,
+                pxs=pxs,
+                cluster_status=cluster_status,
+                cluster_resources=cluster_resources,
+                custom_fields=custom_fields,
+                tag=tag,
+                use_websocket=False,
+                sync_vm_network=False,
+                overwrite_vm_role=overwrite_flags.overwrite_vm_role,
+                overwrite_vm_type=overwrite_flags.overwrite_vm_type,
+                overwrite_vm_tags=overwrite_flags.overwrite_vm_tags,
+                overwrite_vm_description=overwrite_flags.overwrite_vm_description,
+                overwrite_vm_custom_fields=overwrite_flags.overwrite_vm_custom_fields,
+                overwrite_flags=overwrite_flags,
+            )
+        except ProxboxException:
+            raise
+        except Exception as error:  # noqa: BLE001
+            logger.exception("Error while syncing virtual machines during full-update")
+            raise ProxboxException(
+                message="Error while syncing virtual machines.",
+                python_exception=str(error),
+            ) from error
 
-    try:
-        sync_task_history = await sync_all_virtual_machine_task_histories(
-            netbox_session=netbox_session,
-            pxs=pxs,
-            cluster_status=cluster_status,
-            tag_refs=tag_refs,
-        )
-    except ProxboxException:
-        raise
-    except Exception as error:  # noqa: BLE001
-        logger.exception("Error while syncing task history during full-update")
-        raise ProxboxException(
-            message="Error while syncing task history.",
-            python_exception=str(error),
-        ) from error
+        try:
+            sync_task_history = await sync_all_virtual_machine_task_histories(
+                netbox_session=netbox_session,
+                pxs=pxs,
+                cluster_status=cluster_status,
+                tag_refs=tag_refs,
+            )
+        except ProxboxException:
+            raise
+        except Exception as error:  # noqa: BLE001
+            logger.exception("Error while syncing task history during full-update")
+            raise ProxboxException(
+                message="Error while syncing task history.",
+                python_exception=str(error),
+            ) from error
 
-    try:
-        sync_disks = await create_virtual_disks(
-            netbox_session=netbox_session,
-            pxs=pxs,
-            cluster_status=cluster_status,
-            cluster_resources=cluster_resources,
-            tag=tag,
-            use_websocket=False,
-            use_css=False,
-        )
-    except ProxboxException:
-        raise
-    except Exception as error:  # noqa: BLE001
-        logger.exception("Error while syncing virtual disks during full-update")
-        raise ProxboxException(
-            message="Error while syncing virtual disks.",
-            python_exception=str(error),
-        ) from error
+        try:
+            sync_disks = await create_virtual_disks(
+                netbox_session=netbox_session,
+                pxs=pxs,
+                cluster_status=cluster_status,
+                cluster_resources=cluster_resources,
+                tag=tag,
+                use_websocket=False,
+                use_css=False,
+            )
+        except ProxboxException:
+            raise
+        except Exception as error:  # noqa: BLE001
+            logger.exception("Error while syncing virtual disks during full-update")
+            raise ProxboxException(
+                message="Error while syncing virtual disks.",
+                python_exception=str(error),
+            ) from error
 
-    try:
-        sync_backups = await create_all_virtual_machine_backups(
-            netbox_session=netbox_session,
-            pxs=pxs,
-            cluster_status=cluster_status,
-            tag=tag,
-            delete_nonexistent_backup=True,
-            fetch_max_concurrency=fetch_max_concurrency,
-        )
-    except ProxboxException:
-        raise
-    except Exception as error:  # noqa: BLE001
-        logger.exception("Error while syncing backups during full-update")
-        raise ProxboxException(
-            message="Error while syncing backups.",
-            python_exception=str(error),
-        ) from error
+        try:
+            sync_backups = await create_all_virtual_machine_backups(
+                netbox_session=netbox_session,
+                pxs=pxs,
+                cluster_status=cluster_status,
+                tag=tag,
+                delete_nonexistent_backup=True,
+                fetch_max_concurrency=fetch_max_concurrency,
+            )
+        except ProxboxException:
+            raise
+        except Exception as error:  # noqa: BLE001
+            logger.exception("Error while syncing backups during full-update")
+            raise ProxboxException(
+                message="Error while syncing backups.",
+                python_exception=str(error),
+            ) from error
 
-    try:
-        sync_snapshots = await create_all_virtual_machine_snapshots(
-            netbox_session=netbox_session,
-            pxs=pxs,
-            cluster_status=cluster_status,
-            cluster_resources=cluster_resources,
-            tag=tag,
-            fetch_max_concurrency=fetch_max_concurrency,
-        )
-    except ProxboxException:
-        raise
-    except Exception as error:  # noqa: BLE001
-        logger.exception("Error while syncing snapshots during full-update")
-        raise ProxboxException(
-            message="Error while syncing snapshots.",
-            python_exception=str(error),
-        ) from error
+        try:
+            sync_snapshots = await create_all_virtual_machine_snapshots(
+                netbox_session=netbox_session,
+                pxs=pxs,
+                cluster_status=cluster_status,
+                cluster_resources=cluster_resources,
+                tag=tag,
+                fetch_max_concurrency=fetch_max_concurrency,
+            )
+        except ProxboxException:
+            raise
+        except Exception as error:  # noqa: BLE001
+            logger.exception("Error while syncing snapshots during full-update")
+            raise ProxboxException(
+                message="Error while syncing snapshots.",
+                python_exception=str(error),
+            ) from error
 
-    try:
-        sync_node_interfaces = await create_all_device_interfaces(
-            netbox_session=netbox_session,
-            tag=tag,
-            clusters_status=cluster_status,
-            use_websocket=False,
-        )
-    except ProxboxException:
-        raise
-    except Exception as error:  # noqa: BLE001
-        logger.exception("Error while syncing node interfaces during full-update")
-        raise ProxboxException(
-            message="Error while syncing node interfaces.",
-            python_exception=str(error),
-        ) from error
+        try:
+            sync_node_interfaces = await create_all_device_interfaces(
+                netbox_session=netbox_session,
+                tag=tag,
+                clusters_status=cluster_status,
+                use_websocket=False,
+            )
+        except ProxboxException:
+            raise
+        except Exception as error:  # noqa: BLE001
+            logger.exception("Error while syncing node interfaces during full-update")
+            raise ProxboxException(
+                message="Error while syncing node interfaces.",
+                python_exception=str(error),
+            ) from error
 
-    try:
-        sync_vm_interfaces = await create_only_vm_interfaces(
-            netbox_session=netbox_session,
-            pxs=pxs,
-            cluster_status=cluster_status,
-            cluster_resources=cluster_resources,
-            custom_fields=custom_fields,
-            tag=tag,
-            use_websocket=False,
-            overwrite_flags=overwrite_flags,
-        )
-    except ProxboxException:
-        raise
-    except Exception as error:  # noqa: BLE001
-        logger.exception("Error while syncing VM interfaces during full-update")
-        raise ProxboxException(
-            message="Error while syncing VM interfaces.",
-            python_exception=str(error),
-        ) from error
+        try:
+            sync_vm_interfaces = await create_only_vm_interfaces(
+                netbox_session=netbox_session,
+                pxs=pxs,
+                cluster_status=cluster_status,
+                cluster_resources=cluster_resources,
+                custom_fields=custom_fields,
+                tag=tag,
+                use_websocket=False,
+                overwrite_flags=overwrite_flags,
+            )
+        except ProxboxException:
+            raise
+        except Exception as error:  # noqa: BLE001
+            logger.exception("Error while syncing VM interfaces during full-update")
+            raise ProxboxException(
+                message="Error while syncing VM interfaces.",
+                python_exception=str(error),
+            ) from error
 
-    try:
-        sync_vm_ip_addresses = await create_only_vm_ip_addresses(
-            netbox_session=netbox_session,
-            pxs=pxs,
-            cluster_status=cluster_status,
-            cluster_resources=cluster_resources,
-            custom_fields=custom_fields,
-            tag=tag,
-            use_websocket=False,
-            overwrite_flags=overwrite_flags,
-        )
-    except ProxboxException:
-        raise
-    except Exception as error:  # noqa: BLE001
-        logger.exception("Error while syncing VM IP addresses during full-update")
-        raise ProxboxException(
-            message="Error while syncing VM IP addresses.",
-            python_exception=str(error),
-        ) from error
+        try:
+            sync_vm_ip_addresses = await create_only_vm_ip_addresses(
+                netbox_session=netbox_session,
+                pxs=pxs,
+                cluster_status=cluster_status,
+                cluster_resources=cluster_resources,
+                custom_fields=custom_fields,
+                tag=tag,
+                use_websocket=False,
+                overwrite_flags=overwrite_flags,
+            )
+        except ProxboxException:
+            raise
+        except Exception as error:  # noqa: BLE001
+            logger.exception("Error while syncing VM IP addresses during full-update")
+            raise ProxboxException(
+                message="Error while syncing VM IP addresses.",
+                python_exception=str(error),
+            ) from error
 
-    try:
-        sync_replications = await sync_all_replications(
-            netbox_session=netbox_session,
-            pxs=pxs,
-        )
-    except ProxboxException:
-        raise
-    except Exception as error:  # noqa: BLE001
-        logger.exception("Error while syncing replications during full-update")
-        raise ProxboxException(
-            message="Error while syncing replications.",
-            python_exception=str(error),
-        ) from error
+        try:
+            sync_replications = await sync_all_replications(
+                netbox_session=netbox_session,
+                pxs=pxs,
+            )
+        except ProxboxException:
+            raise
+        except Exception as error:  # noqa: BLE001
+            logger.exception("Error while syncing replications during full-update")
+            raise ProxboxException(
+                message="Error while syncing replications.",
+                python_exception=str(error),
+            ) from error
 
-    try:
-        sync_backup_routines = await sync_all_backup_routines(
-            netbox_session=netbox_session,
-            pxs=pxs,
-        )
-    except ProxboxException:
-        raise
-    except Exception as error:  # noqa: BLE001
-        logger.exception("Error while syncing backup routines during full-update")
-        raise ProxboxException(
-            message="Error while syncing backup routines.",
-            python_exception=str(error),
-        ) from error
+        try:
+            sync_backup_routines = await sync_all_backup_routines(
+                netbox_session=netbox_session,
+                pxs=pxs,
+            )
+        except ProxboxException:
+            raise
+        except Exception as error:  # noqa: BLE001
+            logger.exception("Error while syncing backup routines during full-update")
+            raise ProxboxException(
+                message="Error while syncing backup routines.",
+                python_exception=str(error),
+            ) from error
 
-    return {
-        "status": "completed",
-        "devices": sync_nodes,
-        "storage": sync_storage,
-        "virtual_machines": sync_vms,
-        "virtual_disks": sync_disks,
-        "task_history": sync_task_history,
-        "backups": sync_backups,
-        "snapshots": sync_snapshots,
-        "replications": sync_replications,
-        "backup_routines": sync_backup_routines,
-        "node_interfaces": sync_node_interfaces,
-        "vm_interfaces": sync_vm_interfaces,
-        "vm_ip_addresses": sync_vm_ip_addresses,
-        "devices_count": len(sync_nodes),
-        "storage_count": len(sync_storage),
-        "virtual_machines_count": len(sync_vms),
-        "virtual_disks_count": _result_count(sync_disks),
-        "task_history_count": _result_count(sync_task_history),
-        "backups_count": len(sync_backups),
-        "snapshots_count": _result_count(sync_snapshots),
-        "replications_count": sync_replications.get("created", 0)
-        + sync_replications.get("updated", 0),
-        "backup_routines_count": sync_backup_routines.get("created", 0)
-        + sync_backup_routines.get("updated", 0),
-        "node_interfaces_count": len(sync_node_interfaces),
-        "vm_interfaces_count": len(sync_vm_interfaces),
-        "vm_ip_addresses_count": len(sync_vm_ip_addresses),
-    }
+        return {
+            "status": "completed",
+            "devices": sync_nodes,
+            "storage": sync_storage,
+            "virtual_machines": sync_vms,
+            "virtual_disks": sync_disks,
+            "task_history": sync_task_history,
+            "backups": sync_backups,
+            "snapshots": sync_snapshots,
+            "replications": sync_replications,
+            "backup_routines": sync_backup_routines,
+            "node_interfaces": sync_node_interfaces,
+            "vm_interfaces": sync_vm_interfaces,
+            "vm_ip_addresses": sync_vm_ip_addresses,
+            "devices_count": len(sync_nodes),
+            "storage_count": len(sync_storage),
+            "virtual_machines_count": len(sync_vms),
+            "virtual_disks_count": _result_count(sync_disks),
+            "task_history_count": _result_count(sync_task_history),
+            "backups_count": len(sync_backups),
+            "snapshots_count": _result_count(sync_snapshots),
+            "replications_count": sync_replications.get("created", 0)
+            + sync_replications.get("updated", 0),
+            "backup_routines_count": sync_backup_routines.get("created", 0)
+            + sync_backup_routines.get("updated", 0),
+            "node_interfaces_count": len(sync_node_interfaces),
+            "vm_interfaces_count": len(sync_vm_interfaces),
+            "vm_ip_addresses_count": len(sync_vm_ip_addresses),
+        }
+    finally:
+        await release_active_sync(_active_entry)
 
 
 @full_update_router.get("/full-update/stream", response_model=None)
@@ -415,649 +424,650 @@ async def full_update_sync_stream(  # noqa: C901
         set_operation_id(operation_id)
         logger.info("Starting full_update sync (stream)", extra={"operation_id": operation_id})
 
-        try:
-            yield sse_event("bootstrap_done", bootstrap_payload)
-            yield sse_event(
-                "step",
-                {
-                    "step": "stream",
-                    "status": "started",
-                    "message": f"Full update stream connected (operation_id={operation_id})",
-                },
-            )
-            stage_items = [
-                {"name": "devices", "type": "stage"},
-                {"name": "storage", "type": "stage"},
-                {"name": "virtual-machines", "type": "stage"},
-                {"name": "virtual-disks", "type": "stage"},
-                {"name": "task-history", "type": "stage"},
-                {"name": "backups", "type": "stage"},
-                {"name": "snapshots", "type": "stage"},
-                {"name": "replications", "type": "stage"},
-                {"name": "backup-routines", "type": "stage"},
-                {"name": "node-interfaces", "type": "stage"},
-                {"name": "vm-interfaces", "type": "stage"},
-                {"name": "vm-ip-addresses", "type": "stage"},
-            ]
-            yield sse_event(
-                "discovery",
-                {
-                    "event": "discovery",
-                    "phase": "full-update",
-                    "status": "discovered",
-                    "message": f"Discovered {len(stage_items)} sync stage(s) for full update",
-                    "count": len(stage_items),
-                    "items": stage_items,
-                    "progress": {"current": 0, "total": len(stage_items), "percent": 0},
-                    "metadata": {"operation_id": operation_id},
-                },
-            )
-            yield sse_event(
-                "step",
-                {
-                    "step": "devices",
-                    "status": "started",
-                    "message": "Starting devices synchronization.",
-                },
-            )
-
-            async def _run_devices_sync():
-                try:
-                    return await create_proxmox_devices(
-                        netbox_session=netbox_session,
-                        clusters_status=cluster_status,
-                        node=None,
-                        tag=tag,
-                        websocket=devices_bridge,
-                        use_websocket=True,
-                        overwrite_device_role=overwrite_flags.overwrite_device_role,
-                        overwrite_device_type=overwrite_flags.overwrite_device_type,
-                        overwrite_device_tags=overwrite_flags.overwrite_device_tags,
-                        overwrite_flags=overwrite_flags,
-                    )
-                finally:
-                    await devices_bridge.close()
-
-            _devices_start = time.monotonic()
-            devices_task = asyncio.create_task(_run_devices_sync())
-            async for frame in devices_bridge.iter_sse():
-                yield frame
-            sync_nodes = await devices_task
-
-            yield sse_event(
-                "step",
-                {
-                    "step": "devices",
-                    "status": "completed",
-                    "message": "Devices synchronization finished.",
-                    "result": {"count": len(sync_nodes)},
-                    "duration_seconds": round(time.monotonic() - _devices_start, 3),
-                },
-            )
-
-            yield sse_event(
-                "step",
-                {
-                    "step": "storage",
-                    "status": "started",
-                    "message": "Starting storage synchronization.",
-                },
-            )
-
-            async def _run_storage_sync():
-                try:
-                    return await create_storages(
-                        netbox_session=netbox_session,
-                        pxs=pxs,
-                        tag=tag,
-                        websocket=storage_bridge,
-                        use_websocket=True,
-                        fetch_concurrency=fetch_max_concurrency
-                        if fetch_max_concurrency is not None
-                        else 8,
-                        overwrite_flags=overwrite_flags,
-                    )
-                finally:
-                    await storage_bridge.close()
-
-            _storage_start = time.monotonic()
-            storage_task = asyncio.create_task(_run_storage_sync())
-            async for frame in storage_bridge.iter_sse():
-                yield frame
-            sync_storage = await storage_task
-
-            yield sse_event(
-                "step",
-                {
-                    "step": "storage",
-                    "status": "completed",
-                    "message": "Storage synchronization finished.",
-                    "result": {"count": len(sync_storage)},
-                    "duration_seconds": round(time.monotonic() - _storage_start, 3),
-                },
-            )
-
-            yield sse_event(
-                "step",
-                {
-                    "step": "virtual-machines",
-                    "status": "started",
-                    "message": "Starting virtual machines synchronization.",
-                },
-            )
-
-            async def _run_vms_sync():
-                try:
-                    return await create_virtual_machines(
-                        netbox_session=netbox_session,
-                        pxs=pxs,
-                        cluster_status=cluster_status,
-                        cluster_resources=cluster_resources,
-                        custom_fields=custom_fields,
-                        tag=tag,
-                        websocket=vm_bridge,
-                        use_websocket=True,
-                        sync_vm_network=False,
-                        overwrite_vm_role=overwrite_flags.overwrite_vm_role,
-                        overwrite_vm_type=overwrite_flags.overwrite_vm_type,
-                        overwrite_vm_tags=overwrite_flags.overwrite_vm_tags,
-                        overwrite_vm_description=overwrite_flags.overwrite_vm_description,
-                        overwrite_vm_custom_fields=overwrite_flags.overwrite_vm_custom_fields,
-                        overwrite_flags=overwrite_flags,
-                    )
-                finally:
-                    await vm_bridge.close()
-
-            _vms_start = time.monotonic()
-            vms_task = asyncio.create_task(_run_vms_sync())
-            async for frame in vm_bridge.iter_sse():
-                yield frame
-            sync_vms = await vms_task
-
-            yield sse_event(
-                "step",
-                {
-                    "step": "virtual-machines",
-                    "status": "completed",
-                    "message": "Virtual machines synchronization finished.",
-                    "result": {"count": len(sync_vms)},
-                    "duration_seconds": round(time.monotonic() - _vms_start, 3),
-                },
-            )
-
-            yield sse_event(
-                "step",
-                {
-                    "step": "virtual-disks",
-                    "status": "started",
-                    "message": "Starting virtual disks synchronization.",
-                },
-            )
-
-            async def _run_disks_sync():
-                try:
-                    return await create_virtual_disks(
-                        netbox_session=netbox_session,
-                        pxs=pxs,
-                        cluster_status=cluster_status,
-                        cluster_resources=cluster_resources,
-                        tag=tag,
-                        websocket=disks_bridge,
-                        use_websocket=True,
-                        use_css=False,
-                    )
-                finally:
-                    await disks_bridge.close()
-
-            _disks_start = time.monotonic()
-            disks_task = asyncio.create_task(_run_disks_sync())
-            async for frame in disks_bridge.iter_sse():
-                yield frame
-            sync_disks = await disks_task
-
-            yield sse_event(
-                "step",
-                {
-                    "step": "virtual-disks",
-                    "status": "completed",
-                    "message": "Virtual disks synchronization finished.",
-                    "result": {"count": _result_count(sync_disks)},
-                    "duration_seconds": round(time.monotonic() - _disks_start, 3),
-                },
-            )
-
-            yield sse_event(
-                "step",
-                {
-                    "step": "task-history",
-                    "status": "started",
-                    "message": "Starting task history synchronization.",
-                },
-            )
-
-            async def _run_task_history_sync():
-                try:
-                    return await sync_all_virtual_machine_task_histories(
-                        netbox_session=netbox_session,
-                        pxs=pxs,
-                        cluster_status=cluster_status,
-                        tag_refs=tag_refs,
-                        websocket=task_history_bridge,
-                        use_websocket=True,
-                        fetch_max_concurrency=fetch_max_concurrency,
-                    )
-                finally:
-                    await task_history_bridge.close()
-
-            _task_history_start = time.monotonic()
-            task_history_task = asyncio.create_task(_run_task_history_sync())
-            async for frame in task_history_bridge.iter_sse():
-                yield frame
-            sync_task_history = await task_history_task
-
-            yield sse_event(
-                "step",
-                {
-                    "step": "task-history",
-                    "status": "completed",
-                    "message": "Task history synchronization finished.",
-                    "result": {"count": _result_count(sync_task_history)},
-                    "duration_seconds": round(time.monotonic() - _task_history_start, 3),
-                },
-            )
-
-            yield sse_event(
-                "step",
-                {
-                    "step": "backups",
-                    "status": "started",
-                    "message": "Starting backup synchronization.",
-                },
-            )
-
-            async def _run_backups_sync():
-                try:
-                    return await _create_all_virtual_machine_backups(
-                        netbox_session=netbox_session,
-                        pxs=pxs,
-                        cluster_status=cluster_status,
-                        tag=tag,
-                        delete_nonexistent_backup=True,
-                        fetch_max_concurrency=fetch_max_concurrency,
-                        websocket=backups_bridge,
-                        use_websocket=True,
-                    )
-                finally:
-                    await backups_bridge.close()
-
-            _backups_start = time.monotonic()
-            backups_task = asyncio.create_task(_run_backups_sync())
-            async for frame in backups_bridge.iter_sse():
-                yield frame
-            sync_backups = await backups_task
-
-            yield sse_event(
-                "step",
-                {
-                    "step": "backups",
-                    "status": "completed",
-                    "message": "Backup synchronization finished.",
-                    "result": {"count": len(sync_backups)},
-                    "duration_seconds": round(time.monotonic() - _backups_start, 3),
-                },
-            )
-
-            yield sse_event(
-                "step",
-                {
-                    "step": "snapshots",
-                    "status": "started",
-                    "message": "Starting snapshot synchronization.",
-                },
-            )
-
-            async def _run_snapshots_sync():
-                try:
-                    return await _create_all_virtual_machine_snapshots(
-                        netbox_session=netbox_session,
-                        pxs=pxs,
-                        cluster_status=cluster_status,
-                        cluster_resources=cluster_resources,
-                        tag=tag,
-                        fetch_max_concurrency=fetch_max_concurrency,
-                        websocket=snapshots_bridge,
-                        use_websocket=True,
-                    )
-                finally:
-                    await snapshots_bridge.close()
-
-            _snapshots_start = time.monotonic()
-            snapshots_task = asyncio.create_task(_run_snapshots_sync())
-            async for frame in snapshots_bridge.iter_sse():
-                yield frame
-            sync_snapshots = await snapshots_task
-
-            yield sse_event(
-                "step",
-                {
-                    "step": "snapshots",
-                    "status": "completed",
-                    "message": "Snapshot synchronization finished.",
-                    "result": {"count": _result_count(sync_snapshots)},
-                    "duration_seconds": round(time.monotonic() - _snapshots_start, 3),
-                },
-            )
-
-            yield sse_event(
-                "step",
-                {
-                    "step": "node-interfaces",
-                    "status": "started",
-                    "message": "Starting node interfaces synchronization.",
-                },
-            )
-
-            async def _run_node_interfaces_sync():
-                try:
-                    return await create_all_device_interfaces(
-                        netbox_session=netbox_session,
-                        tag=tag,
-                        clusters_status=cluster_status,
-                        websocket=node_interfaces_bridge,
-                        use_websocket=True,
-                    )
-                finally:
-                    await node_interfaces_bridge.close()
-
-            _node_interfaces_start = time.monotonic()
-            node_interfaces_task = asyncio.create_task(_run_node_interfaces_sync())
-            async for frame in node_interfaces_bridge.iter_sse():
-                yield frame
-            sync_node_interfaces = await node_interfaces_task
-
-            yield sse_event(
-                "step",
-                {
-                    "step": "node-interfaces",
-                    "status": "completed",
-                    "message": "Node interfaces synchronization finished.",
-                    "result": {"count": len(sync_node_interfaces)},
-                    "duration_seconds": round(time.monotonic() - _node_interfaces_start, 3),
-                },
-            )
-
-            yield sse_event(
-                "step",
-                {
-                    "step": "vm-interfaces",
-                    "status": "started",
-                    "message": "Starting VM interfaces synchronization.",
-                },
-            )
-
-            async def _run_vm_interfaces_sync():
-                try:
-                    return await create_only_vm_interfaces(
-                        netbox_session=netbox_session,
-                        pxs=pxs,
-                        cluster_status=cluster_status,
-                        cluster_resources=cluster_resources,
-                        custom_fields=custom_fields,
-                        tag=tag,
-                        websocket=vm_interfaces_bridge,
-                        use_websocket=True,
-                        overwrite_flags=overwrite_flags,
-                    )
-                finally:
-                    await vm_interfaces_bridge.close()
-
-            _vm_interfaces_start = time.monotonic()
-            vm_interfaces_task = asyncio.create_task(_run_vm_interfaces_sync())
-            async for frame in vm_interfaces_bridge.iter_sse():
-                yield frame
-            sync_vm_interfaces = await vm_interfaces_task
-
-            yield sse_event(
-                "step",
-                {
-                    "step": "vm-interfaces",
-                    "status": "completed",
-                    "message": "VM interfaces synchronization finished.",
-                    "result": {"count": len(sync_vm_interfaces)},
-                    "duration_seconds": round(time.monotonic() - _vm_interfaces_start, 3),
-                },
-            )
-
-            yield sse_event(
-                "step",
-                {
-                    "step": "vm-ip-addresses",
-                    "status": "started",
-                    "message": "Starting VM IP address synchronization.",
-                },
-            )
-
-            async def _run_vm_ip_addresses_sync():
-                try:
-                    return await create_only_vm_ip_addresses(
-                        netbox_session=netbox_session,
-                        pxs=pxs,
-                        cluster_status=cluster_status,
-                        cluster_resources=cluster_resources,
-                        custom_fields=custom_fields,
-                        tag=tag,
-                        websocket=vm_ip_addresses_bridge,
-                        use_websocket=True,
-                        overwrite_flags=overwrite_flags,
-                    )
-                finally:
-                    await vm_ip_addresses_bridge.close()
-
-            _vm_ip_addresses_start = time.monotonic()
-            vm_ip_addresses_task = asyncio.create_task(_run_vm_ip_addresses_sync())
-            async for frame in vm_ip_addresses_bridge.iter_sse():
-                yield frame
-            sync_vm_ip_addresses = await vm_ip_addresses_task
-
-            yield sse_event(
-                "step",
-                {
-                    "step": "vm-ip-addresses",
-                    "status": "completed",
-                    "message": "VM IP address synchronization finished.",
-                    "result": {"count": len(sync_vm_ip_addresses)},
-                    "duration_seconds": round(time.monotonic() - _vm_ip_addresses_start, 3),
-                },
-            )
-
-            yield sse_event(
-                "step",
-                {
-                    "step": "replications",
-                    "status": "started",
-                    "message": "Starting replications synchronization.",
-                },
-            )
-
-            async def _run_replications_sync():
-                try:
-                    return await sync_all_replications(
-                        netbox_session=netbox_session,
-                        pxs=pxs,
-                    )
-                finally:
-                    await replications_bridge.close()
-
-            _replications_start = time.monotonic()
-            replications_task = asyncio.create_task(_run_replications_sync())
-            async for frame in replications_bridge.iter_sse():
-                yield frame
-            sync_replications = await replications_task
-
-            yield sse_event(
-                "step",
-                {
-                    "step": "replications",
-                    "status": "completed",
-                    "message": "Replications synchronization finished.",
-                    "result": {
-                        "created": sync_replications.get("created", 0),
-                        "updated": sync_replications.get("updated", 0),
+        async with register_active_sync(operation_id, kind="full-update"):
+            try:
+                yield sse_event("bootstrap_done", bootstrap_payload)
+                yield sse_event(
+                    "step",
+                    {
+                        "step": "stream",
+                        "status": "started",
+                        "message": f"Full update stream connected (operation_id={operation_id})",
                     },
-                    "duration_seconds": round(time.monotonic() - _replications_start, 3),
-                },
-            )
-
-            yield sse_event(
-                "step",
-                {
-                    "step": "backup-routines",
-                    "status": "started",
-                    "message": "Starting backup routines synchronization.",
-                },
-            )
-
-            async def _run_backup_routines_sync():
-                try:
-                    return await sync_all_backup_routines(
-                        netbox_session=netbox_session,
-                        pxs=pxs,
-                        bridge=backup_routines_bridge,
-                    )
-                finally:
-                    await backup_routines_bridge.close()
-
-            _backup_routines_start = time.monotonic()
-            backup_routines_task = asyncio.create_task(_run_backup_routines_sync())
-            async for frame in backup_routines_bridge.iter_sse():
-                yield frame
-            sync_backup_routines = await backup_routines_task
-
-            yield sse_event(
-                "step",
-                {
-                    "step": "backup-routines",
-                    "status": "completed",
-                    "message": "Backup routines synchronization finished.",
-                    "result": {
-                        "created": sync_backup_routines.get("created", 0),
-                        "updated": sync_backup_routines.get("updated", 0),
+                )
+                stage_items = [
+                    {"name": "devices", "type": "stage"},
+                    {"name": "storage", "type": "stage"},
+                    {"name": "virtual-machines", "type": "stage"},
+                    {"name": "virtual-disks", "type": "stage"},
+                    {"name": "task-history", "type": "stage"},
+                    {"name": "backups", "type": "stage"},
+                    {"name": "snapshots", "type": "stage"},
+                    {"name": "replications", "type": "stage"},
+                    {"name": "backup-routines", "type": "stage"},
+                    {"name": "node-interfaces", "type": "stage"},
+                    {"name": "vm-interfaces", "type": "stage"},
+                    {"name": "vm-ip-addresses", "type": "stage"},
+                ]
+                yield sse_event(
+                    "discovery",
+                    {
+                        "event": "discovery",
+                        "phase": "full-update",
+                        "status": "discovered",
+                        "message": f"Discovered {len(stage_items)} sync stage(s) for full update",
+                        "count": len(stage_items),
+                        "items": stage_items,
+                        "progress": {"current": 0, "total": len(stage_items), "percent": 0},
+                        "metadata": {"operation_id": operation_id},
                     },
-                    "duration_seconds": round(time.monotonic() - _backup_routines_start, 3),
-                },
-            )
-
-            yield sse_event(
-                "complete",
-                {
-                    "ok": True,
-                    "message": "Full update sync completed.",
-                    "result": {
-                        "devices": sync_nodes,
-                        "storage": sync_storage,
-                        "virtual_machines": sync_vms,
-                        "virtual_disks": sync_disks,
-                        "task_history": sync_task_history,
-                        "backups": sync_backups,
-                        "snapshots": sync_snapshots,
-                        "node_interfaces": sync_node_interfaces,
-                        "vm_interfaces": sync_vm_interfaces,
-                        "vm_ip_addresses": sync_vm_ip_addresses,
-                        "replications": sync_replications,
-                        "backup_routines": sync_backup_routines,
-                        "devices_count": len(sync_nodes),
-                        "storage_count": len(sync_storage),
-                        "virtual_machines_count": len(sync_vms),
-                        "virtual_disks_count": _result_count(sync_disks),
-                        "task_history_count": _result_count(sync_task_history),
-                        "backups_count": len(sync_backups),
-                        "snapshots_count": _result_count(sync_snapshots),
-                        "node_interfaces_count": len(sync_node_interfaces),
-                        "vm_interfaces_count": len(sync_vm_interfaces),
-                        "vm_ip_addresses_count": len(sync_vm_ip_addresses),
-                        "replications_count": sync_replications.get("created", 0)
-                        + sync_replications.get("updated", 0),
-                        "backup_routines_count": sync_backup_routines.get("created", 0)
-                        + sync_backup_routines.get("updated", 0),
+                )
+                yield sse_event(
+                    "step",
+                    {
+                        "step": "devices",
+                        "status": "started",
+                        "message": "Starting devices synchronization.",
                     },
-                },
-            )
-        except asyncio.CancelledError:
-            yield sse_event(
-                "error",
-                {
-                    "step": "full-update",
-                    "status": "failed",
-                    "error": "Server shutdown or request cancelled.",
-                    "detail": "Server shutdown or request cancelled.",
-                },
-            )
-            yield sse_event(
-                "complete",
-                {
-                    "ok": False,
-                    "message": "Full update sync cancelled.",
-                    "errors": [{"detail": "Server shutdown or request cancelled."}],
-                },
-            )
-        except ProxboxException as error:
-            yield sse_event(
-                "error_detail",
-                {
-                    "event": "error_detail",
-                    "phase": "full-update",
-                    "category": ErrorCategory.INTERNAL.value,
-                    "message": "Full update synchronization failed",
-                    "detail": error.detail or error.message,
-                    "suggestion": "Review backend logs and retry the full update",
-                },
-            )
-            yield sse_event(
-                "error",
-                {
-                    "step": "full-update",
-                    "status": "failed",
-                    "error": error.message,
-                    "detail": error.detail,
-                },
-            )
-            yield sse_event(
-                "complete",
-                {
-                    "ok": False,
-                    "message": error.message,
-                    "errors": [{"detail": error.detail or error.message}],
-                },
-            )
-        except Exception as error:  # noqa: BLE001
-            yield sse_event(
-                "error_detail",
-                {
-                    "event": "error_detail",
-                    "phase": "full-update",
-                    "category": ErrorCategory.INTERNAL.value,
-                    "message": "Unexpected error during full update",
-                    "detail": str(error),
-                    "suggestion": "Check backend logs for stack trace and retry",
-                },
-            )
-            yield sse_event(
-                "error",
-                {
-                    "step": "full-update",
-                    "status": "failed",
-                    "error": str(error),
-                    "detail": str(error),
-                },
-            )
-            yield sse_event(
-                "complete",
-                {
-                    "ok": False,
-                    "message": "Full update sync failed.",
-                    "errors": [{"detail": str(error)}],
-                },
-            )
+                )
+
+                async def _run_devices_sync():
+                    try:
+                        return await create_proxmox_devices(
+                            netbox_session=netbox_session,
+                            clusters_status=cluster_status,
+                            node=None,
+                            tag=tag,
+                            websocket=devices_bridge,
+                            use_websocket=True,
+                            overwrite_device_role=overwrite_flags.overwrite_device_role,
+                            overwrite_device_type=overwrite_flags.overwrite_device_type,
+                            overwrite_device_tags=overwrite_flags.overwrite_device_tags,
+                            overwrite_flags=overwrite_flags,
+                        )
+                    finally:
+                        await devices_bridge.close()
+
+                _devices_start = time.monotonic()
+                devices_task = asyncio.create_task(_run_devices_sync())
+                async for frame in devices_bridge.iter_sse():
+                    yield frame
+                sync_nodes = await devices_task
+
+                yield sse_event(
+                    "step",
+                    {
+                        "step": "devices",
+                        "status": "completed",
+                        "message": "Devices synchronization finished.",
+                        "result": {"count": len(sync_nodes)},
+                        "duration_seconds": round(time.monotonic() - _devices_start, 3),
+                    },
+                )
+
+                yield sse_event(
+                    "step",
+                    {
+                        "step": "storage",
+                        "status": "started",
+                        "message": "Starting storage synchronization.",
+                    },
+                )
+
+                async def _run_storage_sync():
+                    try:
+                        return await create_storages(
+                            netbox_session=netbox_session,
+                            pxs=pxs,
+                            tag=tag,
+                            websocket=storage_bridge,
+                            use_websocket=True,
+                            fetch_concurrency=fetch_max_concurrency
+                            if fetch_max_concurrency is not None
+                            else 8,
+                            overwrite_flags=overwrite_flags,
+                        )
+                    finally:
+                        await storage_bridge.close()
+
+                _storage_start = time.monotonic()
+                storage_task = asyncio.create_task(_run_storage_sync())
+                async for frame in storage_bridge.iter_sse():
+                    yield frame
+                sync_storage = await storage_task
+
+                yield sse_event(
+                    "step",
+                    {
+                        "step": "storage",
+                        "status": "completed",
+                        "message": "Storage synchronization finished.",
+                        "result": {"count": len(sync_storage)},
+                        "duration_seconds": round(time.monotonic() - _storage_start, 3),
+                    },
+                )
+
+                yield sse_event(
+                    "step",
+                    {
+                        "step": "virtual-machines",
+                        "status": "started",
+                        "message": "Starting virtual machines synchronization.",
+                    },
+                )
+
+                async def _run_vms_sync():
+                    try:
+                        return await create_virtual_machines(
+                            netbox_session=netbox_session,
+                            pxs=pxs,
+                            cluster_status=cluster_status,
+                            cluster_resources=cluster_resources,
+                            custom_fields=custom_fields,
+                            tag=tag,
+                            websocket=vm_bridge,
+                            use_websocket=True,
+                            sync_vm_network=False,
+                            overwrite_vm_role=overwrite_flags.overwrite_vm_role,
+                            overwrite_vm_type=overwrite_flags.overwrite_vm_type,
+                            overwrite_vm_tags=overwrite_flags.overwrite_vm_tags,
+                            overwrite_vm_description=overwrite_flags.overwrite_vm_description,
+                            overwrite_vm_custom_fields=overwrite_flags.overwrite_vm_custom_fields,
+                            overwrite_flags=overwrite_flags,
+                        )
+                    finally:
+                        await vm_bridge.close()
+
+                _vms_start = time.monotonic()
+                vms_task = asyncio.create_task(_run_vms_sync())
+                async for frame in vm_bridge.iter_sse():
+                    yield frame
+                sync_vms = await vms_task
+
+                yield sse_event(
+                    "step",
+                    {
+                        "step": "virtual-machines",
+                        "status": "completed",
+                        "message": "Virtual machines synchronization finished.",
+                        "result": {"count": len(sync_vms)},
+                        "duration_seconds": round(time.monotonic() - _vms_start, 3),
+                    },
+                )
+
+                yield sse_event(
+                    "step",
+                    {
+                        "step": "virtual-disks",
+                        "status": "started",
+                        "message": "Starting virtual disks synchronization.",
+                    },
+                )
+
+                async def _run_disks_sync():
+                    try:
+                        return await create_virtual_disks(
+                            netbox_session=netbox_session,
+                            pxs=pxs,
+                            cluster_status=cluster_status,
+                            cluster_resources=cluster_resources,
+                            tag=tag,
+                            websocket=disks_bridge,
+                            use_websocket=True,
+                            use_css=False,
+                        )
+                    finally:
+                        await disks_bridge.close()
+
+                _disks_start = time.monotonic()
+                disks_task = asyncio.create_task(_run_disks_sync())
+                async for frame in disks_bridge.iter_sse():
+                    yield frame
+                sync_disks = await disks_task
+
+                yield sse_event(
+                    "step",
+                    {
+                        "step": "virtual-disks",
+                        "status": "completed",
+                        "message": "Virtual disks synchronization finished.",
+                        "result": {"count": _result_count(sync_disks)},
+                        "duration_seconds": round(time.monotonic() - _disks_start, 3),
+                    },
+                )
+
+                yield sse_event(
+                    "step",
+                    {
+                        "step": "task-history",
+                        "status": "started",
+                        "message": "Starting task history synchronization.",
+                    },
+                )
+
+                async def _run_task_history_sync():
+                    try:
+                        return await sync_all_virtual_machine_task_histories(
+                            netbox_session=netbox_session,
+                            pxs=pxs,
+                            cluster_status=cluster_status,
+                            tag_refs=tag_refs,
+                            websocket=task_history_bridge,
+                            use_websocket=True,
+                            fetch_max_concurrency=fetch_max_concurrency,
+                        )
+                    finally:
+                        await task_history_bridge.close()
+
+                _task_history_start = time.monotonic()
+                task_history_task = asyncio.create_task(_run_task_history_sync())
+                async for frame in task_history_bridge.iter_sse():
+                    yield frame
+                sync_task_history = await task_history_task
+
+                yield sse_event(
+                    "step",
+                    {
+                        "step": "task-history",
+                        "status": "completed",
+                        "message": "Task history synchronization finished.",
+                        "result": {"count": _result_count(sync_task_history)},
+                        "duration_seconds": round(time.monotonic() - _task_history_start, 3),
+                    },
+                )
+
+                yield sse_event(
+                    "step",
+                    {
+                        "step": "backups",
+                        "status": "started",
+                        "message": "Starting backup synchronization.",
+                    },
+                )
+
+                async def _run_backups_sync():
+                    try:
+                        return await _create_all_virtual_machine_backups(
+                            netbox_session=netbox_session,
+                            pxs=pxs,
+                            cluster_status=cluster_status,
+                            tag=tag,
+                            delete_nonexistent_backup=True,
+                            fetch_max_concurrency=fetch_max_concurrency,
+                            websocket=backups_bridge,
+                            use_websocket=True,
+                        )
+                    finally:
+                        await backups_bridge.close()
+
+                _backups_start = time.monotonic()
+                backups_task = asyncio.create_task(_run_backups_sync())
+                async for frame in backups_bridge.iter_sse():
+                    yield frame
+                sync_backups = await backups_task
+
+                yield sse_event(
+                    "step",
+                    {
+                        "step": "backups",
+                        "status": "completed",
+                        "message": "Backup synchronization finished.",
+                        "result": {"count": len(sync_backups)},
+                        "duration_seconds": round(time.monotonic() - _backups_start, 3),
+                    },
+                )
+
+                yield sse_event(
+                    "step",
+                    {
+                        "step": "snapshots",
+                        "status": "started",
+                        "message": "Starting snapshot synchronization.",
+                    },
+                )
+
+                async def _run_snapshots_sync():
+                    try:
+                        return await _create_all_virtual_machine_snapshots(
+                            netbox_session=netbox_session,
+                            pxs=pxs,
+                            cluster_status=cluster_status,
+                            cluster_resources=cluster_resources,
+                            tag=tag,
+                            fetch_max_concurrency=fetch_max_concurrency,
+                            websocket=snapshots_bridge,
+                            use_websocket=True,
+                        )
+                    finally:
+                        await snapshots_bridge.close()
+
+                _snapshots_start = time.monotonic()
+                snapshots_task = asyncio.create_task(_run_snapshots_sync())
+                async for frame in snapshots_bridge.iter_sse():
+                    yield frame
+                sync_snapshots = await snapshots_task
+
+                yield sse_event(
+                    "step",
+                    {
+                        "step": "snapshots",
+                        "status": "completed",
+                        "message": "Snapshot synchronization finished.",
+                        "result": {"count": _result_count(sync_snapshots)},
+                        "duration_seconds": round(time.monotonic() - _snapshots_start, 3),
+                    },
+                )
+
+                yield sse_event(
+                    "step",
+                    {
+                        "step": "node-interfaces",
+                        "status": "started",
+                        "message": "Starting node interfaces synchronization.",
+                    },
+                )
+
+                async def _run_node_interfaces_sync():
+                    try:
+                        return await create_all_device_interfaces(
+                            netbox_session=netbox_session,
+                            tag=tag,
+                            clusters_status=cluster_status,
+                            websocket=node_interfaces_bridge,
+                            use_websocket=True,
+                        )
+                    finally:
+                        await node_interfaces_bridge.close()
+
+                _node_interfaces_start = time.monotonic()
+                node_interfaces_task = asyncio.create_task(_run_node_interfaces_sync())
+                async for frame in node_interfaces_bridge.iter_sse():
+                    yield frame
+                sync_node_interfaces = await node_interfaces_task
+
+                yield sse_event(
+                    "step",
+                    {
+                        "step": "node-interfaces",
+                        "status": "completed",
+                        "message": "Node interfaces synchronization finished.",
+                        "result": {"count": len(sync_node_interfaces)},
+                        "duration_seconds": round(time.monotonic() - _node_interfaces_start, 3),
+                    },
+                )
+
+                yield sse_event(
+                    "step",
+                    {
+                        "step": "vm-interfaces",
+                        "status": "started",
+                        "message": "Starting VM interfaces synchronization.",
+                    },
+                )
+
+                async def _run_vm_interfaces_sync():
+                    try:
+                        return await create_only_vm_interfaces(
+                            netbox_session=netbox_session,
+                            pxs=pxs,
+                            cluster_status=cluster_status,
+                            cluster_resources=cluster_resources,
+                            custom_fields=custom_fields,
+                            tag=tag,
+                            websocket=vm_interfaces_bridge,
+                            use_websocket=True,
+                            overwrite_flags=overwrite_flags,
+                        )
+                    finally:
+                        await vm_interfaces_bridge.close()
+
+                _vm_interfaces_start = time.monotonic()
+                vm_interfaces_task = asyncio.create_task(_run_vm_interfaces_sync())
+                async for frame in vm_interfaces_bridge.iter_sse():
+                    yield frame
+                sync_vm_interfaces = await vm_interfaces_task
+
+                yield sse_event(
+                    "step",
+                    {
+                        "step": "vm-interfaces",
+                        "status": "completed",
+                        "message": "VM interfaces synchronization finished.",
+                        "result": {"count": len(sync_vm_interfaces)},
+                        "duration_seconds": round(time.monotonic() - _vm_interfaces_start, 3),
+                    },
+                )
+
+                yield sse_event(
+                    "step",
+                    {
+                        "step": "vm-ip-addresses",
+                        "status": "started",
+                        "message": "Starting VM IP address synchronization.",
+                    },
+                )
+
+                async def _run_vm_ip_addresses_sync():
+                    try:
+                        return await create_only_vm_ip_addresses(
+                            netbox_session=netbox_session,
+                            pxs=pxs,
+                            cluster_status=cluster_status,
+                            cluster_resources=cluster_resources,
+                            custom_fields=custom_fields,
+                            tag=tag,
+                            websocket=vm_ip_addresses_bridge,
+                            use_websocket=True,
+                            overwrite_flags=overwrite_flags,
+                        )
+                    finally:
+                        await vm_ip_addresses_bridge.close()
+
+                _vm_ip_addresses_start = time.monotonic()
+                vm_ip_addresses_task = asyncio.create_task(_run_vm_ip_addresses_sync())
+                async for frame in vm_ip_addresses_bridge.iter_sse():
+                    yield frame
+                sync_vm_ip_addresses = await vm_ip_addresses_task
+
+                yield sse_event(
+                    "step",
+                    {
+                        "step": "vm-ip-addresses",
+                        "status": "completed",
+                        "message": "VM IP address synchronization finished.",
+                        "result": {"count": len(sync_vm_ip_addresses)},
+                        "duration_seconds": round(time.monotonic() - _vm_ip_addresses_start, 3),
+                    },
+                )
+
+                yield sse_event(
+                    "step",
+                    {
+                        "step": "replications",
+                        "status": "started",
+                        "message": "Starting replications synchronization.",
+                    },
+                )
+
+                async def _run_replications_sync():
+                    try:
+                        return await sync_all_replications(
+                            netbox_session=netbox_session,
+                            pxs=pxs,
+                        )
+                    finally:
+                        await replications_bridge.close()
+
+                _replications_start = time.monotonic()
+                replications_task = asyncio.create_task(_run_replications_sync())
+                async for frame in replications_bridge.iter_sse():
+                    yield frame
+                sync_replications = await replications_task
+
+                yield sse_event(
+                    "step",
+                    {
+                        "step": "replications",
+                        "status": "completed",
+                        "message": "Replications synchronization finished.",
+                        "result": {
+                            "created": sync_replications.get("created", 0),
+                            "updated": sync_replications.get("updated", 0),
+                        },
+                        "duration_seconds": round(time.monotonic() - _replications_start, 3),
+                    },
+                )
+
+                yield sse_event(
+                    "step",
+                    {
+                        "step": "backup-routines",
+                        "status": "started",
+                        "message": "Starting backup routines synchronization.",
+                    },
+                )
+
+                async def _run_backup_routines_sync():
+                    try:
+                        return await sync_all_backup_routines(
+                            netbox_session=netbox_session,
+                            pxs=pxs,
+                            bridge=backup_routines_bridge,
+                        )
+                    finally:
+                        await backup_routines_bridge.close()
+
+                _backup_routines_start = time.monotonic()
+                backup_routines_task = asyncio.create_task(_run_backup_routines_sync())
+                async for frame in backup_routines_bridge.iter_sse():
+                    yield frame
+                sync_backup_routines = await backup_routines_task
+
+                yield sse_event(
+                    "step",
+                    {
+                        "step": "backup-routines",
+                        "status": "completed",
+                        "message": "Backup routines synchronization finished.",
+                        "result": {
+                            "created": sync_backup_routines.get("created", 0),
+                            "updated": sync_backup_routines.get("updated", 0),
+                        },
+                        "duration_seconds": round(time.monotonic() - _backup_routines_start, 3),
+                    },
+                )
+
+                yield sse_event(
+                    "complete",
+                    {
+                        "ok": True,
+                        "message": "Full update sync completed.",
+                        "result": {
+                            "devices": sync_nodes,
+                            "storage": sync_storage,
+                            "virtual_machines": sync_vms,
+                            "virtual_disks": sync_disks,
+                            "task_history": sync_task_history,
+                            "backups": sync_backups,
+                            "snapshots": sync_snapshots,
+                            "node_interfaces": sync_node_interfaces,
+                            "vm_interfaces": sync_vm_interfaces,
+                            "vm_ip_addresses": sync_vm_ip_addresses,
+                            "replications": sync_replications,
+                            "backup_routines": sync_backup_routines,
+                            "devices_count": len(sync_nodes),
+                            "storage_count": len(sync_storage),
+                            "virtual_machines_count": len(sync_vms),
+                            "virtual_disks_count": _result_count(sync_disks),
+                            "task_history_count": _result_count(sync_task_history),
+                            "backups_count": len(sync_backups),
+                            "snapshots_count": _result_count(sync_snapshots),
+                            "node_interfaces_count": len(sync_node_interfaces),
+                            "vm_interfaces_count": len(sync_vm_interfaces),
+                            "vm_ip_addresses_count": len(sync_vm_ip_addresses),
+                            "replications_count": sync_replications.get("created", 0)
+                            + sync_replications.get("updated", 0),
+                            "backup_routines_count": sync_backup_routines.get("created", 0)
+                            + sync_backup_routines.get("updated", 0),
+                        },
+                    },
+                )
+            except asyncio.CancelledError:
+                yield sse_event(
+                    "error",
+                    {
+                        "step": "full-update",
+                        "status": "failed",
+                        "error": "Server shutdown or request cancelled.",
+                        "detail": "Server shutdown or request cancelled.",
+                    },
+                )
+                yield sse_event(
+                    "complete",
+                    {
+                        "ok": False,
+                        "message": "Full update sync cancelled.",
+                        "errors": [{"detail": "Server shutdown or request cancelled."}],
+                    },
+                )
+            except ProxboxException as error:
+                yield sse_event(
+                    "error_detail",
+                    {
+                        "event": "error_detail",
+                        "phase": "full-update",
+                        "category": ErrorCategory.INTERNAL.value,
+                        "message": "Full update synchronization failed",
+                        "detail": error.detail or error.message,
+                        "suggestion": "Review backend logs and retry the full update",
+                    },
+                )
+                yield sse_event(
+                    "error",
+                    {
+                        "step": "full-update",
+                        "status": "failed",
+                        "error": error.message,
+                        "detail": error.detail,
+                    },
+                )
+                yield sse_event(
+                    "complete",
+                    {
+                        "ok": False,
+                        "message": error.message,
+                        "errors": [{"detail": error.detail or error.message}],
+                    },
+                )
+            except Exception as error:  # noqa: BLE001
+                yield sse_event(
+                    "error_detail",
+                    {
+                        "event": "error_detail",
+                        "phase": "full-update",
+                        "category": ErrorCategory.INTERNAL.value,
+                        "message": "Unexpected error during full update",
+                        "detail": str(error),
+                        "suggestion": "Check backend logs for stack trace and retry",
+                    },
+                )
+                yield sse_event(
+                    "error",
+                    {
+                        "step": "full-update",
+                        "status": "failed",
+                        "error": str(error),
+                        "detail": str(error),
+                    },
+                )
+                yield sse_event(
+                    "complete",
+                    {
+                        "ok": False,
+                        "message": "Full update sync failed.",
+                        "errors": [{"detail": str(error)}],
+                    },
+                )
 
     return StreamingResponse(
         event_stream(),

--- a/proxbox_api/app/sync_state.py
+++ b/proxbox_api/app/sync_state.py
@@ -1,0 +1,120 @@
+"""Process-local registry for in-flight Proxbox sync operations.
+
+The registry exposes:
+
+- ``register_active_sync`` — an async context manager that records a sync
+  while its block runs and removes it on exit (including cancellation and
+  exceptions). Wrap the body of a sync handler — or, for streaming endpoints,
+  the inside of the ``event_stream()`` generator — so the registration tracks
+  the actual lifetime of the work, not just the route handler.
+- ``get_active_sync`` / ``is_active`` — read helpers used by the ``GET
+  /sync/active`` probe.
+
+The registry is intentionally process-local and memory-only. It is a *soft
+probe* (good enough for "is this single API replica currently running a
+sync?"), not a distributed lock. When the API runs with multiple uvicorn
+workers, each worker maintains its own view; cron/single-exec setups should
+treat ``/sync/active`` as advisory and rely on cron interval > sync duration.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+
+_active_lock = asyncio.Lock()
+_active_runs: list[dict[str, str]] = []
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+async def acquire_active_sync(
+    operation_id: str,
+    *,
+    kind: str = "full-update",
+) -> dict[str, str]:
+    """Record an in-flight sync and return the registry entry handle.
+
+    Pair with ``release_active_sync`` in a ``try/finally``. Prefer
+    ``register_active_sync`` (the ``async with`` form) when the call site can
+    accommodate it — both routes share the same underlying storage.
+    """
+    entry = {
+        "id": operation_id,
+        "kind": kind,
+        "started_at": _utcnow_iso(),
+    }
+    async with _active_lock:
+        _active_runs.append(entry)
+    return entry
+
+
+async def release_active_sync(entry: dict[str, str]) -> None:
+    """Remove a previously-acquired registry entry. Safe if already removed."""
+    async with _active_lock:
+        try:
+            _active_runs.remove(entry)
+        except ValueError:
+            pass
+
+
+@asynccontextmanager
+async def register_active_sync(
+    operation_id: str,
+    *,
+    kind: str = "full-update",
+) -> AsyncIterator[None]:
+    """Record an in-flight sync for the duration of the ``async with`` block.
+
+    The entry is removed on normal exit, exception, and cancellation. Wrap the
+    generator body of a streaming endpoint (not the route handler, which
+    returns immediately after constructing the ``StreamingResponse``) so the
+    registry reflects the real work lifetime.
+    """
+    entry = await acquire_active_sync(operation_id, kind=kind)
+    try:
+        yield
+    finally:
+        await release_active_sync(entry)
+
+
+async def get_active_sync() -> dict[str, object]:
+    """Return the soft-probe response payload for ``GET /sync/active``.
+
+    Reports the oldest currently-running sync (FIFO) so the probe stays stable
+    while a new run starts before the previous one finishes. The full list of
+    in-flight runs is returned under ``runs`` for diagnostics.
+    """
+    async with _active_lock:
+        snapshot = list(_active_runs)
+    if not snapshot:
+        return {
+            "active": False,
+            "started_at": None,
+            "id": None,
+            "kind": None,
+            "runs": [],
+        }
+    head = snapshot[0]
+    return {
+        "active": True,
+        "started_at": head["started_at"],
+        "id": head["id"],
+        "kind": head["kind"],
+        "runs": snapshot,
+    }
+
+
+async def is_active() -> bool:
+    """Return ``True`` when at least one sync is currently registered."""
+    async with _active_lock:
+        return bool(_active_runs)
+
+
+def _reset_for_tests() -> None:
+    """Drop all registry state. Test-only; not exported in ``__init__``."""
+    _active_runs.clear()

--- a/proxbox_api/routes/sync/CLAUDE.md
+++ b/proxbox_api/routes/sync/CLAUDE.md
@@ -9,8 +9,15 @@ Internal sync helper routes that expose targeted, per-object synchronization ope
 ```
 routes/sync/
 ├── __init__.py          # Router registration and shared sync route helpers
+├── active.py            # GET /sync/active soft-probe endpoint (issue #71)
 └── individual/          # Per-object sync route handlers (see individual/CLAUDE.md)
 ```
+
+The `active.py` route reads the process-local registry maintained by
+`proxbox_api.app.sync_state` (registered by both `/full-update` handlers).
+It is intentionally a soft probe — a cron / single-exec caller can use it to
+fast-fail when a sync is already running on the local replica, but operators
+running multiple uvicorn workers should not rely on it as a distributed lock.
 
 ## Key Patterns
 

--- a/proxbox_api/routes/sync/active.py
+++ b/proxbox_api/routes/sync/active.py
@@ -1,0 +1,24 @@
+"""``GET /sync/active`` — soft probe for in-flight full-update runs."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from proxbox_api.app.sync_state import get_active_sync
+from proxbox_api.schemas.sync import SyncActiveResponse
+
+router = APIRouter()
+
+
+@router.get("/sync/active", response_model=SyncActiveResponse, tags=["sync"])
+async def sync_active() -> SyncActiveResponse:
+    """Report whether this API replica is currently running a sync.
+
+    The registry is in-memory and process-local, so this endpoint is a soft
+    probe — useful for single-replica deployments and for cron/single-exec
+    callers that want to fast-fail when a sync is already in flight. Operators
+    running multiple uvicorn workers should treat conflicting answers across
+    workers as expected.
+    """
+    payload = await get_active_sync()
+    return SyncActiveResponse.model_validate(payload)

--- a/proxbox_api/schemas/sync.py
+++ b/proxbox_api/schemas/sync.py
@@ -268,3 +268,30 @@ def behavior_flags_from_query_params(
         if name in query_params:
             resolved[name] = query_params[name]
     return SyncBehaviorFlags(**resolved)
+
+
+class ActiveSyncRun(ProxboxBaseModel):
+    """Diagnostic entry for one in-flight sync run."""
+
+    id: str = Field(description="Operation ID assigned when the sync started.")
+    kind: str = Field(description="Sync flavour, e.g. 'full-update'.")
+    started_at: str = Field(description="ISO-8601 UTC timestamp of registration.")
+
+
+class SyncActiveResponse(ProxboxBaseModel):
+    """Response shape for ``GET /sync/active``.
+
+    ``active`` is the oldest currently-running sync (FIFO). ``runs`` lists every
+    in-flight registration for the local API replica (the registry is
+    process-local, so this is a soft probe — see the ``sync_state`` module).
+    """
+
+    active: bool = Field(description="True when a sync is currently registered.")
+    started_at: str | None = Field(
+        default=None, description="Start timestamp of the oldest active run."
+    )
+    id: str | None = Field(default=None, description="Operation ID of the oldest active run.")
+    kind: str | None = Field(default=None, description="Kind of the oldest active run.")
+    runs: list[ActiveSyncRun] = Field(
+        default_factory=list, description="All in-flight runs on this API replica."
+    )

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -46,6 +46,7 @@ Unit, integration, and end-to-end tests for the `proxbox_api` backend package. A
 | `test_streaming_detailed_messages.py` | Detailed-message streaming payload shape |
 | `test_structured_logging.py` | `SyncPhaseLogger` operation phase logging |
 | `test_stub_routes.py` | HTTP 501 stub endpoints for unimplemented operations |
+| `test_sync_active.py` | `GET /sync/active` soft probe + `sync_state` registry lifecycle (issue #71) |
 | `test_sync_error_handling.py` | `@with_retry` decorator and domain error wrapping |
 | `test_sync_overwrite_flags.py` | Behavior of `SyncOverwriteFlags` propagation through the sync pipeline |
 | `test_task_history_sync.py` | Task history sync workflow |

--- a/tests/test_sync_active.py
+++ b/tests/test_sync_active.py
@@ -1,0 +1,139 @@
+"""Tests for the ``GET /sync/active`` soft-probe endpoint and registry."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from proxbox_api.app.sync_state import (
+    _reset_for_tests,
+    acquire_active_sync,
+    get_active_sync,
+    is_active,
+    register_active_sync,
+    release_active_sync,
+)
+from proxbox_api.main import app
+
+
+@pytest.fixture(autouse=True)
+def _reset_sync_registry():
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+class TestSyncStateRegistry:
+    """Unit tests for the in-memory registry helpers."""
+
+    @pytest.mark.asyncio
+    async def test_idle_state(self):
+        snapshot = await get_active_sync()
+        assert snapshot["active"] is False
+        assert snapshot["started_at"] is None
+        assert snapshot["id"] is None
+        assert snapshot["runs"] == []
+        assert await is_active() is False
+
+    @pytest.mark.asyncio
+    async def test_acquire_release_round_trip(self):
+        entry = await acquire_active_sync("op-1", kind="full-update")
+        try:
+            snapshot = await get_active_sync()
+            assert snapshot["active"] is True
+            assert snapshot["id"] == "op-1"
+            assert snapshot["kind"] == "full-update"
+            assert snapshot["started_at"] is not None
+            assert len(snapshot["runs"]) == 1
+            assert await is_active() is True
+        finally:
+            await release_active_sync(entry)
+        snapshot = await get_active_sync()
+        assert snapshot["active"] is False
+        assert snapshot["runs"] == []
+
+    @pytest.mark.asyncio
+    async def test_context_manager_cleans_on_exception(self):
+        with pytest.raises(RuntimeError):
+            async with register_active_sync("op-boom", kind="full-update"):
+                assert await is_active() is True
+                raise RuntimeError("boom")
+        assert await is_active() is False
+
+    @pytest.mark.asyncio
+    async def test_context_manager_cleans_on_cancellation(self):
+        started = asyncio.Event()
+
+        async def worker():
+            async with register_active_sync("op-cancel", kind="full-update"):
+                started.set()
+                await asyncio.sleep(60)
+
+        task = asyncio.create_task(worker())
+        await started.wait()
+        assert await is_active() is True
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert await is_active() is False
+
+    @pytest.mark.asyncio
+    async def test_reports_oldest_run_first_with_concurrent_runs(self):
+        async with register_active_sync("op-first", kind="full-update"):
+            async with register_active_sync("op-second", kind="full-update"):
+                snapshot = await get_active_sync()
+                assert snapshot["active"] is True
+                assert snapshot["id"] == "op-first"
+                assert {r["id"] for r in snapshot["runs"]} == {
+                    "op-first",
+                    "op-second",
+                }
+        assert await is_active() is False
+
+
+class TestSyncActiveEndpoint:
+    """HTTP-level tests for the ``GET /sync/active`` probe."""
+
+    @pytest.mark.asyncio
+    async def test_idle_returns_inactive(self, authenticated_client):
+        resp = await authenticated_client.get("/sync/active")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["active"] is False
+        assert body["started_at"] is None
+        assert body["id"] is None
+        assert body["runs"] == []
+
+    @pytest.mark.asyncio
+    async def test_reports_in_flight_run(self, authenticated_client):
+        async with register_active_sync("op-live", kind="full-update"):
+            resp = await authenticated_client.get("/sync/active")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["active"] is True
+            assert body["id"] == "op-live"
+            assert body["kind"] == "full-update"
+            assert body["started_at"] is not None
+            assert len(body["runs"]) == 1
+            assert body["runs"][0]["id"] == "op-live"
+        resp = await authenticated_client.get("/sync/active")
+        assert resp.json()["active"] is False
+
+    @pytest.mark.asyncio
+    async def test_requires_auth(self, client_with_fake_netbox):
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            resp = await client.get("/sync/active")
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_response_shape_matches_schema(self, authenticated_client):
+        resp = await authenticated_client.get("/sync/active")
+        assert resp.status_code == 200
+        body = resp.json()
+        expected_keys = {"active", "started_at", "id", "kind", "runs"}
+        assert expected_keys.issubset(body.keys())


### PR DESCRIPTION
Closes #71.

## Summary

- New `proxbox_api.app.sync_state` module — process-local registry of in-flight full-update runs with `acquire_active_sync` / `release_active_sync` and an `async with register_active_sync(...)` context manager that releases the entry on success, exception, and cancellation.
- `POST /full-update` and `POST /full-update/stream` both register their `operation_id` so the probe reflects real in-flight work. The streaming variant wraps the SSE generator body (not the route handler) so the entry tracks the generator's lifetime.
- New `GET /sync/active` route returning `{ active, started_at, id, kind, runs }`. `runs` lists every in-flight registration for the local replica (FIFO; the top-level fields mirror the oldest run).
- Auth-gated under the existing `APIKeyAuthMiddleware` (the endpoint is not added to `AUTH_EXEMPT_PATHS`).
- Documented as a soft probe in `docs/api/http-reference.md` with a multi-worker caveat — it is not a distributed lock.

## Test plan

- [x] `uv run pytest tests/test_sync_active.py` — 9 new tests covering registry lifecycle (idle, acquire/release, exception cleanup, cancellation cleanup, FIFO with concurrent runs) and the HTTP endpoint (idle 200, active reports run, requires auth 401, response shape).
- [x] Regression: `uv run pytest tests/test_main_smoke.py tests/test_api_routes.py tests/test_overwrite_flags_contract.py tests/test_schema_contracts.py` — all pass.
- [x] `uv run ruff check .` and `uv run ruff format --check .` clean.
- [x] `uv run python -m compileall proxbox_api tests` succeeds.