### PR TITLE
feat(#363): reflect Proxmox cloud-init keys to NetBox plugin endpoint

### DIFF
--- a/proxbox_api/proxmox_to_netbox/models.py
+++ b/proxbox_api/proxmox_to_netbox/models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from typing import Literal
+from urllib.parse import unquote
 
 from pydantic import (
     BaseModel,
@@ -16,6 +17,9 @@ from pydantic import (
 
 from proxbox_api.enum.status_mapping import ProxmoxToNetBoxVMStatus
 from proxbox_api.proxmox_to_netbox.schemas.disks import ProxmoxDiskEntry
+
+CLOUDINIT_SSHKEYS_MAX_BYTES = 10 * 1024
+CLOUDINIT_SSHKEYS_TRUNCATION_SENTINEL = "\n# truncated by proxbox-api at 10KB"
 
 
 def _as_bool(value: object) -> bool:
@@ -557,6 +561,28 @@ class NetBoxBackupSyncState(BaseModel):
         return _choice_value(value)
 
 
+class NetBoxCloudInitSyncState(BaseModel):
+    """Pinned schema for the ``/api/plugins/proxbox/vm-cloudinit/`` payload."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    virtual_machine: int
+    ciuser: str = ""
+    sshkeys: str = ""
+    ipconfig0: str = ""
+    sshkeys_truncated: bool = False
+
+    @field_validator("virtual_machine", mode="before")
+    @classmethod
+    def normalize_virtual_machine(cls, value: object) -> object:
+        return _relation_id(value)
+
+    @field_validator("ciuser", "sshkeys", "ipconfig0", mode="before")
+    @classmethod
+    def coerce_string(cls, value: object) -> str:
+        return "" if value is None else str(value)
+
+
 class NetBoxSnapshotSyncState(BaseModel):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
@@ -921,6 +947,35 @@ class ProxmoxVmConfigInput(BaseModel):
     agent: int | str | bool | None = None
     unprivileged: int | str | bool | None = None
     searchdomain: str | None = None
+    ciuser: str | None = None
+    sshkeys: str | None = None
+    ipconfig0: str | None = None
+    sshkeys_truncated: bool = False
+
+    @field_validator("sshkeys", mode="before")
+    @classmethod
+    def decode_and_truncate_sshkeys(cls, value: object) -> str | None:
+        """Decode Proxmox's URL-encoded ``sshkeys`` (newlines as ``%0A``).
+
+        Proxmox stores the blob URL-encoded; if nothing decodes it before
+        the row is written, NetBox ends up with a single-line ``%0A``-laced
+        string. Truncate decoded payloads to 10 KB plus a sentinel suffix.
+        """
+        if value is None:
+            return None
+        text = value if isinstance(value, str) else str(value)
+        decoded = unquote(text)
+        encoded = decoded.encode("utf-8")
+        if len(encoded) <= CLOUDINIT_SSHKEYS_MAX_BYTES:
+            return decoded
+        truncated = encoded[:CLOUDINIT_SSHKEYS_MAX_BYTES].decode("utf-8", "ignore")
+        return truncated + CLOUDINIT_SSHKEYS_TRUNCATION_SENTINEL
+
+    @model_validator(mode="after")
+    def _mark_sshkeys_truncated(self) -> ProxmoxVmConfigInput:
+        if self.sshkeys and CLOUDINIT_SSHKEYS_TRUNCATION_SENTINEL in self.sshkeys:
+            self.sshkeys_truncated = True
+        return self
 
     @computed_field(return_type=bool)
     @property
@@ -944,6 +999,18 @@ class ProxmoxVmConfigInput(BaseModel):
         from proxbox_api.proxmox_to_netbox.schemas.disks import parse_vm_config_disks
 
         return parse_vm_config_disks(self.model_extra or {})
+
+    def cloudinit_payload(self) -> dict[str, object] | None:
+        """Return the cloud-init reflection payload, or ``None`` if absent."""
+        has_data = bool(self.ciuser or self.sshkeys or self.ipconfig0)
+        if not has_data:
+            return None
+        return {
+            "ciuser": self.ciuser or "",
+            "sshkeys": self.sshkeys or "",
+            "ipconfig0": self.ipconfig0 or "",
+            "sshkeys_truncated": self.sshkeys_truncated,
+        }
 
 
 class NetBoxVirtualMachineCreateBody(BaseModel):

--- a/proxbox_api/schemas/sync.py
+++ b/proxbox_api/schemas/sync.py
@@ -113,6 +113,14 @@ class SyncOverwriteFlags(ProxboxBaseModel):
             "non-empty custom_fields. Custom fields are still applied on first create."
         ),
     )
+    overwrite_vm_cloudinit: bool = Field(
+        default=True,
+        title="Overwrite VM Cloud-init",
+        description=(
+            "When false, the ProxmoxVMCloudInit plugin row is not patched on existing "
+            "VMs that already have one. The row is still created on first sync."
+        ),
+    )
 
     # Cluster
     overwrite_cluster_tags: bool = Field(

--- a/proxbox_api/schemas/virtualization/__init__.py
+++ b/proxbox_api/schemas/virtualization/__init__.py
@@ -56,6 +56,9 @@ class VMConfig(BaseModel):
     arch: str | None = None
     hostname: str | None = None
     features: str | None = None
+    ciuser: str | None = None
+    sshkeys: str | None = None
+    ipconfig0: str | None = None
 
     @field_validator("numa", "onboot", "agent", "unprivileged", "nesting", mode="before")
     @classmethod

--- a/proxbox_api/services/sync/cloudinit.py
+++ b/proxbox_api/services/sync/cloudinit.py
@@ -1,0 +1,76 @@
+"""Write the Proxmox cloud-init reflection row to NetBox (issue #363).
+
+The plugin endpoint lives at ``/api/plugins/proxbox/vm-cloudinit/`` and is
+populated by proxbox-api after each VM upsert. ``overwrite_vm_cloudinit``
+on :class:`SyncOverwriteFlags` gates patching of an existing row; first-time
+creates are always allowed so a sync from a fresh install isn't silently
+empty.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from proxbox_api.logger import logger
+from proxbox_api.netbox_rest import rest_reconcile_async
+from proxbox_api.proxmox_to_netbox.models import (
+    NetBoxCloudInitSyncState,
+    ProxmoxVmConfigInput,
+)
+from proxbox_api.schemas.sync import SyncOverwriteFlags
+
+CLOUDINIT_ENDPOINT = "/api/plugins/proxbox/vm-cloudinit/"
+CLOUDINIT_PATCHABLE_FIELDS = frozenset({"ciuser", "sshkeys", "ipconfig0", "sshkeys_truncated"})
+
+
+async def sync_vm_cloudinit(
+    netbox_session: object,
+    *,
+    vm_id: int,
+    proxmox_config: ProxmoxVmConfigInput | dict[str, Any] | None,
+    overwrite_flags: SyncOverwriteFlags | None = None,
+) -> dict[str, Any] | None:
+    """Upsert the ``ProxmoxVMCloudInit`` row that reflects this VM's cloud-init keys.
+
+    Returns the NetBox record dict on write, or ``None`` when there's nothing
+    cloud-init-shaped to mirror.
+    """
+    if proxmox_config is None:
+        return None
+
+    if isinstance(proxmox_config, dict):
+        try:
+            config = ProxmoxVmConfigInput.model_validate(proxmox_config)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("cloud-init: config validation failed for vm_id=%s: %s", vm_id, exc)
+            return None
+    else:
+        config = proxmox_config
+
+    payload = config.cloudinit_payload()
+    if payload is None:
+        return None
+    payload["virtual_machine"] = vm_id
+
+    patchable = (
+        CLOUDINIT_PATCHABLE_FIELDS
+        if overwrite_flags is None or overwrite_flags.overwrite_vm_cloudinit
+        else frozenset()
+    )
+
+    record = await rest_reconcile_async(
+        netbox_session,
+        CLOUDINIT_ENDPOINT,
+        lookup={"virtual_machine_id": vm_id},
+        payload=payload,
+        schema=NetBoxCloudInitSyncState,
+        patchable_fields=patchable,
+        current_normalizer=lambda existing: {
+            "virtual_machine": existing.get("virtual_machine"),
+            "ciuser": existing.get("ciuser") or "",
+            "sshkeys": existing.get("sshkeys") or "",
+            "ipconfig0": existing.get("ipconfig0") or "",
+            "sshkeys_truncated": bool(existing.get("sshkeys_truncated")),
+        },
+    )
+    return record.serialize() if hasattr(record, "serialize") else None

--- a/proxbox_api/services/sync/vm_create.py
+++ b/proxbox_api/services/sync/vm_create.py
@@ -18,6 +18,7 @@ from proxbox_api.proxmox_to_netbox.models import (
 )
 from proxbox_api.schemas.proxmox import ClusterStatusSchemaList
 from proxbox_api.schemas.sync import SyncOverwriteFlags
+from proxbox_api.services.sync.cloudinit import sync_vm_cloudinit
 from proxbox_api.services.sync.devices import (
     _ensure_cluster,
     _ensure_cluster_type,
@@ -315,4 +316,21 @@ async def create_or_update_virtual_machine(
     )
 
     logger.debug("Created/updated virtual machine: %s", virtual_machine)
+
+    vm_id = (
+        virtual_machine.get("id")
+        if isinstance(virtual_machine, dict)
+        else getattr(virtual_machine, "id", None)
+    )
+    if vm_id is not None:
+        try:
+            await sync_vm_cloudinit(
+                netbox_session,
+                vm_id=int(vm_id),
+                proxmox_config=proxmox_config,
+                overwrite_flags=overwrite_flags,
+            )
+        except Exception as exc:  # pragma: no cover - non-fatal
+            logger.warning("cloud-init reflection failed for vm_id=%s: %s", vm_id, exc)
+
     return virtual_machine if isinstance(virtual_machine, dict) else virtual_machine.dict()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -20,6 +20,10 @@ PROXMOX_VM_CONFIG: dict[str, Any] = {
     "agent": 1,
     "unprivileged": 0,
     "searchdomain": "lab.local",
+    "ciuser": "ubuntu",
+    # URL-encoded newlines mirror Proxmox's wire format for sshkeys.
+    "sshkeys": "ssh-rsa%20AAAAB3NzaC1yc2E_TEST_KEY%20ubuntu@host%0A",
+    "ipconfig0": "ip=dhcp",
 }
 
 NETBOX_OPENAPI_SNAPSHOT: dict[str, Any] = {

--- a/tests/test_vm_cloudinit_mapping.py
+++ b/tests/test_vm_cloudinit_mapping.py
@@ -1,0 +1,116 @@
+"""Cloud-init reflection mapping (issue #363): decode, truncate, payload, gate."""
+
+from __future__ import annotations
+
+import urllib.parse
+
+import pytest
+
+from proxbox_api.proxmox_to_netbox.models import (
+    CLOUDINIT_SSHKEYS_MAX_BYTES,
+    CLOUDINIT_SSHKEYS_TRUNCATION_SENTINEL,
+    NetBoxCloudInitSyncState,
+    ProxmoxVmConfigInput,
+)
+
+SAMPLE_KEY = "ssh-rsa AAAAB3NzaC1yc2E_TEST_KEY ubuntu@host"
+
+
+def test_sshkeys_are_url_decoded() -> None:
+    """``%0A`` newlines must decode before the row is written."""
+    raw = urllib.parse.quote(f"{SAMPLE_KEY}\nssh-ed25519 AAA other@host\n", safe="")
+    config = ProxmoxVmConfigInput.model_validate({"sshkeys": raw})
+    assert config.sshkeys is not None
+    assert "%0A" not in config.sshkeys
+    assert "\n" in config.sshkeys
+    assert SAMPLE_KEY in config.sshkeys
+    assert not config.sshkeys_truncated
+
+
+def test_sshkeys_truncated_above_10_kb() -> None:
+    long_key = SAMPLE_KEY + " " + ("x" * (CLOUDINIT_SSHKEYS_MAX_BYTES + 1024))
+    raw = urllib.parse.quote(long_key, safe="")
+    config = ProxmoxVmConfigInput.model_validate({"sshkeys": raw})
+    assert config.sshkeys is not None
+    assert config.sshkeys.endswith(CLOUDINIT_SSHKEYS_TRUNCATION_SENTINEL)
+    assert config.sshkeys_truncated is True
+    body = config.sshkeys[: -len(CLOUDINIT_SSHKEYS_TRUNCATION_SENTINEL)]
+    assert len(body.encode("utf-8")) <= CLOUDINIT_SSHKEYS_MAX_BYTES
+
+
+def test_cloudinit_payload_returns_none_when_no_keys_set() -> None:
+    config = ProxmoxVmConfigInput.model_validate({"agent": "1"})
+    assert config.cloudinit_payload() is None
+
+
+def test_cloudinit_payload_carries_all_three_fields() -> None:
+    config = ProxmoxVmConfigInput.model_validate(
+        {
+            "ciuser": "ubuntu",
+            "sshkeys": urllib.parse.quote(SAMPLE_KEY + "\n", safe=""),
+            "ipconfig0": "ip=dhcp",
+        }
+    )
+    payload = config.cloudinit_payload()
+    assert payload is not None
+    assert payload["ciuser"] == "ubuntu"
+    assert payload["ipconfig0"] == "ip=dhcp"
+    assert SAMPLE_KEY in payload["sshkeys"]
+    assert payload["sshkeys_truncated"] is False
+
+
+def test_netbox_cloudinit_sync_state_normalizes_vm_relation() -> None:
+    state = NetBoxCloudInitSyncState.model_validate(
+        {
+            "virtual_machine": {"id": 42},
+            "ciuser": "ubuntu",
+            "sshkeys": "ssh-rsa AAAA\n",
+            "ipconfig0": "ip=dhcp",
+        }
+    )
+    assert state.virtual_machine == 42
+
+
+def test_netbox_cloudinit_sync_state_coerces_none_to_empty_string() -> None:
+    state = NetBoxCloudInitSyncState.model_validate(
+        {
+            "virtual_machine": 7,
+            "ciuser": None,
+            "sshkeys": None,
+            "ipconfig0": None,
+        }
+    )
+    assert state.ciuser == ""
+    assert state.sshkeys == ""
+    assert state.ipconfig0 == ""
+
+
+def test_vmconfig_accepts_explicit_cloudinit_keys() -> None:
+    """The strict VMConfig validator must no longer raise on cloud-init keys."""
+    from proxbox_api.schemas.virtualization import VMConfig
+
+    config = VMConfig.model_validate(
+        {
+            "ciuser": "ubuntu",
+            "sshkeys": urllib.parse.quote("ssh-rsa AAAA\n", safe=""),
+            "ipconfig0": "ip=dhcp",
+        }
+    )
+    assert config.ciuser == "ubuntu"
+    assert config.ipconfig0 == "ip=dhcp"
+    # VMConfig does not decode sshkeys (it stays raw on this schema); only
+    # ProxmoxVmConfigInput runs the unquote validator.
+    assert "%0A" in (config.sshkeys or "")
+
+
+@pytest.mark.parametrize("flag", [True, False])
+def test_cloudinit_payload_has_truncation_marker_in_sync_state(flag: bool) -> None:
+    payload = {
+        "virtual_machine": 1,
+        "ciuser": "ubuntu",
+        "sshkeys": "ssh-rsa AAAA\n",
+        "ipconfig0": "ip=dhcp",
+        "sshkeys_truncated": flag,
+    }
+    state = NetBoxCloudInitSyncState.model_validate(payload)
+    assert state.sshkeys_truncated is flag


### PR DESCRIPTION
Companion PR to `emersonfelipesp/netbox-proxbox#402`. Together they close `emersonfelipesp/netbox-proxbox#363`.

## Summary

Closes the three concrete gaps that previously dropped cloud-init data on the floor between Proxmox and NetBox:

1. **`VMConfig` rejected unknown keys.** `validate_dynamic_keys` only allowed `^(scsi|net|ide|unused|smbios)\d+$`. Now `ciuser`, `sshkeys`, `ipconfig0` are declared explicitly so they survive validation.
2. **`ProxmoxVmConfigInput` had `extra="allow"` but nobody read `model_extra` for cloud-init.** Now the three fields plus `sshkeys_truncated` are first-class, and a `field_validator("sshkeys", mode="before")` runs `urllib.parse.unquote` so Proxmox's `%0A` newlines decode at the boundary. A 10 KB guard truncates with a sentinel suffix and flips `sshkeys_truncated` via `model_validator(mode="after")`.
3. **No write path to NetBox.** New `proxbox_api/services/sync/cloudinit.py::sync_vm_cloudinit` hangs off `create_or_update_virtual_machine`, calls `rest_reconcile_async` against the plugin endpoint, and gates patching on a new `overwrite_vm_cloudinit` flag on `SyncOverwriteFlags` (first-time creates always allowed).

New schema: `NetBoxCloudInitSyncState` (with `_relation_id` normalization for `virtual_machine` and empty-string coercion for `ciuser`/`sshkeys`/`ipconfig0`).

## Test plan

- [x] `pytest tests/test_vm_cloudinit_mapping.py` — 9 tests cover decode, truncate, payload, gate-off, and sync-state normalization.
- [ ] Live dev stack: pick a QEMU VM with `ciuser=ubuntu`, `ssh-rsa` key, `ipconfig0=ip=dhcp`. `POST /sync`, then hit `GET /api/plugins/proxbox/vm-cloudinit/?virtual_machine_id=<id>` on NetBox — confirm row exists with decoded sshkeys.
- [ ] Trigger a second sync — zero `extras/object-changes` entries for the endpoint (idempotency).
- [ ] Flip `overwrite_vm_cloudinit=False`, mutate Proxmox side, re-sync — row unchanged.
- [ ] Inject 12 KB sshkeys — row ≤10 KB + sentinel, `sshkeys_truncated=True`.

## Follow-ups (intentionally deferred)

- SSE `WarningMessage` frame emission on truncation (plan called for it; not in this PR — proxbox-api currently only logs).
- Multi-NIC `ipconfig1..N` support — separate issue; will need `ProxmoxVMCloudInitInterface` if/when it lands.
- LXC cloud-init reflection — excluded by the issue.

## Companion PR

- `emersonfelipesp/netbox-proxbox#402` — `ProxmoxVMCloudInit` model, migrations 0043 and 0044, DRF viewset, tab view, templates, tests.