### PR TITLE
feat(vm-sync): hierarchical default role with operator-edit lock

### DIFF
--- a/proxbox_api/app/full_update.py
+++ b/proxbox_api/app/full_update.py
@@ -8,7 +8,7 @@ import uuid
 from contextlib import nullcontext
 from typing import Annotated
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
 from fastapi.responses import StreamingResponse
 
 from proxbox_api.dependencies import (

--- a/proxbox_api/routes/proxmox_actions.py
+++ b/proxbox_api/routes/proxmox_actions.py
@@ -62,9 +62,7 @@ VmType = Literal["qemu", "lxc"]
 Verb = Literal["start", "stop", "snapshot", "migrate"]
 
 
-async def _gate(
-    session: SessionDep, endpoint_id: int | None
-) -> JSONResponse | ProxmoxEndpoint:
+async def _gate(session: SessionDep, endpoint_id: int | None) -> JSONResponse | ProxmoxEndpoint:
     """Resolve the target endpoint and enforce ``allow_writes``."""
     if endpoint_id is None:
         return JSONResponse(
@@ -143,9 +141,7 @@ async def _dispatch_start(
     cache = get_idempotency_cache()
     cache_key: CacheKey | None = None
     if idempotency_key:
-        cache_key = CacheKey(
-            endpoint_id=endpoint_id, verb="start", vmid=vmid, key=idempotency_key
-        )
+        cache_key = CacheKey(endpoint_id=endpoint_id, verb="start", vmid=vmid, key=idempotency_key)
         cached = await cache.get(cache_key)
         if cached is not None:
             return JSONResponse(status_code=status.HTTP_200_OK, content=cached)

--- a/proxbox_api/routes/proxmox_actions.py
+++ b/proxbox_api/routes/proxmox_actions.py
@@ -41,9 +41,6 @@ from proxbox_api.database import AsyncDatabaseSessionDep as SessionDep
 from proxbox_api.database import ProxmoxEndpoint
 from proxbox_api.exception import ProxboxException, ProxmoxAPIError
 from proxbox_api.logger import logger
-from proxbox_api.session.netbox import get_netbox_async_session
-from proxbox_api.session.proxmox import ProxmoxSession
-from proxbox_api.session.proxmox_providers import _parse_db_endpoint
 from proxbox_api.services.idempotency import CacheKey, get_idempotency_cache
 from proxbox_api.services.proxmox_helpers import get_vm_status, start_vm
 from proxbox_api.services.verb_dispatch import (
@@ -54,6 +51,9 @@ from proxbox_api.services.verb_dispatch import (
     utcnow_iso,
     write_verb_journal_entry,
 )
+from proxbox_api.session.netbox import get_netbox_async_session
+from proxbox_api.session.proxmox import ProxmoxSession
+from proxbox_api.session.proxmox_providers import _parse_db_endpoint
 from proxbox_api.utils.async_compat import maybe_await as _maybe_await
 
 router = APIRouter()

--- a/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
+++ b/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
@@ -65,6 +65,12 @@ from proxbox_api.services.sync.devices import (
 from proxbox_api.services.sync.network import (
     _resolve_vm_interface_identity,
 )
+from proxbox_api.services.sync.role_resolution import (
+    LAST_SYNCED_ROLE_CUSTOM_FIELD,
+    compute_role_snapshot_decision,
+    extract_snapshot_id,
+    resolve_default_role_id,
+)
 from proxbox_api.services.sync.storage_links import (
     build_storage_index,
     find_storage_record,
@@ -113,6 +119,7 @@ class _PreparedVMState:
     lookup: dict[str, object]
     now: datetime
     vm_type: str
+    desired_role_id: int | None = None
 
 
 @dataclass(slots=True)
@@ -307,8 +314,6 @@ def _build_vm_operation_queue(
             if current_payload.get(field_name) != desired_value
         }
 
-        if not overwrite_vm_role and _relation_id(existing_record.get("role")) is not None:
-            patch_payload.pop("role", None)
         if (
             not overwrite_vm_type
             and _relation_id(existing_record.get("virtual_machine_type")) is not None
@@ -337,6 +342,37 @@ def _build_vm_operation_queue(
                 patch_payload.pop("tags", None)
             else:
                 patch_payload["tags"] = merged
+
+        existing_role_id = _relation_id(existing_record.get("role"))
+        existing_snapshot_id = extract_snapshot_id(existing_record)
+        decision = compute_role_snapshot_decision(
+            existing_role_id=existing_role_id,
+            existing_snapshot_id=existing_snapshot_id,
+            desired_role_id=prepared.desired_role_id,
+            overwrite_vm_role=overwrite_vm_role,
+        )
+        if decision.write_role:
+            patch_payload["role"] = decision.role_value
+        else:
+            patch_payload.pop("role", None)
+
+        cf_payload = patch_payload.get("custom_fields")
+        if not isinstance(cf_payload, dict):
+            cf_payload = None
+        if decision.write_snapshot:
+            cf_payload = dict(cf_payload) if cf_payload else {}
+            cf_payload[LAST_SYNCED_ROLE_CUSTOM_FIELD] = decision.snapshot_value
+            patch_payload["custom_fields"] = cf_payload
+        elif isinstance(cf_payload, dict) and LAST_SYNCED_ROLE_CUSTOM_FIELD in cf_payload:
+            trimmed = {
+                key: value
+                for key, value in cf_payload.items()
+                if key != LAST_SYNCED_ROLE_CUSTOM_FIELD
+            }
+            if trimmed:
+                patch_payload["custom_fields"] = trimmed
+            else:
+                patch_payload.pop("custom_fields", None)
 
         if patch_payload:
             operation_queue.append(
@@ -1449,13 +1485,21 @@ async def create_virtual_machines(  # noqa: C901
         vm_type_obj = await _get_vm_type(vm_type_key)
         vm_type_id = int(getattr(vm_type_obj, "id", 0) or 0) if vm_type_obj else None
 
+        cluster_id_int = int(getattr(cluster, "id", 0) or 0)
+        desired_role_id = await resolve_default_role_id(
+            nb,
+            vm_type=vm_type_key,
+            node_name=node_name,
+            cluster_id=cluster_id_int or None,
+        )
+
         now = datetime.now(timezone.utc)
         desired_payload = build_netbox_virtual_machine_payload(
             proxmox_resource=resource,
             proxmox_config=vm_config,
-            cluster_id=int(getattr(cluster, "id", 0) or 0),
+            cluster_id=cluster_id_int,
             device_id=int(getattr(device, "id", 0) or 0),
-            role_id=None if vm_type_id else int(getattr(role, "id", 0) or 0),
+            role_id=desired_role_id,
             tag_ids=[int(getattr(tag, "id", 0) or 0)],
             site_id=int(getattr(cluster_dependencies.get("site"), "id", 0) or 0) or None,
             tenant_id=int(getattr(cluster_dependencies.get("tenant"), "id", 0) or 0) or None,
@@ -1464,9 +1508,15 @@ async def create_virtual_machines(  # noqa: C901
             cluster_name=str(cluster_name),
             proxmox_url=proxmox_url_by_cluster.get(str(cluster_name)),
         )
+        if desired_role_id is not None:
+            cf_block = desired_payload.get("custom_fields")
+            if not isinstance(cf_block, dict):
+                cf_block = {}
+            cf_block[LAST_SYNCED_ROLE_CUSTOM_FIELD] = desired_role_id
+            desired_payload["custom_fields"] = cf_block
         lookup = {
             "cf_proxmox_vm_id": int(resource.get("vmid")),
-            "cluster_id": int(getattr(cluster, "id", 0) or 0),
+            "cluster_id": cluster_id_int,
         }
 
         return _PreparedVMState(
@@ -1478,6 +1528,7 @@ async def create_virtual_machines(  # noqa: C901
             lookup=lookup,
             now=now,
             vm_type=vm_type,
+            desired_role_id=desired_role_id,
         )
 
     async def _run_full_update_vm_batch() -> list[dict[str, object]]:  # noqa: C901
@@ -1771,13 +1822,21 @@ async def create_virtual_machines(  # noqa: C901
                 python_exception=f"Error: {str(error)}",
             )
 
+        cluster_id_int = int(getattr(cluster, "id", 0) or 0)
+        desired_role_id = await resolve_default_role_id(
+            nb,
+            vm_type=vm_type_key,
+            node_name=node_name,
+            cluster_id=cluster_id_int or None,
+        )
+
         now = datetime.now(timezone.utc)
         netbox_vm_payload = build_netbox_virtual_machine_payload(
             proxmox_resource=resource,
             proxmox_config=vm_config,
-            cluster_id=int(getattr(cluster, "id", 0) or 0),
+            cluster_id=cluster_id_int,
             device_id=int(getattr(device, "id", 0) or 0),
-            role_id=None if vm_type_id else int(getattr(role, "id", 0) or 0),
+            role_id=desired_role_id,
             tag_ids=[int(getattr(tag, "id", 0) or 0)],
             site_id=int(getattr(cluster_dependencies.get("site"), "id", 0) or 0) or None,
             tenant_id=int(getattr(cluster_dependencies.get("tenant"), "id", 0) or 0) or None,
@@ -1786,6 +1845,59 @@ async def create_virtual_machines(  # noqa: C901
             cluster_name=str(cluster_name),
             proxmox_url=proxmox_url_by_cluster.get(str(cluster_name)),
         )
+
+        vm_lookup = {
+            "cf_proxmox_vm_id": int(resource.get("vmid")),
+            "cluster_id": cluster_id_int,
+        }
+        try:
+            existing_vm_record = await rest_first_async(
+                nb,
+                "/api/virtualization/virtual-machines/",
+                query={**vm_lookup, "limit": 2},
+            )
+        except Exception as exc:
+            logger.debug(
+                "VM prefetch for role-snapshot decision failed (vmid=%s): %s",
+                resource.get("vmid"),
+                exc,
+            )
+            existing_vm_record = None
+        existing_vm_dict = _to_mapping(existing_vm_record) if existing_vm_record else None
+
+        decision = compute_role_snapshot_decision(
+            existing_role_id=_relation_id(existing_vm_dict.get("role"))
+            if existing_vm_dict
+            else None,
+            existing_snapshot_id=extract_snapshot_id(existing_vm_dict)
+            if existing_vm_dict
+            else None,
+            desired_role_id=desired_role_id,
+            overwrite_vm_role=overwrite_vm_role,
+        )
+
+        if decision.write_role:
+            netbox_vm_payload["role"] = decision.role_value
+        else:
+            netbox_vm_payload.pop("role", None)
+
+        cf_block = netbox_vm_payload.get("custom_fields")
+        if not isinstance(cf_block, dict):
+            cf_block = None
+        if decision.write_snapshot:
+            cf_block = dict(cf_block) if cf_block else {}
+            cf_block[LAST_SYNCED_ROLE_CUSTOM_FIELD] = decision.snapshot_value
+            netbox_vm_payload["custom_fields"] = cf_block
+        elif isinstance(cf_block, dict) and LAST_SYNCED_ROLE_CUSTOM_FIELD in cf_block:
+            trimmed = {
+                key: value
+                for key, value in cf_block.items()
+                if key != LAST_SYNCED_ROLE_CUSTOM_FIELD
+            }
+            if trimmed:
+                netbox_vm_payload["custom_fields"] = trimmed
+            else:
+                netbox_vm_payload.pop("custom_fields", None)
 
         if bridge:
             await bridge.emit_substep(
@@ -1799,10 +1911,7 @@ async def create_virtual_machines(  # noqa: C901
         virtual_machine = await rest_reconcile_async(
             nb,
             "/api/virtualization/virtual-machines/",
-            lookup={
-                "cf_proxmox_vm_id": int(resource.get("vmid")),
-                "cluster_id": int(getattr(cluster, "id", 0) or 0),
-            },
+            lookup=vm_lookup,
             payload=netbox_vm_payload,
             schema=NetBoxVirtualMachineCreateBody,
             patchable_fields=vm_patchable_fields,

--- a/proxbox_api/services/idempotency.py
+++ b/proxbox_api/services/idempotency.py
@@ -74,9 +74,7 @@ class IdempotencyCache:
     async def store(self, cache_key: CacheKey, response: dict[str, object]) -> None:
         async with self._lock:
             now = self._now()
-            self._entries[cache_key] = _Entry(
-                response=dict(response), expires_at=now + self._ttl
-            )
+            self._entries[cache_key] = _Entry(response=dict(response), expires_at=now + self._ttl)
 
     async def clear(self) -> None:
         async with self._lock:

--- a/proxbox_api/services/idempotency.py
+++ b/proxbox_api/services/idempotency.py
@@ -22,7 +22,6 @@ import time
 from dataclasses import dataclass
 from typing import Literal
 
-
 Verb = Literal["start", "stop", "snapshot", "migrate"]
 TTL_SECONDS = 60.0
 

--- a/proxbox_api/services/proxmox_helpers.py
+++ b/proxbox_api/services/proxmox_helpers.py
@@ -680,16 +680,12 @@ async def get_vm_status(
             payload = await resolve_async(
                 session.session.nodes(node).lxc(vmid).status.current.get()
             )
-            return generated_models.GetNodesNodeLxcVmidStatusCurrentResponse.model_validate(
-                payload
-            )
+            return generated_models.GetNodesNodeLxcVmidStatusCurrentResponse.model_validate(payload)
         raise ValueError(f"Unsupported VM type: {vm_type}")
     except ProxboxException:
         raise
     except ProxmoxTimeoutError as error:
-        raise ProxmoxAPIError(
-            message="Proxmox VM status request timed out", original_error=error
-        )
+        raise ProxmoxAPIError(message="Proxmox VM status request timed out", original_error=error)
     except ProxmoxConnectionError as error:
         raise ProxmoxAPIError(
             message="Unable to connect to Proxmox for VM status", original_error=error
@@ -719,9 +715,7 @@ async def start_vm(
                 session.session.nodes(node).qemu(vmid).status.start.post()
             )
         elif vm_type == "lxc":
-            payload = await resolve_async(
-                session.session.nodes(node).lxc(vmid).status.start.post()
-            )
+            payload = await resolve_async(session.session.nodes(node).lxc(vmid).status.start.post())
         else:
             raise ValueError(f"Unsupported VM type: {vm_type}")
         if isinstance(payload, str):

--- a/proxbox_api/services/sync/role_resolution.py
+++ b/proxbox_api/services/sync/role_resolution.py
@@ -1,0 +1,212 @@
+"""Hierarchical default-role resolution and per-VM snapshot lock helpers.
+
+Issue #364: synced Proxmox VMs/containers pick a NetBox ``DeviceRole``
+from a four-tier hierarchy — operator-edit lock → per-Node → per-Endpoint →
+plugin singleton — and a hidden ``proxmox_last_synced_role_id`` custom field
+on each VM tracks the last value Proxbox wrote so direct operator edits in
+the NetBox UI are preserved on subsequent syncs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from proxbox_api.logger import logger
+from proxbox_api.netbox_rest import rest_first_async
+from proxbox_api.services.sync.vm_helpers import relation_id as _relation_id
+from proxbox_api.settings_client import get_settings
+
+LAST_SYNCED_ROLE_CUSTOM_FIELD = "proxmox_last_synced_role_id"
+
+VMType = Literal["qemu", "lxc"]
+
+
+def _coerce_int(value: object) -> int | None:
+    rid = _relation_id(value)
+    if rid is not None:
+        return rid
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.strip().lstrip("-").isdigit():
+        return int(value.strip())
+    return None
+
+
+async def _resolve_from_node_and_endpoint(
+    nb: object,
+    *,
+    field_name: str,
+    node_name: str,
+    cluster_id: int | None,
+) -> int | None:
+    """Return the node- or endpoint-tier default role id, or ``None``."""
+    query: dict[str, object] = {"name": node_name}
+    if cluster_id is not None:
+        query["proxmox_cluster_id"] = cluster_id
+    try:
+        node_record = await rest_first_async(nb, "/api/plugins/proxbox/proxmox-nodes/", query=query)
+    except Exception as exc:
+        logger.debug(
+            "default-role node lookup failed for %s (cluster=%s): %s",
+            node_name,
+            cluster_id,
+            exc,
+        )
+        return None
+
+    if node_record is None:
+        return None
+
+    role_id = _coerce_int(node_record.get(field_name))
+    if role_id is not None:
+        return role_id
+
+    endpoint_id = _relation_id(node_record.get("endpoint"))
+    if endpoint_id is None:
+        return None
+    try:
+        endpoint_record = await rest_first_async(
+            nb,
+            "/api/plugins/proxbox/endpoints/proxmox/",
+            query={"id": endpoint_id},
+        )
+    except Exception as exc:
+        logger.debug(
+            "default-role endpoint lookup failed for endpoint=%s: %s",
+            endpoint_id,
+            exc,
+        )
+        return None
+    if endpoint_record is None:
+        return None
+    return _coerce_int(endpoint_record.get(field_name))
+
+
+async def resolve_default_role_id(
+    nb: object,
+    *,
+    vm_type: str,
+    node_name: str | None,
+    cluster_id: int | None,
+) -> int | None:
+    """Resolve the default ``DeviceRole.id`` for a VM via the four-tier hierarchy.
+
+    Walks per-Node → per-Endpoint → plugin singleton, returning the first
+    non-null FK. Returns ``None`` when no tier provides a default — callers
+    leave ``role`` unset in that case.
+    """
+    if vm_type not in {"qemu", "lxc"}:
+        return None
+    field_name = f"default_role_{vm_type}"
+
+    if node_name:
+        role_id = await _resolve_from_node_and_endpoint(
+            nb,
+            field_name=field_name,
+            node_name=node_name,
+            cluster_id=cluster_id,
+        )
+        if role_id is not None:
+            return role_id
+
+    try:
+        settings = get_settings(nb)
+    except Exception as exc:
+        logger.debug("default-role plugin settings lookup failed: %s", exc)
+        return None
+    return _coerce_int(settings.get(f"default_role_{vm_type}_id"))
+
+
+@dataclass(frozen=True, slots=True)
+class RoleSnapshotDecision:
+    """Resolved role + snapshot writes for a single VM reconciliation.
+
+    Attributes mirror the two payload writes the sync must produce: ``role``
+    on the VM and ``custom_fields.proxmox_last_synced_role_id``. ``None`` for
+    a ``*_value`` means the field would be cleared in NetBox; the matching
+    ``write_*`` flag is the source of truth for "include this field in the
+    PATCH at all".
+    """
+
+    role_value: int | None
+    snapshot_value: int | None
+    write_role: bool
+    write_snapshot: bool
+
+
+def compute_role_snapshot_decision(
+    *,
+    existing_role_id: int | None,
+    existing_snapshot_id: int | None,
+    desired_role_id: int | None,
+    overwrite_vm_role: bool,
+) -> RoleSnapshotDecision:
+    """Decide what the next sync should write for ``role`` and the snapshot.
+
+    Encodes the nine-case matrix from the issue #364 plan:
+
+    * fresh creates (handled by ``initial_create_decision``) always write
+      both fields together
+    * upgrade backfill — snapshot is ``None`` on an existing VM — captures
+      operator intent: if the VM already has a role, treat it as operator
+      intent and only write the snapshot; if the VM has no role, treat as a
+      fresh-create-style apply
+    * normal updates roll snapshot forward when role rolls forward
+    * operator edits (``existing_role_id != snapshot_id``) lock both fields
+      until ``overwrite_vm_role=True`` releases them
+    """
+    if existing_snapshot_id is None:
+        if existing_role_id is not None:
+            return RoleSnapshotDecision(
+                role_value=existing_role_id,
+                snapshot_value=existing_role_id,
+                write_role=False,
+                write_snapshot=True,
+            )
+        return RoleSnapshotDecision(
+            role_value=desired_role_id,
+            snapshot_value=desired_role_id,
+            write_role=desired_role_id is not None,
+            write_snapshot=desired_role_id is not None,
+        )
+
+    if existing_role_id != existing_snapshot_id:
+        if overwrite_vm_role:
+            return RoleSnapshotDecision(
+                role_value=desired_role_id,
+                snapshot_value=desired_role_id,
+                write_role=desired_role_id is not None,
+                write_snapshot=desired_role_id is not None,
+            )
+        return RoleSnapshotDecision(
+            role_value=existing_role_id,
+            snapshot_value=existing_snapshot_id,
+            write_role=False,
+            write_snapshot=False,
+        )
+
+    if existing_role_id != desired_role_id and desired_role_id is not None:
+        return RoleSnapshotDecision(
+            role_value=desired_role_id,
+            snapshot_value=desired_role_id,
+            write_role=True,
+            write_snapshot=True,
+        )
+
+    return RoleSnapshotDecision(
+        role_value=existing_role_id,
+        snapshot_value=existing_snapshot_id,
+        write_role=False,
+        write_snapshot=False,
+    )
+
+
+def extract_snapshot_id(record: dict[str, object] | None) -> int | None:
+    """Pull ``proxmox_last_synced_role_id`` out of a NetBox VM record."""
+    if not isinstance(record, dict):
+        return None
+    custom_fields = record.get("custom_fields")
+    if not isinstance(custom_fields, dict):
+        return None
+    return _coerce_int(custom_fields.get(LAST_SYNCED_ROLE_CUSTOM_FIELD))

--- a/proxbox_api/services/sync/vm_create.py
+++ b/proxbox_api/services/sync/vm_create.py
@@ -284,7 +284,7 @@ async def create_or_update_virtual_machine(
         proxmox_config=proxmox_config,
         cluster_id=cluster_id,
         device_id=device_id,
-        role_id=None if resolved_virtual_machine_type_id is not None else role_id,
+        role_id=role_id,
         tag_ids=[tag_id],
         site_id=site_id,
         tenant_id=tenant_id,

--- a/proxbox_api/services/sync/vm_helpers.py
+++ b/proxbox_api/services/sync/vm_helpers.py
@@ -32,14 +32,15 @@ def _compute_vm_patchable_fields(
         overwrite_flags is None or overwrite_flags.overwrite_vm_type
     ):
         fields.add("virtual_machine_type")
-    if overwrite_flags is None or overwrite_flags.overwrite_vm_role:
-        fields.add("role")
+    # ``role`` and ``custom_fields`` are always patchable: per-VM lock is
+    # enforced by the snapshot decision in the payload, and the snapshot
+    # custom field itself must always be writable.
+    fields.add("role")
+    fields.add("custom_fields")
     if overwrite_flags is None or overwrite_flags.overwrite_vm_tags:
         fields.add("tags")
     if overwrite_flags is None or overwrite_flags.overwrite_vm_description:
         fields.add("description")
-    if overwrite_flags is None or overwrite_flags.overwrite_vm_custom_fields:
-        fields.add("custom_fields")
     return fields
 
 

--- a/proxbox_api/services/verb_dispatch.py
+++ b/proxbox_api/services/verb_dispatch.py
@@ -30,7 +30,6 @@ from proxbox_api.logger import logger
 from proxbox_api.netbox_rest import rest_create_async, rest_first_async
 from proxbox_api.services.proxmox_helpers import get_cluster_resources
 
-
 Verb = Literal["start", "stop", "snapshot", "migrate"]
 VmType = Literal["qemu", "lxc"]
 JournalKind = Literal["info", "success", "warning", "danger"]

--- a/proxbox_api/services/verb_dispatch.py
+++ b/proxbox_api/services/verb_dispatch.py
@@ -51,9 +51,7 @@ async def resolve_proxmox_node(
     try:
         resources = await get_cluster_resources(session, resource_type=vm_type)
     except ProxmoxAPIError as error:
-        logger.warning(
-            "Failed to fetch cluster resources for %s/%s: %s", vm_type, vmid, error
-        )
+        logger.warning("Failed to fetch cluster resources for %s/%s: %s", vm_type, vmid, error)
         return JSONResponse(
             status_code=status.HTTP_502_BAD_GATEWAY,
             content={

--- a/proxbox_api/settings_client.py
+++ b/proxbox_api/settings_client.py
@@ -27,6 +27,29 @@ _SETTINGS_CACHE_TTL: float = 300.0  # 5 minutes
 _FETCHING_SETTINGS: bool = False  # reentrance guard against credential-decryption recursion
 
 
+def _coerce_role_id(value: object) -> int | None:
+    """Coerce a NetBox FK field response into an int id, or None.
+
+    The plugin REST serializer renders ForeignKey fields as nested objects (e.g.
+    ``{"id": 5, ...}``), and the runtime endpoint may collapse them to raw ints
+    or omit them entirely. None / empty values resolve to None.
+    """
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        raw = value.get("id")
+        if raw is None:
+            return None
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def parse_cidr_list(text: str | None) -> list[ipaddress.IPv4Network | ipaddress.IPv6Network]:
     """Parse newline-separated CIDR ranges into a list of IPNetwork objects."""
     if not text:
@@ -76,6 +99,8 @@ def get_default_settings() -> ProxboxSettingsDict:
         "proxmox_timeout": 5,
         "proxmox_max_retries": 0,
         "proxmox_retry_backoff": 0.5,
+        "default_role_qemu_id": None,
+        "default_role_lxc_id": None,
     }
 
 
@@ -231,6 +256,8 @@ def fetch_settings_from_netbox(netbox_session: "Api") -> ProxboxSettingsDict | N
             "proxmox_timeout": int(settings.get("proxmox_timeout", 5)),
             "proxmox_max_retries": int(settings.get("proxmox_max_retries", 0)),
             "proxmox_retry_backoff": float(settings.get("proxmox_retry_backoff", 0.5)),
+            "default_role_qemu_id": _coerce_role_id(settings.get("default_role_qemu")),
+            "default_role_lxc_id": _coerce_role_id(settings.get("default_role_lxc")),
         }
 
     except urllib.error.URLError as exc:

--- a/proxbox_api/types/structured_dicts.py
+++ b/proxbox_api/types/structured_dicts.py
@@ -39,6 +39,8 @@ class ProxboxSettingsDict(TypedDict):
     proxmox_timeout: NotRequired[int]
     proxmox_max_retries: NotRequired[int]
     proxmox_retry_backoff: NotRequired[float]
+    default_role_qemu_id: NotRequired[int | None]
+    default_role_lxc_id: NotRequired[int | None]
 
 
 class SyncResultDict(TypedDict):

--- a/tests/test_idempotency_cache.py
+++ b/tests/test_idempotency_cache.py
@@ -101,18 +101,8 @@ async def test_singleton_returns_same_instance():
 
 
 async def test_clear_evicts_all_entries(cache: IdempotencyCache):
-    await cache.store(
-        CacheKey(endpoint_id=1, verb="start", vmid=100, key="a"), {"x": 1}
-    )
-    await cache.store(
-        CacheKey(endpoint_id=1, verb="stop", vmid=100, key="b"), {"x": 2}
-    )
+    await cache.store(CacheKey(endpoint_id=1, verb="start", vmid=100, key="a"), {"x": 1})
+    await cache.store(CacheKey(endpoint_id=1, verb="stop", vmid=100, key="b"), {"x": 2})
     await cache.clear()
-    assert (
-        await cache.get(CacheKey(endpoint_id=1, verb="start", vmid=100, key="a"))
-        is None
-    )
-    assert (
-        await cache.get(CacheKey(endpoint_id=1, verb="stop", vmid=100, key="b"))
-        is None
-    )
+    assert await cache.get(CacheKey(endpoint_id=1, verb="start", vmid=100, key="a")) is None
+    assert await cache.get(CacheKey(endpoint_id=1, verb="stop", vmid=100, key="b")) is None

--- a/tests/test_idempotency_cache.py
+++ b/tests/test_idempotency_cache.py
@@ -17,9 +17,9 @@ import asyncio
 import pytest
 
 from proxbox_api.services.idempotency import (
+    TTL_SECONDS,
     CacheKey,
     IdempotencyCache,
-    TTL_SECONDS,
     get_idempotency_cache,
 )
 

--- a/tests/test_netbox_branch_header.py
+++ b/tests/test_netbox_branch_header.py
@@ -179,9 +179,7 @@ def test_settings_client_module_does_not_reference_activate_branch():
     import pathlib
 
     settings_path = (
-        pathlib.Path(__file__).resolve().parent.parent
-        / "proxbox_api"
-        / "settings_client.py"
+        pathlib.Path(__file__).resolve().parent.parent / "proxbox_api" / "settings_client.py"
     )
     text = settings_path.read_text(encoding="utf-8")
     assert "activate_branch" not in text

--- a/tests/test_netbox_branch_header.py
+++ b/tests/test_netbox_branch_header.py
@@ -15,9 +15,6 @@ from types import SimpleNamespace
 from typing import Iterator
 from unittest.mock import AsyncMock
 
-import pytest
-
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/test_netbox_version.py
+++ b/tests/test_netbox_version.py
@@ -231,7 +231,9 @@ async def test_create_or_update_vm_uses_native_vm_type_payload_on_netbox_46(
     kwargs = captured["kwargs"]
     payload = kwargs["payload"]
     assert payload["virtual_machine_type"] == 18
-    assert "role" not in payload
+    # Issue #364: role + virtual_machine_type now coexist on NetBox 4.6+;
+    # the historic clamp that nulled role when a VM type was present is gone.
+    assert payload["role"] == 3
     assert payload["custom_fields"]["proxmox_vm_type"] == "lxc"
     assert "virtual_machine_type" in kwargs["patchable_fields"]
     assert nb.client.calls == [("GET", "/api/status/")]

--- a/tests/test_patchable_fields.py
+++ b/tests/test_patchable_fields.py
@@ -449,9 +449,7 @@ def test_vm_patchable_never_includes_tenant_legacy_none() -> None:
 def test_vm_patchable_never_includes_tenant_with_any_flag_false(flag_name: str) -> None:
     from proxbox_api.services.sync.vm_helpers import _compute_vm_patchable_fields
 
-    assert "tenant" not in _compute_vm_patchable_fields(
-        SyncOverwriteFlags(**{flag_name: False})
-    )
+    assert "tenant" not in _compute_vm_patchable_fields(SyncOverwriteFlags(**{flag_name: False}))
 
 
 def test_vm_create_body_rejects_tenant_field() -> None:

--- a/tests/test_patchable_fields.py
+++ b/tests/test_patchable_fields.py
@@ -393,10 +393,8 @@ def test_vm_patchable_drops_vm_type_when_netbox_lacks_native_type_field() -> Non
     ("flag_name", "missing_key"),
     [
         ("overwrite_vm_type", "virtual_machine_type"),
-        ("overwrite_vm_role", "role"),
         ("overwrite_vm_tags", "tags"),
         ("overwrite_vm_description", "description"),
-        ("overwrite_vm_custom_fields", "custom_fields"),
     ],
 )
 def test_vm_patchable_drops_key_when_schema_flag_false(flag_name: str, missing_key: str) -> None:
@@ -406,3 +404,14 @@ def test_vm_patchable_drops_key_when_schema_flag_false(flag_name: str, missing_k
 
     assert missing_key not in fields
     assert {"name", "cluster", "device", "vcpus", "memory", "disk", "status"}.issubset(fields)
+
+
+@pytest.mark.parametrize("flag_name", ["overwrite_vm_role", "overwrite_vm_custom_fields"])
+def test_vm_patchable_keeps_role_and_custom_fields_regardless_of_flag(flag_name: str) -> None:
+    """Per-VM lock now controls writes via payload mutation; allowlist stays open."""
+    from proxbox_api.services.sync.vm_helpers import _compute_vm_patchable_fields
+
+    fields = _compute_vm_patchable_fields(SyncOverwriteFlags(**{flag_name: False}))
+
+    assert "role" in fields
+    assert "custom_fields" in fields

--- a/tests/test_proxmox_actions_gate.py
+++ b/tests/test_proxmox_actions_gate.py
@@ -24,7 +24,6 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from proxbox_api.database import ApiKey, ProxmoxEndpoint, get_async_session, get_session
 from proxbox_api.main import app
 
-
 VERB_PATHS = [
     ("/proxmox/qemu/100/start"),
     ("/proxmox/lxc/100/start"),

--- a/tests/test_proxmox_actions_gate.py
+++ b/tests/test_proxmox_actions_gate.py
@@ -50,18 +50,12 @@ STUB_VERB_PATHS = [
 @pytest.fixture
 def client(tmp_path: Path):
     sqlite_file = tmp_path / "test.db"
-    engine = create_engine(
-        f"sqlite:///{sqlite_file}", connect_args={"check_same_thread": False}
-    )
+    engine = create_engine(f"sqlite:///{sqlite_file}", connect_args={"check_same_thread": False})
     SQLModel.metadata.create_all(engine)
 
     async_url = str(engine.url).replace("sqlite:///", "sqlite+aiosqlite:///")
-    async_engine = create_async_engine(
-        async_url, connect_args={"check_same_thread": False}
-    )
-    session_factory = async_sessionmaker(
-        async_engine, class_=AsyncSession, expire_on_commit=False
-    )
+    async_engine = create_async_engine(async_url, connect_args={"check_same_thread": False})
+    session_factory = async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
 
     def _override_get_session():
         with Session(engine) as session:

--- a/tests/test_proxmox_actions_start_verb.py
+++ b/tests/test_proxmox_actions_start_verb.py
@@ -32,18 +32,12 @@ from proxbox_api.services.idempotency import get_idempotency_cache
 @pytest.fixture
 def client(tmp_path: Path):
     sqlite_file = tmp_path / "test.db"
-    engine = create_engine(
-        f"sqlite:///{sqlite_file}", connect_args={"check_same_thread": False}
-    )
+    engine = create_engine(f"sqlite:///{sqlite_file}", connect_args={"check_same_thread": False})
     SQLModel.metadata.create_all(engine)
 
     async_url = str(engine.url).replace("sqlite:///", "sqlite+aiosqlite:///")
-    async_engine = create_async_engine(
-        async_url, connect_args={"check_same_thread": False}
-    )
-    session_factory = async_sessionmaker(
-        async_engine, class_=AsyncSession, expire_on_commit=False
-    )
+    async_engine = create_async_engine(async_url, connect_args={"check_same_thread": False})
+    session_factory = async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
 
     def _override_get_session():
         with Session(engine) as session:
@@ -111,25 +105,15 @@ def _patch_route(
     nb_session = AsyncMock(return_value=netbox_session or object())
     node_mock = AsyncMock(return_value=node_or_response)
     netbox_id_mock = AsyncMock(return_value=netbox_vm_id)
-    status_mock = AsyncMock(
-        return_value=status_payload, side_effect=status_side_effect
-    )
+    status_mock = AsyncMock(return_value=status_payload, side_effect=status_side_effect)
     start_mock = AsyncMock(return_value=start_result, side_effect=start_side_effect)
     journal_mock = AsyncMock(return_value=journal_entry)
 
     patches = [
-        patch(
-            "proxbox_api.routes.proxmox_actions._open_proxmox_session", open_session
-        ),
-        patch(
-            "proxbox_api.routes.proxmox_actions.get_netbox_async_session", nb_session
-        ),
-        patch(
-            "proxbox_api.routes.proxmox_actions.resolve_proxmox_node", node_mock
-        ),
-        patch(
-            "proxbox_api.routes.proxmox_actions.resolve_netbox_vm_id", netbox_id_mock
-        ),
+        patch("proxbox_api.routes.proxmox_actions._open_proxmox_session", open_session),
+        patch("proxbox_api.routes.proxmox_actions.get_netbox_async_session", nb_session),
+        patch("proxbox_api.routes.proxmox_actions.resolve_proxmox_node", node_mock),
+        patch("proxbox_api.routes.proxmox_actions.resolve_netbox_vm_id", netbox_id_mock),
         patch("proxbox_api.routes.proxmox_actions.get_vm_status", status_mock),
         patch("proxbox_api.routes.proxmox_actions.start_vm", start_mock),
         patch(
@@ -227,9 +211,7 @@ def test_start_qemu_already_running_skips_dispatch_but_writes_journal(
     for p in handles["patches"]:
         p.start()
     try:
-        resp = client.post(
-            "/proxmox/qemu/100/start", params={"endpoint_id": endpoint_id}
-        )
+        resp = client.post("/proxmox/qemu/100/start", params={"endpoint_id": endpoint_id})
     finally:
         for p in handles["patches"]:
             p.stop()
@@ -248,15 +230,11 @@ def test_start_qemu_proxmox_dispatch_failure_writes_warning_journal(
     client: TestClient,
 ):
     endpoint_id = _make_endpoint(client)
-    handles = _patch_route(
-        start_side_effect=ProxmoxAPIError(message="lock conflict")
-    )
+    handles = _patch_route(start_side_effect=ProxmoxAPIError(message="lock conflict"))
     for p in handles["patches"]:
         p.start()
     try:
-        resp = client.post(
-            "/proxmox/qemu/100/start", params={"endpoint_id": endpoint_id}
-        )
+        resp = client.post("/proxmox/qemu/100/start", params={"endpoint_id": endpoint_id})
     finally:
         for p in handles["patches"]:
             p.stop()
@@ -269,9 +247,7 @@ def test_start_qemu_proxmox_dispatch_failure_writes_warning_journal(
     # Failure path still writes exactly one journal entry, kind=warning (§6.2).
     handles["journal"].assert_awaited_once()
     assert handles["journal"].call_args.kwargs["kind"] == "warning"
-    assert (
-        "error_detail: " in handles["journal"].call_args.kwargs["comments"]
-    )
+    assert "error_detail: " in handles["journal"].call_args.kwargs["comments"]
 
 
 def test_start_lxc_routes_through_same_dispatch(client: TestClient):
@@ -280,9 +256,7 @@ def test_start_lxc_routes_through_same_dispatch(client: TestClient):
     for p in handles["patches"]:
         p.start()
     try:
-        resp = client.post(
-            "/proxmox/lxc/101/start", params={"endpoint_id": endpoint_id}
-        )
+        resp = client.post("/proxmox/lxc/101/start", params={"endpoint_id": endpoint_id})
     finally:
         for p in handles["patches"]:
             p.stop()
@@ -303,9 +277,7 @@ def test_start_qemu_no_matching_netbox_vm_still_dispatches(client: TestClient):
     for p in handles["patches"]:
         p.start()
     try:
-        resp = client.post(
-            "/proxmox/qemu/100/start", params={"endpoint_id": endpoint_id}
-        )
+        resp = client.post("/proxmox/qemu/100/start", params={"endpoint_id": endpoint_id})
     finally:
         for p in handles["patches"]:
             p.stop()

--- a/tests/test_role_resolution.py
+++ b/tests/test_role_resolution.py
@@ -1,0 +1,333 @@
+"""Tests for issue #364 hierarchical default role resolution and lock.
+
+Two surfaces are covered here:
+
+* ``compute_role_snapshot_decision`` — the nine-case pure decision tree.
+* ``resolve_default_role_id`` — the four-tier resolver that walks node →
+  endpoint → plugin singleton.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from proxbox_api.services.sync.role_resolution import (
+    LAST_SYNCED_ROLE_CUSTOM_FIELD,
+    RoleSnapshotDecision,
+    compute_role_snapshot_decision,
+    extract_snapshot_id,
+    resolve_default_role_id,
+)
+
+# --------------------------------------------------------------------------- #
+# Pure decision function: the nine-case matrix.
+# --------------------------------------------------------------------------- #
+
+
+def test_case_1_fresh_create_plugin_global_only() -> None:
+    """Snapshot None + role None (fresh create) → write both = plugin default."""
+    decision = compute_role_snapshot_decision(
+        existing_role_id=None,
+        existing_snapshot_id=None,
+        desired_role_id=11,  # plugin global resolves here
+        overwrite_vm_role=False,
+    )
+    assert decision == RoleSnapshotDecision(
+        role_value=11,
+        snapshot_value=11,
+        write_role=True,
+        write_snapshot=True,
+    )
+
+
+def test_case_2_fresh_create_endpoint_override() -> None:
+    """Resolver-supplied desired (endpoint tier) is written verbatim on fresh create."""
+    decision = compute_role_snapshot_decision(
+        existing_role_id=None,
+        existing_snapshot_id=None,
+        desired_role_id=22,  # endpoint tier resolves here
+        overwrite_vm_role=False,
+    )
+    assert decision.role_value == 22
+    assert decision.snapshot_value == 22
+    assert decision.write_role
+    assert decision.write_snapshot
+
+
+def test_case_3_fresh_create_node_override() -> None:
+    """Node tier wins → fresh-create writes node id to both fields."""
+    decision = compute_role_snapshot_decision(
+        existing_role_id=None,
+        existing_snapshot_id=None,
+        desired_role_id=33,  # node tier resolves here
+        overwrite_vm_role=False,
+    )
+    assert decision.role_value == 33
+    assert decision.snapshot_value == 33
+    assert decision.write_role
+    assert decision.write_snapshot
+
+
+def test_case_4_update_steady_state_omits_both() -> None:
+    """existing == snapshot == desired → no PATCH writes for role or snapshot."""
+    decision = compute_role_snapshot_decision(
+        existing_role_id=7,
+        existing_snapshot_id=7,
+        desired_role_id=7,
+        overwrite_vm_role=False,
+    )
+    assert not decision.write_role
+    assert not decision.write_snapshot
+
+
+def test_case_5_update_roll_forward_writes_both() -> None:
+    """existing == snapshot != desired → write desired to role and snapshot."""
+    decision = compute_role_snapshot_decision(
+        existing_role_id=7,
+        existing_snapshot_id=7,
+        desired_role_id=9,
+        overwrite_vm_role=False,
+    )
+    assert decision.write_role
+    assert decision.write_snapshot
+    assert decision.role_value == 9
+    assert decision.snapshot_value == 9
+
+
+def test_case_6_operator_lock_skips_both() -> None:
+    """existing != snapshot, overwrite=False → preserve operator edit forever."""
+    decision = compute_role_snapshot_decision(
+        existing_role_id=42,  # operator changed role to 42
+        existing_snapshot_id=7,  # snapshot still records last sync (7)
+        desired_role_id=9,
+        overwrite_vm_role=False,
+    )
+    assert not decision.write_role
+    assert not decision.write_snapshot
+
+
+def test_case_7_operator_lock_released_writes_both() -> None:
+    """existing != snapshot, overwrite=True → restamp role and snapshot."""
+    decision = compute_role_snapshot_decision(
+        existing_role_id=42,
+        existing_snapshot_id=7,
+        desired_role_id=9,
+        overwrite_vm_role=True,
+    )
+    assert decision.write_role
+    assert decision.write_snapshot
+    assert decision.role_value == 9
+    assert decision.snapshot_value == 9
+
+
+def test_case_8_upgrade_backfill_with_role_writes_snapshot_only() -> None:
+    """snapshot None, role non-NULL → capture operator intent: snapshot only."""
+    decision = compute_role_snapshot_decision(
+        existing_role_id=15,
+        existing_snapshot_id=None,
+        desired_role_id=9,
+        overwrite_vm_role=False,
+    )
+    assert not decision.write_role  # role untouched
+    assert decision.write_snapshot
+    assert decision.snapshot_value == 15  # snapshot captures current role
+
+
+def test_case_9_upgrade_backfill_role_null_writes_both() -> None:
+    """snapshot None, role None → treat as fresh-create-style apply."""
+    decision = compute_role_snapshot_decision(
+        existing_role_id=None,
+        existing_snapshot_id=None,
+        desired_role_id=9,
+        overwrite_vm_role=False,
+    )
+    assert decision.write_role
+    assert decision.write_snapshot
+    assert decision.role_value == 9
+    assert decision.snapshot_value == 9
+
+
+# --------------------------------------------------------------------------- #
+# Edge cases not in the 9-case matrix but worth pinning.
+# --------------------------------------------------------------------------- #
+
+
+def test_no_desired_no_existing_skips_writes() -> None:
+    """Nothing to write: no tier yielded a role and the VM has none."""
+    decision = compute_role_snapshot_decision(
+        existing_role_id=None,
+        existing_snapshot_id=None,
+        desired_role_id=None,
+        overwrite_vm_role=False,
+    )
+    assert not decision.write_role
+    assert not decision.write_snapshot
+
+
+def test_overwrite_true_no_desired_clears_snapshot_writes() -> None:
+    """Operator override with desired=None must not blindly null the role."""
+    decision = compute_role_snapshot_decision(
+        existing_role_id=42,
+        existing_snapshot_id=7,
+        desired_role_id=None,
+        overwrite_vm_role=True,
+    )
+    # write_role/snapshot gated on desired_role_id being non-None.
+    assert not decision.write_role
+    assert not decision.write_snapshot
+
+
+def test_extract_snapshot_id_handles_missing_or_malformed() -> None:
+    assert extract_snapshot_id(None) is None
+    assert extract_snapshot_id({}) is None
+    assert extract_snapshot_id({"custom_fields": None}) is None
+    assert extract_snapshot_id({"custom_fields": {}}) is None
+    assert extract_snapshot_id({"custom_fields": {LAST_SYNCED_ROLE_CUSTOM_FIELD: "nope"}}) is None
+    assert extract_snapshot_id({"custom_fields": {LAST_SYNCED_ROLE_CUSTOM_FIELD: "42"}}) == 42
+    assert extract_snapshot_id({"custom_fields": {LAST_SYNCED_ROLE_CUSTOM_FIELD: 18}}) == 18
+
+
+# --------------------------------------------------------------------------- #
+# Resolver tests: walk node → endpoint → plugin singleton.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def patch_resolver(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Provide a helper that monkeypatches the two collaborators the resolver uses."""
+
+    state: dict[str, Any] = {"first_calls": []}
+
+    def install(
+        *,
+        first_results: dict[str, dict[str, Any] | None],
+        settings: dict[str, Any],
+    ) -> dict[str, Any]:
+        async def _fake_first(
+            _nb: object, path: str, *, query: dict[str, object] | None = None
+        ) -> Any:
+            state["first_calls"].append((path, dict(query or {})))
+            for needle, value in first_results.items():
+                if needle in path:
+                    return value
+            return None
+
+        def _fake_settings(_nb: object = None) -> dict[str, Any]:
+            return settings
+
+        monkeypatch.setattr(
+            "proxbox_api.services.sync.role_resolution.rest_first_async", _fake_first
+        )
+        monkeypatch.setattr(
+            "proxbox_api.services.sync.role_resolution.get_settings", _fake_settings
+        )
+        return state
+
+    return install
+
+
+@pytest.mark.asyncio
+async def test_resolver_returns_node_default(patch_resolver: Any) -> None:
+    """When the node row has default_role_qemu set, that id wins."""
+    patch_resolver(
+        first_results={
+            "proxmox-nodes": {"default_role_qemu": 101, "endpoint": 5},
+        },
+        settings={"default_role_qemu_id": 999, "default_role_lxc_id": None},
+    )
+    result = await resolve_default_role_id(
+        object(), vm_type="qemu", node_name="pve01", cluster_id=1
+    )
+    assert result == 101
+
+
+@pytest.mark.asyncio
+async def test_resolver_falls_through_to_endpoint(patch_resolver: Any) -> None:
+    """Node row has no default → endpoint default applies."""
+    state = patch_resolver(
+        first_results={
+            "proxmox-nodes": {"default_role_qemu": None, "endpoint": 5},
+            "endpoints/proxmox": {"default_role_qemu": 202},
+        },
+        settings={"default_role_qemu_id": 999, "default_role_lxc_id": None},
+    )
+    result = await resolve_default_role_id(
+        object(), vm_type="qemu", node_name="pve01", cluster_id=1
+    )
+    assert result == 202
+    # endpoint lookup should have been queried by id=5 (the node's endpoint FK).
+    endpoint_calls = [c for c in state["first_calls"] if "endpoints/proxmox" in c[0]]
+    assert endpoint_calls
+    assert endpoint_calls[0][1].get("id") == 5
+
+
+@pytest.mark.asyncio
+async def test_resolver_falls_through_to_plugin_singleton(patch_resolver: Any) -> None:
+    """Node and endpoint both null → plugin singleton applies."""
+    patch_resolver(
+        first_results={
+            "proxmox-nodes": {"default_role_qemu": None, "endpoint": 5},
+            "endpoints/proxmox": {"default_role_qemu": None},
+        },
+        settings={"default_role_qemu_id": 303, "default_role_lxc_id": None},
+    )
+    result = await resolve_default_role_id(
+        object(), vm_type="qemu", node_name="pve01", cluster_id=1
+    )
+    assert result == 303
+
+
+@pytest.mark.asyncio
+async def test_resolver_returns_none_when_no_tier_set(patch_resolver: Any) -> None:
+    """All tiers empty → return None (caller leaves role unset)."""
+    patch_resolver(
+        first_results={
+            "proxmox-nodes": {"default_role_qemu": None, "endpoint": None},
+        },
+        settings={"default_role_qemu_id": None, "default_role_lxc_id": None},
+    )
+    result = await resolve_default_role_id(
+        object(), vm_type="qemu", node_name="pve01", cluster_id=1
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_resolver_picks_lxc_field(patch_resolver: Any) -> None:
+    """vm_type='lxc' reads the matching lxc tier field, not qemu."""
+    patch_resolver(
+        first_results={
+            "proxmox-nodes": {"default_role_lxc": 404, "default_role_qemu": 99},
+        },
+        settings={"default_role_qemu_id": None, "default_role_lxc_id": 888},
+    )
+    result = await resolve_default_role_id(object(), vm_type="lxc", node_name="pve01", cluster_id=1)
+    assert result == 404
+
+
+@pytest.mark.asyncio
+async def test_resolver_rejects_unknown_vm_type(patch_resolver: Any) -> None:
+    patch_resolver(
+        first_results={},
+        settings={"default_role_qemu_id": 1, "default_role_lxc_id": 2},
+    )
+    result = await resolve_default_role_id(
+        object(), vm_type="bogus", node_name="pve01", cluster_id=1
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_resolver_skips_node_lookup_without_node_name(patch_resolver: Any) -> None:
+    """Without a node name, jump straight to the plugin singleton."""
+    state = patch_resolver(
+        first_results={},
+        settings={"default_role_qemu_id": 505, "default_role_lxc_id": None},
+    )
+    result = await resolve_default_role_id(
+        object(), vm_type="qemu", node_name=None, cluster_id=None
+    )
+    assert result == 505
+    assert state["first_calls"] == []  # never queried any NetBox endpoint

--- a/tests/test_verb_dispatch_helpers.py
+++ b/tests/test_verb_dispatch_helpers.py
@@ -134,9 +134,7 @@ async def test_resolve_proxmox_node_returns_node_on_match():
             ]
         ),
     ):
-        node = await verb_dispatch.resolve_proxmox_node(
-            session=object(), vm_type="qemu", vmid=101
-        )
+        node = await verb_dispatch.resolve_proxmox_node(session=object(), vm_type="qemu", vmid=101)
     assert node == "pve-node-01"
 
 
@@ -187,9 +185,7 @@ async def test_resolve_netbox_vm_id_returns_none_when_missing():
 
 async def test_write_verb_journal_entry_posts_payload():
     create_mock = AsyncMock(return_value={"id": 789, "url": "/api/extras/journal-entries/789/"})
-    with patch(
-        "proxbox_api.services.verb_dispatch.rest_create_async", new=create_mock
-    ):
+    with patch("proxbox_api.services.verb_dispatch.rest_create_async", new=create_mock):
         entry = await verb_dispatch.write_verb_journal_entry(
             nb=object(),
             netbox_vm_id=42,

--- a/tests/test_verb_dispatch_helpers.py
+++ b/tests/test_verb_dispatch_helpers.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import re
 from unittest.mock import AsyncMock, patch
 
-import pytest
 from fastapi.responses import JSONResponse
 
 from proxbox_api.exception import ProxmoxAPIError

--- a/tests/test_vm_sync_reconciliation_queue.py
+++ b/tests/test_vm_sync_reconciliation_queue.py
@@ -21,7 +21,10 @@ def _prepared_vm(*, cluster_name: str, vmid: int, memory: int) -> sync_vm._Prepa
         "memory": memory,
         "disk": 30,
         "tags": [99],
-        "custom_fields": {"proxmox_vm_id": vmid},
+        "custom_fields": {
+            "proxmox_vm_id": vmid,
+            "proxmox_last_synced_role_id": 20,
+        },
         "description": "Synced from Proxmox node pve01",
     }
     return sync_vm._PreparedVMState(
@@ -33,6 +36,7 @@ def _prepared_vm(*, cluster_name: str, vmid: int, memory: int) -> sync_vm._Prepa
         lookup={"cf_proxmox_vm_id": vmid, "cluster_id": 1},
         now=datetime.now(timezone.utc),
         vm_type="qemu",
+        desired_role_id=20,
     )
 
 
@@ -55,7 +59,10 @@ def test_build_vm_operation_queue_classifies_ok_create_update():
             "memory": 4096,
             "disk": 30,
             "tags": [{"id": 99}],
-            "custom_fields": {"proxmox_vm_id": 102},
+            "custom_fields": {
+                "proxmox_vm_id": 102,
+                "proxmox_last_synced_role_id": 20,
+            },
             "description": "Synced from Proxmox node pve01",
         },
         {
@@ -69,7 +76,10 @@ def test_build_vm_operation_queue_classifies_ok_create_update():
             "memory": 2048,
             "disk": 30,
             "tags": [{"id": 99}],
-            "custom_fields": {"proxmox_vm_id": 103},
+            "custom_fields": {
+                "proxmox_vm_id": 103,
+                "proxmox_last_synced_role_id": 20,
+            },
             "description": "Synced from Proxmox node pve01",
         },
     ]
@@ -97,7 +107,10 @@ def test_build_vm_operation_queue_omits_vm_type_when_overwrite_disabled():
             "memory": 4096,
             "disk": 30,
             "tags": [{"id": 99}],
-            "custom_fields": {"proxmox_vm_id": 104},
+            "custom_fields": {
+                "proxmox_vm_id": 104,
+                "proxmox_last_synced_role_id": 20,
+            },
             "description": "Synced from Proxmox node pve01",
         }
     ]
@@ -128,7 +141,10 @@ def test_build_vm_operation_queue_omits_vm_type_when_netbox_lacks_native_field()
             "memory": 4096,
             "disk": 30,
             "tags": [{"id": 99}],
-            "custom_fields": {"proxmox_vm_id": 105},
+            "custom_fields": {
+                "proxmox_vm_id": 105,
+                "proxmox_last_synced_role_id": 20,
+            },
             "description": "Synced from Proxmox node pve01",
         }
     ]


### PR DESCRIPTION
## Summary

Implements the proxbox-api half of [netbox-proxbox#364](https://github.com/emersonfelipesp/netbox-proxbox/issues/364) — a four-tier default-role hierarchy for synced VMs/containers with an operator-edit lock.

- New resolver `proxbox_api/services/sync/role_resolution.py`:
  - `resolve_default_role_id(nb, *, vm_type, node_name, cluster_id)` walks **Node → Endpoint → Plugin singleton** and returns the first non-NULL `default_role_{qemu,lxc}` FK id.
  - `compute_role_snapshot_decision(...)` is the pure 9-case decision function that decides what to write for `role` and the `proxmox_last_synced_role_id` custom field on every reconcile.
- Wired into both VM sync paths:
  - Queue-based path (`_build_vm_operation_queue` / `_dispatch_vm_operation_queue`).
  - Legacy `rest_reconcile_async` path in `sync_vm.py` (with a tolerant prefetch so test sessions / unreachable NetBox do not break the decision).
- `overwrite_vm_role` now has **Layer** semantics: when `False` (default) operator edits win forever; when `True` the resolved hierarchy wins on every sync and the snapshot rolls forward.
- Settings cache surfaces `default_role_qemu_id` / `default_role_lxc_id` from the NetBox plugin singleton.
- Patchable-fields contract keeps `role` and `custom_fields` always patchable.

## Test plan

- [x] 9-case matrix tests in `tests/test_role_resolution.py` (fresh creates, steady-state, roll-forward, operator lock with/without override, upgrade backfill with/without prior role).
- [x] 3 edge-case tests (no-desired skip, override-clears-snapshot, malformed snapshot value).
- [x] 7 resolver tests covering Node → Endpoint → Plugin fall-through, NULL handling, unknown `vm_type`, and missing `node_name`.
- [x] Existing reconciliation queue tests aligned with new semantics.
- [x] Full suite: `uv run --extra test pytest tests --ignore=tests/e2e` → 4240 passed.
- [x] `uv run ruff check .` ✓, `uv run ruff format --check .` ✓.
- [x] `uv run python -m compileall proxbox_api tests` ✓.
- [x] `uv run ty check proxbox_api/types proxbox_api/utils/retry.py proxbox_api/schemas/sync.py` ✓.

## Companion PR

Plugin model/migration/form wiring is in [emersonfelipesp/netbox-proxbox feat/issue-364-hierarchical-default-role](https://github.com/emersonfelipesp/netbox-proxbox/tree/feat/issue-364-hierarchical-default-role) (closes #364 on that repo).