### PR TITLE
feat(#406): port NetBox Branching (#370) to v0.0.11

### DIFF
--- a/contracts/overwrite_flags.json
+++ b/contracts/overwrite_flags.json
@@ -13,6 +13,7 @@
     "overwrite_vm_tags",
     "overwrite_vm_description",
     "overwrite_vm_custom_fields",
+    "overwrite_vm_cloudinit",
     "overwrite_cluster_tags",
     "overwrite_cluster_description",
     "overwrite_cluster_custom_fields",

--- a/proxbox_api/app/full_update.py
+++ b/proxbox_api/app/full_update.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import asyncio
 import time
 import uuid
+from contextlib import nullcontext
+from typing import Annotated
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Query, Request
 from fastapi.responses import StreamingResponse
 
 from proxbox_api.app.sync_state import (
@@ -70,7 +72,7 @@ def _result_count(value) -> int:
 
 
 @full_update_router.get("/full-update")
-async def full_update_sync(  # noqa: C901
+async def full_update_sync(
     netbox_session: NetBoxSessionDep,
     pxs: ProxmoxSessionsDep,
     cluster_status: ClusterStatusDep,
@@ -79,6 +81,70 @@ async def full_update_sync(  # noqa: C901
     tag: ProxboxTagDep,
     overwrite_flags: ResolvedSyncOverwriteFlagsDep = SyncOverwriteFlags(),
     fetch_max_concurrency: int | None = None,
+    netbox_branch_schema_id: Annotated[
+        str | None,
+        Query(
+            description=(
+                "Optional netbox-branching schema_id (X-NetBox-Branch). When set, all "
+                "NetBox writes performed by this sync run carry the header so changes "
+                "land on the branch rather than main."
+            ),
+        ),
+    ] = None,
+) -> dict:
+    return await _full_update_sync_run(
+        netbox_session=netbox_session,
+        pxs=pxs,
+        cluster_status=cluster_status,
+        cluster_resources=cluster_resources,
+        custom_fields=custom_fields,
+        tag=tag,
+        overwrite_flags=overwrite_flags,
+        fetch_max_concurrency=fetch_max_concurrency,
+        netbox_branch_schema_id=netbox_branch_schema_id,
+    )
+
+
+async def _full_update_sync_run(
+    *,
+    netbox_session,
+    pxs,
+    cluster_status,
+    cluster_resources,
+    custom_fields,
+    tag,
+    overwrite_flags: SyncOverwriteFlags,
+    fetch_max_concurrency: int | None,
+    netbox_branch_schema_id: str | None,
+) -> dict:
+    branch_scope = (
+        netbox_session.activate_branch(netbox_branch_schema_id)
+        if netbox_branch_schema_id
+        else nullcontext()
+    )
+    with branch_scope:
+        return await _full_update_sync_impl(
+            netbox_session=netbox_session,
+            pxs=pxs,
+            cluster_status=cluster_status,
+            cluster_resources=cluster_resources,
+            custom_fields=custom_fields,
+            tag=tag,
+            overwrite_flags=overwrite_flags,
+            fetch_max_concurrency=fetch_max_concurrency,
+        )
+
+
+async def _full_update_sync_impl(  # noqa: C901
+    *,
+    netbox_session,
+    pxs,
+    cluster_status,
+    cluster_resources,
+    custom_fields,
+    tag,
+    overwrite_flags: SyncOverwriteFlags,
+    fetch_max_concurrency: int | None,
 ) -> dict:
     sync_nodes: list = []
     sync_storage: list = []
@@ -369,6 +435,16 @@ async def full_update_sync_stream(  # noqa: C901
     tag: ProxboxTagDep,
     overwrite_flags: ResolvedSyncOverwriteFlagsDep = SyncOverwriteFlags(),
     fetch_max_concurrency: int | None = None,
+    netbox_branch_schema_id: Annotated[
+        str | None,
+        Query(
+            description=(
+                "Optional netbox-branching schema_id (X-NetBox-Branch). When set, all "
+                "NetBox writes performed by this sync stream carry the header so changes "
+                "land on the branch rather than main."
+            ),
+        ),
+    ] = None,
 ) -> StreamingResponse:
     bootstrap_status_obj = getattr(request.app.state, "bootstrap_status", None)
     bootstrap_payload: dict[str, object]
@@ -1069,8 +1145,18 @@ async def full_update_sync_stream(  # noqa: C901
                     },
                 )
 
+    async def branched_stream():
+        branch_scope = (
+            netbox_session.activate_branch(netbox_branch_schema_id)
+            if netbox_branch_schema_id
+            else nullcontext()
+        )
+        with branch_scope:
+            async for frame in event_stream():
+                yield frame
+
     return StreamingResponse(
-        event_stream(),
+        branched_stream(),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",

--- a/proxbox_api/routes/proxmox_actions.py
+++ b/proxbox_api/routes/proxmox_actions.py
@@ -47,9 +47,6 @@ from proxbox_api.database import AsyncDatabaseSessionDep as SessionDep
 from proxbox_api.database import ProxmoxEndpoint
 from proxbox_api.exception import ProxboxException, ProxmoxAPIError
 from proxbox_api.logger import logger
-from proxbox_api.session.netbox import get_netbox_async_session
-from proxbox_api.session.proxmox import ProxmoxSession
-from proxbox_api.session.proxmox_providers import _parse_db_endpoint
 from proxbox_api.services.idempotency import CacheKey, get_idempotency_cache
 from proxbox_api.services.proxmox_helpers import (
     cancel_task,
@@ -69,6 +66,9 @@ from proxbox_api.services.verb_dispatch import (
     utcnow_iso,
     write_verb_journal_entry,
 )
+from proxbox_api.session.netbox import get_netbox_async_session
+from proxbox_api.session.proxmox import ProxmoxSession
+from proxbox_api.session.proxmox_providers import _parse_db_endpoint
 from proxbox_api.utils.async_compat import maybe_await as _maybe_await
 
 router = APIRouter()
@@ -77,9 +77,7 @@ VmType = Literal["qemu", "lxc"]
 Verb = Literal["start", "stop", "snapshot", "migrate"]
 
 
-async def _gate(
-    session: SessionDep, endpoint_id: int | None
-) -> JSONResponse | ProxmoxEndpoint:
+async def _gate(session: SessionDep, endpoint_id: int | None) -> JSONResponse | ProxmoxEndpoint:
     """Resolve the target endpoint and enforce ``allow_writes``."""
     if endpoint_id is None:
         return JSONResponse(
@@ -169,9 +167,7 @@ async def _dispatch_start(
     cache = get_idempotency_cache()
     cache_key: CacheKey | None = None
     if idempotency_key:
-        cache_key = CacheKey(
-            endpoint_id=endpoint_id, verb="start", vmid=vmid, key=idempotency_key
-        )
+        cache_key = CacheKey(endpoint_id=endpoint_id, verb="start", vmid=vmid, key=idempotency_key)
         cached = await cache.get(cache_key)
         if cached is not None:
             return JSONResponse(status_code=status.HTTP_200_OK, content=cached)
@@ -304,9 +300,7 @@ async def _dispatch_stop(
     cache = get_idempotency_cache()
     cache_key: CacheKey | None = None
     if idempotency_key:
-        cache_key = CacheKey(
-            endpoint_id=endpoint_id, verb="stop", vmid=vmid, key=idempotency_key
-        )
+        cache_key = CacheKey(endpoint_id=endpoint_id, verb="stop", vmid=vmid, key=idempotency_key)
         cached = await cache.get(cache_key)
         if cached is not None:
             return JSONResponse(status_code=status.HTTP_200_OK, content=cached)

--- a/proxbox_api/routes/sync/individual/cluster.py
+++ b/proxbox_api/routes/sync/individual/cluster.py
@@ -1,6 +1,8 @@
 """Individual cluster sync route."""
 
 import uuid
+from contextlib import nullcontext
+from typing import Annotated
 
 from fastapi import APIRouter, Query
 
@@ -25,6 +27,18 @@ async def sync_cluster(
     dry_run: bool = Query(
         default=False, title="Dry Run", description="If true, don't make changes"
     ),
+    netbox_branch_schema_id: Annotated[
+        str | None,
+        Query(
+            description=(
+                "Optional netbox-branching schema_id (X-NetBox-Branch). When set, all "
+                "NetBox writes performed by this single-cluster sync run carry the "
+                "header so changes land on the branch rather than main. Bridges "
+                "issue #370 (header pass-through) through SyncContext (#375) per "
+                "issue #406."
+            ),
+        ),
+    ] = None,
 ):
     """Sync a single cluster from Proxmox to NetBox."""
     px = resolve_proxmox_session(pxs, cluster_name)
@@ -39,5 +53,10 @@ async def sync_cluster(
         tag=tag,
         settings=settings,
         operation_id=operation_id,
+        netbox_branch=netbox_branch_schema_id or "",
     )
-    return await sync_cluster_individual(ctx, cluster_name, dry_run=dry_run)
+    branch_scope = (
+        nb.activate_branch(netbox_branch_schema_id) if netbox_branch_schema_id else nullcontext()
+    )
+    with branch_scope:
+        return await sync_cluster_individual(ctx, cluster_name, dry_run=dry_run)

--- a/proxbox_api/services/idempotency.py
+++ b/proxbox_api/services/idempotency.py
@@ -22,7 +22,6 @@ import time
 from dataclasses import dataclass
 from typing import Literal
 
-
 Verb = Literal["start", "stop", "snapshot", "migrate"]
 TTL_SECONDS = 60.0
 
@@ -75,9 +74,7 @@ class IdempotencyCache:
     async def store(self, cache_key: CacheKey, response: dict[str, object]) -> None:
         async with self._lock:
             now = self._now()
-            self._entries[cache_key] = _Entry(
-                response=dict(response), expires_at=now + self._ttl
-            )
+            self._entries[cache_key] = _Entry(response=dict(response), expires_at=now + self._ttl)
 
     async def clear(self) -> None:
         async with self._lock:

--- a/proxbox_api/services/proxmox_helpers.py
+++ b/proxbox_api/services/proxmox_helpers.py
@@ -680,16 +680,12 @@ async def get_vm_status(
             payload = await resolve_async(
                 session.session.nodes(node).lxc(vmid).status.current.get()
             )
-            return generated_models.GetNodesNodeLxcVmidStatusCurrentResponse.model_validate(
-                payload
-            )
+            return generated_models.GetNodesNodeLxcVmidStatusCurrentResponse.model_validate(payload)
         raise ValueError(f"Unsupported VM type: {vm_type}")
     except ProxboxException:
         raise
     except ProxmoxTimeoutError as error:
-        raise ProxmoxAPIError(
-            message="Proxmox VM status request timed out", original_error=error
-        )
+        raise ProxmoxAPIError(message="Proxmox VM status request timed out", original_error=error)
     except ProxmoxConnectionError as error:
         raise ProxmoxAPIError(
             message="Unable to connect to Proxmox for VM status", original_error=error
@@ -719,9 +715,7 @@ async def start_vm(
                 session.session.nodes(node).qemu(vmid).status.start.post()
             )
         elif vm_type == "lxc":
-            payload = await resolve_async(
-                session.session.nodes(node).lxc(vmid).status.start.post()
-            )
+            payload = await resolve_async(session.session.nodes(node).lxc(vmid).status.start.post())
         else:
             raise ValueError(f"Unsupported VM type: {vm_type}")
         if isinstance(payload, str):
@@ -760,13 +754,9 @@ async def stop_vm(
     """
     try:
         if vm_type == "qemu":
-            payload = await resolve_async(
-                session.session.nodes(node).qemu(vmid).status.stop.post()
-            )
+            payload = await resolve_async(session.session.nodes(node).qemu(vmid).status.stop.post())
         elif vm_type == "lxc":
-            payload = await resolve_async(
-                session.session.nodes(node).lxc(vmid).status.stop.post()
-            )
+            payload = await resolve_async(session.session.nodes(node).lxc(vmid).status.stop.post())
         else:
             raise ValueError(f"Unsupported VM type: {vm_type}")
         if isinstance(payload, str):
@@ -792,7 +782,7 @@ async def stop_vm(
 
 
 @_dual_mode
-async def create_vm_snapshot(
+async def create_vm_snapshot(  # noqa: C901
     session: ProxmoxSession,
     node: str,
     vm_type: str,
@@ -829,9 +819,7 @@ async def create_vm_snapshot(
     except ProxboxException:
         raise
     except ProxmoxTimeoutError as error:
-        raise ProxmoxAPIError(
-            message="Proxmox VM snapshot request timed out", original_error=error
-        )
+        raise ProxmoxAPIError(message="Proxmox VM snapshot request timed out", original_error=error)
     except ProxmoxConnectionError as error:
         raise ProxmoxAPIError(
             message="Unable to connect to Proxmox for VM snapshot", original_error=error
@@ -860,21 +848,15 @@ async def migrate_preflight(
     """
     try:
         if vm_type == "qemu":
-            payload = await resolve_async(
-                session.session.nodes(node).qemu(vmid).migrate.get()
-            )
+            payload = await resolve_async(session.session.nodes(node).qemu(vmid).migrate.get())
         elif vm_type == "lxc":
-            payload = await resolve_async(
-                session.session.nodes(node).lxc(vmid).migrate.get()
-            )
+            payload = await resolve_async(session.session.nodes(node).lxc(vmid).migrate.get())
         else:
             raise ValueError(f"Unsupported VM type: {vm_type}")
     except ProxboxException:
         raise
     except ProxmoxTimeoutError as error:
-        raise ProxmoxAPIError(
-            message="Proxmox migrate preflight timed out", original_error=error
-        )
+        raise ProxmoxAPIError(message="Proxmox migrate preflight timed out", original_error=error)
     except ProxmoxConnectionError as error:
         raise ProxmoxAPIError(
             message="Unable to connect to Proxmox for migrate preflight",
@@ -933,9 +915,7 @@ async def migrate_vm(
     except ProxboxException:
         raise
     except ProxmoxTimeoutError as error:
-        raise ProxmoxAPIError(
-            message="Proxmox VM migrate request timed out", original_error=error
-        )
+        raise ProxmoxAPIError(message="Proxmox VM migrate request timed out", original_error=error)
     except ProxmoxConnectionError as error:
         raise ProxmoxAPIError(
             message="Unable to connect to Proxmox for VM migrate",
@@ -964,9 +944,7 @@ async def cancel_task(
     except ProxboxException:
         raise
     except ProxmoxTimeoutError as error:
-        raise ProxmoxAPIError(
-            message="Proxmox task cancel request timed out", original_error=error
-        )
+        raise ProxmoxAPIError(message="Proxmox task cancel request timed out", original_error=error)
     except ProxmoxConnectionError as error:
         raise ProxmoxAPIError(
             message="Unable to connect to Proxmox for task cancel",

--- a/proxbox_api/services/verb_dispatch.py
+++ b/proxbox_api/services/verb_dispatch.py
@@ -30,7 +30,6 @@ from proxbox_api.logger import logger
 from proxbox_api.netbox_rest import rest_create_async, rest_first_async
 from proxbox_api.services.proxmox_helpers import get_cluster_resources
 
-
 Verb = Literal["start", "stop", "snapshot", "migrate"]
 VmType = Literal["qemu", "lxc"]
 JournalKind = Literal["info", "success", "warning", "danger"]
@@ -52,9 +51,7 @@ async def resolve_proxmox_node(
     try:
         resources = await get_cluster_resources(session, resource_type=vm_type)
     except ProxmoxAPIError as error:
-        logger.warning(
-            "Failed to fetch cluster resources for %s/%s: %s", vm_type, vmid, error
-        )
+        logger.warning("Failed to fetch cluster resources for %s/%s: %s", vm_type, vmid, error)
         return JSONResponse(
             status_code=status.HTTP_502_BAD_GATEWAY,
             content={

--- a/tests/test_cluster_sync_branch_bridge.py
+++ b/tests/test_cluster_sync_branch_bridge.py
@@ -1,0 +1,202 @@
+"""Tests for the SyncContext ↔ X-NetBox-Branch bridge on the cluster route.
+
+Issue #406 Phase 2. The cluster route at
+``proxbox_api/routes/sync/individual/cluster.py`` accepts a
+``netbox_branch_schema_id`` query parameter and must:
+
+1. Populate :attr:`SyncContext.netbox_branch` with the schema id (or "" when
+   absent). The field stays observational — reconcilers do not branch on
+   it — but loggers and SSE emitters can read it from the context.
+2. Wrap the call to ``sync_cluster_individual`` in
+   ``netbox_session.activate_branch(schema_id)`` so every NetBox write
+   carries ``X-NetBox-Branch``, mirroring the full-update gate added by
+   issue #370.
+
+These tests pin the bridge contract end-to-end without exercising any
+real reconciler — ``sync_cluster_individual`` itself is stubbed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Iterator
+
+from proxbox_api.services.run_session import SyncContext
+
+
+class _RecordingSession:
+    """Stand-in for the netbox-sdk Api facade.
+
+    Captures the schema id seen at ``activate_branch`` entry and which
+    SyncContext is observed at "request time" via ``record_call()``.
+    """
+
+    def __init__(self) -> None:
+        self._active: str | None = None
+        self.activated_with: list[str] = []
+        self.calls: list[tuple[bool, str | None]] = []
+
+    @contextmanager
+    def activate_branch(self, schema_id: str) -> Iterator["_RecordingSession"]:
+        self.activated_with.append(schema_id)
+        prior = self._active
+        self._active = schema_id
+        try:
+            yield self
+        finally:
+            self._active = prior
+
+    def record_call(self) -> None:
+        self.calls.append((self._active is not None, self._active))
+
+
+def _make_settings():
+    from proxbox_api.schemas import PluginConfig
+    from proxbox_api.schemas.netbox import NetboxSessionSchema
+
+    return PluginConfig(
+        proxmox=[],
+        netbox=NetboxSessionSchema(domain="netbox.example.com", http_port=8000, token="test-token"),
+    )
+
+
+def _stub_cluster_helpers(monkeypatch, captured_ctx: list[SyncContext]):
+    """Patch ``resolve_proxmox_session`` and ``sync_cluster_individual``.
+
+    The bridge's contract is "build SyncContext correctly and open the
+    branch scope before calling sync_cluster_individual". We don't need
+    to run the real reconciler to verify that — only to capture what the
+    route hands it.
+    """
+    import proxbox_api.routes.sync.individual.cluster as route_module
+
+    monkeypatch.setattr(
+        route_module,
+        "resolve_proxmox_session",
+        lambda pxs, name: SimpleNamespace(cluster=SimpleNamespace(name=name)),
+    )
+
+    async def _stub_sync(ctx: SyncContext, cluster_name: str, *, dry_run: bool = False):
+        captured_ctx.append(ctx)
+        # Touch the recording session so the test can prove the branch
+        # scope is open at "request time".
+        if hasattr(ctx.nb, "record_call"):
+            ctx.nb.record_call()
+        return {"action": "unchanged", "cluster_name": cluster_name, "dry_run": dry_run}
+
+    monkeypatch.setattr(route_module, "sync_cluster_individual", _stub_sync)
+
+
+def test_cluster_route_threads_schema_id_into_sync_context(monkeypatch):
+    """When the query param is set, ``ctx.netbox_branch`` carries it."""
+    captured: list[SyncContext] = []
+    _stub_cluster_helpers(monkeypatch, captured)
+
+    from proxbox_api.routes.sync.individual.cluster import sync_cluster
+
+    nb = _RecordingSession()
+    asyncio.run(
+        sync_cluster(
+            nb=nb,
+            pxs=[SimpleNamespace(cluster=SimpleNamespace(name="lab"))],
+            tag=SimpleNamespace(id=7, name="Proxbox", slug="proxbox", color="ff5722"),
+            settings=_make_settings(),
+            cluster_name="lab",
+            dry_run=False,
+            netbox_branch_schema_id="abcd1234",
+        )
+    )
+
+    assert captured, "sync_cluster_individual was not invoked"
+    assert captured[0].netbox_branch == "abcd1234"
+    assert nb.activated_with == ["abcd1234"]
+    # The request observed the branch as active.
+    assert nb.calls == [(True, "abcd1234")]
+
+
+def test_cluster_route_leaves_branch_unset_when_schema_id_omitted(monkeypatch):
+    """No schema id ⇒ ``ctx.netbox_branch == ""`` and no activate_branch call."""
+    captured: list[SyncContext] = []
+    _stub_cluster_helpers(monkeypatch, captured)
+
+    from proxbox_api.routes.sync.individual.cluster import sync_cluster
+
+    nb = _RecordingSession()
+    asyncio.run(
+        sync_cluster(
+            nb=nb,
+            pxs=[SimpleNamespace(cluster=SimpleNamespace(name="lab"))],
+            tag=SimpleNamespace(id=7, name="Proxbox", slug="proxbox", color="ff5722"),
+            settings=_make_settings(),
+            cluster_name="lab",
+            dry_run=False,
+        )
+    )
+
+    assert captured[0].netbox_branch == ""
+    assert nb.activated_with == []
+    assert nb.calls == [(False, None)]
+
+
+def test_cluster_route_treats_empty_schema_id_as_unset(monkeypatch):
+    """An empty string from the query layer must not open a branch scope.
+
+    FastAPI may surface ``?netbox_branch_schema_id=`` as ``""`` rather than
+    ``None`` depending on parsing. The route uses ``or ""`` falsy-coalesce so
+    both cases land in the no-branch path.
+    """
+    captured: list[SyncContext] = []
+    _stub_cluster_helpers(monkeypatch, captured)
+
+    from proxbox_api.routes.sync.individual.cluster import sync_cluster
+
+    nb = _RecordingSession()
+    asyncio.run(
+        sync_cluster(
+            nb=nb,
+            pxs=[SimpleNamespace(cluster=SimpleNamespace(name="lab"))],
+            tag=SimpleNamespace(id=7, name="Proxbox", slug="proxbox", color="ff5722"),
+            settings=_make_settings(),
+            cluster_name="lab",
+            dry_run=False,
+            netbox_branch_schema_id="",
+        )
+    )
+
+    assert captured[0].netbox_branch == ""
+    assert nb.activated_with == []
+
+
+def test_cluster_route_skips_branch_scope_when_resolve_fails(monkeypatch):
+    """Early-return on resolve failure must not open a branch scope.
+
+    ``resolve_proxmox_session`` returning ``None`` is a precondition
+    failure — the route returns a structured error. No NetBox writes
+    happen, so no branch header is needed.
+    """
+    import proxbox_api.routes.sync.individual.cluster as route_module
+
+    monkeypatch.setattr(route_module, "resolve_proxmox_session", lambda pxs, name: None)
+
+    async def _unreachable_sync(*args, **kwargs):  # pragma: no cover - asserted below
+        raise AssertionError("sync_cluster_individual must not run when resolve fails")
+
+    monkeypatch.setattr(route_module, "sync_cluster_individual", _unreachable_sync)
+
+    nb = _RecordingSession()
+    result = asyncio.run(
+        route_module.sync_cluster(
+            nb=nb,
+            pxs=[],
+            tag=SimpleNamespace(id=7, name="Proxbox", slug="proxbox", color="ff5722"),
+            settings=_make_settings(),
+            cluster_name="ghost",
+            dry_run=False,
+            netbox_branch_schema_id="abcd1234",
+        )
+    )
+
+    assert "error" in result
+    assert nb.activated_with == []

--- a/tests/test_full_update_stream_branching.py
+++ b/tests/test_full_update_stream_branching.py
@@ -1,0 +1,163 @@
+"""Tests that the /full-update/stream SSE entry point activates the netbox-sdk
+branch context when ``netbox_branch_schema_id`` is supplied as a query parameter.
+
+The stream wraps its event loop in ``netbox_session.activate_branch(schema_id)``
+so the X-NetBox-Branch header is attached to every NetBox write performed
+during the run. These tests pin that contract without needing a live FastAPI
+client.
+
+Port of PR #74 (`feat(#370): thread netbox_branch_schema_id ...`) onto
+v0.0.11. v0.0.11's stream route takes ``request: Request`` as its first
+positional argument and uses the ``_create_*`` private helpers for backups
+and snapshots, so the stub list and call signature differ from the
+``main``-branch original.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Any, Iterator
+from unittest.mock import AsyncMock
+
+
+def _stub_dependencies(monkeypatch):
+    """Patch all stage helpers so the stream completes quickly."""
+    targets = [
+        ("create_proxmox_devices", lambda **kw: asyncio.sleep(0, result=[])),
+        ("create_virtual_machines", lambda **kw: asyncio.sleep(0, result=[])),
+        ("create_storages", lambda **kw: asyncio.sleep(0, result=[])),
+        (
+            "create_virtual_disks",
+            lambda **kw: asyncio.sleep(
+                0, result={"count": 0, "created": 0, "updated": 0, "skipped": 0}
+            ),
+        ),
+        ("create_all_virtual_machine_backups", lambda **kw: asyncio.sleep(0, result=[])),
+        ("_create_all_virtual_machine_backups", lambda **kw: asyncio.sleep(0, result=[])),
+        (
+            "create_all_virtual_machine_snapshots",
+            lambda **kw: asyncio.sleep(0, result={"count": 0, "created": 0, "skipped": 0}),
+        ),
+        (
+            "_create_all_virtual_machine_snapshots",
+            lambda **kw: asyncio.sleep(0, result={"count": 0, "created": 0, "skipped": 0}),
+        ),
+        (
+            "sync_all_virtual_machine_task_histories",
+            lambda **kw: asyncio.sleep(0, result={"count": 0, "created": 0, "skipped": 0}),
+        ),
+        ("create_all_device_interfaces", lambda **kw: asyncio.sleep(0, result=[])),
+        ("create_only_vm_interfaces", lambda **kw: asyncio.sleep(0, result=[])),
+        ("create_only_vm_ip_addresses", lambda **kw: asyncio.sleep(0, result=[])),
+        (
+            "sync_all_replications",
+            lambda **kw: asyncio.sleep(0, result={"created": 0, "updated": 0}),
+        ),
+        (
+            "sync_all_backup_routines",
+            lambda **kw: asyncio.sleep(0, result={"created": 0, "updated": 0}),
+        ),
+    ]
+    for name, fn in targets:
+        monkeypatch.setattr(f"proxbox_api.app.full_update.{name}", fn)
+
+
+def _fake_request() -> SimpleNamespace:
+    """Mimic just enough of starlette.Request for the stream route."""
+    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(bootstrap_status=None)))
+
+
+async def _drain_stream(response) -> None:
+    """Consume the StreamingResponse body so the inner context manager exits."""
+    async for _ in response.body_iterator:
+        pass
+
+
+def test_stream_does_not_activate_branch_when_schema_id_missing(monkeypatch):
+    _stub_dependencies(monkeypatch)
+
+    from proxbox_api.main import full_update_sync_stream
+
+    session = SimpleNamespace(activate_branch=AsyncMock())
+
+    response = asyncio.run(
+        full_update_sync_stream(
+            request=_fake_request(),
+            netbox_session=session,
+            pxs=[],
+            cluster_status=[],
+            cluster_resources=[],
+            custom_fields=[],
+            tag=type("Tag", (), {"id": 1, "name": "Proxbox", "slug": "proxbox", "color": "ff0"})(),
+        )
+    )
+    asyncio.run(_drain_stream(response))
+
+    session.activate_branch.assert_not_called()
+
+
+def test_stream_activates_branch_with_schema_id(monkeypatch):
+    _stub_dependencies(monkeypatch)
+
+    from proxbox_api.main import full_update_sync_stream
+
+    captured: list[Any] = []
+    entered = 0
+    exited = 0
+
+    @contextmanager
+    def _activate(schema_id: Any) -> Iterator[None]:
+        nonlocal entered, exited
+        captured.append(schema_id)
+        entered += 1
+        try:
+            yield
+        finally:
+            exited += 1
+
+    session = SimpleNamespace(activate_branch=_activate)
+
+    response = asyncio.run(
+        full_update_sync_stream(
+            request=_fake_request(),
+            netbox_session=session,
+            pxs=[],
+            cluster_status=[],
+            cluster_resources=[],
+            custom_fields=[],
+            tag=type("Tag", (), {"id": 1, "name": "Proxbox", "slug": "proxbox", "color": "ff0"})(),
+            netbox_branch_schema_id="cafef00d",
+        )
+    )
+    asyncio.run(_drain_stream(response))
+
+    assert captured == ["cafef00d"]
+    assert entered == 1
+    assert exited == 1, "branch context must close after the stream finishes"
+
+
+def test_stream_does_not_activate_branch_when_schema_id_empty(monkeypatch):
+    """Empty-string schema_id must be treated as no branch."""
+    _stub_dependencies(monkeypatch)
+
+    from proxbox_api.main import full_update_sync_stream
+
+    session = SimpleNamespace(activate_branch=AsyncMock())
+
+    response = asyncio.run(
+        full_update_sync_stream(
+            request=_fake_request(),
+            netbox_session=session,
+            pxs=[],
+            cluster_status=[],
+            cluster_resources=[],
+            custom_fields=[],
+            tag=type("Tag", (), {"id": 1, "name": "Proxbox", "slug": "proxbox", "color": "ff0"})(),
+            netbox_branch_schema_id="",
+        )
+    )
+    asyncio.run(_drain_stream(response))
+
+    session.activate_branch.assert_not_called()

--- a/tests/test_idempotency_cache.py
+++ b/tests/test_idempotency_cache.py
@@ -17,9 +17,9 @@ import asyncio
 import pytest
 
 from proxbox_api.services.idempotency import (
+    TTL_SECONDS,
     CacheKey,
     IdempotencyCache,
-    TTL_SECONDS,
     get_idempotency_cache,
 )
 
@@ -101,18 +101,8 @@ async def test_singleton_returns_same_instance():
 
 
 async def test_clear_evicts_all_entries(cache: IdempotencyCache):
-    await cache.store(
-        CacheKey(endpoint_id=1, verb="start", vmid=100, key="a"), {"x": 1}
-    )
-    await cache.store(
-        CacheKey(endpoint_id=1, verb="stop", vmid=100, key="b"), {"x": 2}
-    )
+    await cache.store(CacheKey(endpoint_id=1, verb="start", vmid=100, key="a"), {"x": 1})
+    await cache.store(CacheKey(endpoint_id=1, verb="stop", vmid=100, key="b"), {"x": 2})
     await cache.clear()
-    assert (
-        await cache.get(CacheKey(endpoint_id=1, verb="start", vmid=100, key="a"))
-        is None
-    )
-    assert (
-        await cache.get(CacheKey(endpoint_id=1, verb="stop", vmid=100, key="b"))
-        is None
-    )
+    assert await cache.get(CacheKey(endpoint_id=1, verb="start", vmid=100, key="a")) is None
+    assert await cache.get(CacheKey(endpoint_id=1, verb="stop", vmid=100, key="b")) is None

--- a/tests/test_netbox_branch_header.py
+++ b/tests/test_netbox_branch_header.py
@@ -1,0 +1,191 @@
+"""Tests for X-NetBox-Branch header propagation through netbox-sdk activate_branch().
+
+The plugin → proxbox-api branch header pass-through is implemented by calling
+``netbox_session.activate_branch(schema_id)`` on the netbox-sdk Api facade,
+which opens a ``header_scope(X-NetBox-Branch=...)`` for the duration of the
+context. These tests pin that the header is set when a schema id is provided
+and absent when it is not.
+
+Port of PR #74 onto v0.0.11. The sync route on v0.0.11 calls only the public
+``create_*`` helpers from inside ``_full_update_sync_impl``, so the stub list
+matches the ``main``-branch original. The route is now reachable via the thin
+wrapper ``full_update_sync`` → ``_full_update_sync_run`` → ``_full_update_sync_impl``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Iterator
+from unittest.mock import AsyncMock
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _RecordingSession:
+    """Stand-in for the netbox-sdk Api facade.
+
+    Captures the active branch schema_id while inside ``activate_branch()`` and
+    records every (header_active, value) seen at "request time" via ``record_call()``.
+    """
+
+    def __init__(self) -> None:
+        self._active: str | None = None
+        self.calls: list[tuple[bool, str | None]] = []
+
+    @contextmanager
+    def activate_branch(self, schema_id: str) -> Iterator["_RecordingSession"]:
+        prior = self._active
+        self._active = schema_id
+        try:
+            yield self
+        finally:
+            self._active = prior
+
+    def record_call(self) -> None:
+        self.calls.append((self._active is not None, self._active))
+
+
+# ---------------------------------------------------------------------------
+# activate_branch() context behavior
+# ---------------------------------------------------------------------------
+
+
+def test_activate_branch_sets_value_inside_scope():
+    session = _RecordingSession()
+    session.record_call()
+    with session.activate_branch("abcd1234"):
+        session.record_call()
+    session.record_call()
+
+    assert session.calls == [
+        (False, None),
+        (True, "abcd1234"),
+        (False, None),
+    ]
+
+
+def test_nested_activate_branch_restores_outer():
+    session = _RecordingSession()
+    with session.activate_branch("outer-id"):
+        session.record_call()
+        with session.activate_branch("inner-id"):
+            session.record_call()
+        session.record_call()
+
+    assert session.calls == [
+        (True, "outer-id"),
+        (True, "inner-id"),
+        (True, "outer-id"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# full_update_sync route: schema_id gating
+# ---------------------------------------------------------------------------
+
+
+def _stub_full_update_dependencies(monkeypatch):
+    """Patch all stage helpers on full_update so the route runs to completion."""
+    targets = [
+        ("create_proxmox_devices", lambda **kw: asyncio.sleep(0, result=[])),
+        ("create_virtual_machines", lambda **kw: asyncio.sleep(0, result=[])),
+        ("create_storages", lambda **kw: asyncio.sleep(0, result=[])),
+        (
+            "create_virtual_disks",
+            lambda **kw: asyncio.sleep(
+                0, result={"count": 0, "created": 0, "updated": 0, "skipped": 0}
+            ),
+        ),
+        ("create_all_virtual_machine_backups", lambda **kw: asyncio.sleep(0, result=[])),
+        (
+            "create_all_virtual_machine_snapshots",
+            lambda **kw: asyncio.sleep(0, result={"count": 0, "created": 0, "skipped": 0}),
+        ),
+        (
+            "sync_all_virtual_machine_task_histories",
+            lambda **kw: asyncio.sleep(0, result={"count": 0, "created": 0, "skipped": 0}),
+        ),
+        ("create_all_device_interfaces", lambda **kw: asyncio.sleep(0, result=[])),
+        ("create_only_vm_interfaces", lambda **kw: asyncio.sleep(0, result=[])),
+        ("create_only_vm_ip_addresses", lambda **kw: asyncio.sleep(0, result=[])),
+        (
+            "sync_all_replications",
+            lambda **kw: asyncio.sleep(0, result={"created": 0, "updated": 0}),
+        ),
+        (
+            "sync_all_backup_routines",
+            lambda **kw: asyncio.sleep(0, result={"created": 0, "updated": 0}),
+        ),
+    ]
+    for name, fn in targets:
+        monkeypatch.setattr(f"proxbox_api.app.full_update.{name}", fn)
+
+
+def test_full_update_sync_does_not_call_activate_branch_without_schema_id(monkeypatch):
+    _stub_full_update_dependencies(monkeypatch)
+
+    from proxbox_api.main import full_update_sync
+
+    session = SimpleNamespace(activate_branch=AsyncMock())
+    asyncio.run(
+        full_update_sync(
+            netbox_session=session,
+            pxs=[],
+            cluster_status=[],
+            cluster_resources=[],
+            custom_fields=[],
+            tag=type("Tag", (), {"id": 1, "name": "Proxbox", "slug": "proxbox", "color": "ff0"})(),
+        )
+    )
+
+    session.activate_branch.assert_not_called()
+
+
+def test_full_update_sync_invokes_activate_branch_with_schema_id(monkeypatch):
+    _stub_full_update_dependencies(monkeypatch)
+
+    from proxbox_api.main import full_update_sync
+
+    captured: list[str] = []
+
+    @contextmanager
+    def _activate(schema_id: str):
+        captured.append(schema_id)
+        yield
+
+    session = SimpleNamespace(activate_branch=_activate)
+    asyncio.run(
+        full_update_sync(
+            netbox_session=session,
+            pxs=[],
+            cluster_status=[],
+            cluster_resources=[],
+            custom_fields=[],
+            tag=type("Tag", (), {"id": 1, "name": "Proxbox", "slug": "proxbox", "color": "ff0"})(),
+            netbox_branch_schema_id="abcd1234",
+        )
+    )
+
+    assert captured == ["abcd1234"]
+
+
+# ---------------------------------------------------------------------------
+# settings_client must NEVER attach a branch header
+# ---------------------------------------------------------------------------
+
+
+def test_settings_client_module_does_not_reference_activate_branch():
+    """Settings are read from main; a branch header on settings fetches would
+    cause per-branch cache pollution. Pin the absence of the call in source."""
+    import pathlib
+
+    settings_path = (
+        pathlib.Path(__file__).resolve().parent.parent / "proxbox_api" / "settings_client.py"
+    )
+    text = settings_path.read_text(encoding="utf-8")
+    assert "activate_branch" not in text
+    assert "X-NetBox-Branch" not in text

--- a/tests/test_overwrite_flags_contract.py
+++ b/tests/test_overwrite_flags_contract.py
@@ -1,7 +1,7 @@
 """Cross-repo drift detector for the overwrite_* flag set.
 
 The plugin (`netbox-proxbox`) and the backend (`proxbox-api`) each carry the
-same canonical 23-flag list as a single source of truth:
+same canonical 24-flag list as a single source of truth:
 
 - Plugin: `netbox_proxbox.constants.OVERWRITE_FIELDS`
 - Backend: `proxbox_api.schemas.sync.SyncOverwriteFlags.model_fields`
@@ -9,7 +9,7 @@ same canonical 23-flag list as a single source of truth:
 A copy of the canonical names + order is committed to BOTH repos as
 `contracts/overwrite_flags.json`. This test asserts that the local source of
 truth on this side matches the manifest exactly. The mirror repo runs the same
-test against its own source of truth. Any developer who adds a 23rd flag to
+test against its own source of truth. Any developer who adds another flag to
 either side must update both manifests; CI on both repos fails otherwise.
 """
 
@@ -40,10 +40,10 @@ def test_manifest_matches_sync_overwrite_flags_model_fields() -> None:
     )
 
 
-def test_manifest_field_count_is_canonical_23() -> None:
+def test_manifest_field_count_is_canonical_24() -> None:
     """Sanity check: any change to flag count is intentional and reviewed."""
     manifest_fields = _load_manifest_fields()
-    assert len(manifest_fields) == 23
+    assert len(manifest_fields) == 24
 
 
 def test_manifest_has_no_duplicate_fields() -> None:

--- a/tests/test_proxmox_actions_gate.py
+++ b/tests/test_proxmox_actions_gate.py
@@ -24,7 +24,6 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from proxbox_api.database import ApiKey, ProxmoxEndpoint, get_async_session, get_session
 from proxbox_api.main import app
 
-
 VERB_PATHS = [
     ("/proxmox/qemu/100/start"),
     ("/proxmox/lxc/100/start"),
@@ -44,18 +43,12 @@ VERB_PATHS = [
 @pytest.fixture
 def client(tmp_path: Path):
     sqlite_file = tmp_path / "test.db"
-    engine = create_engine(
-        f"sqlite:///{sqlite_file}", connect_args={"check_same_thread": False}
-    )
+    engine = create_engine(f"sqlite:///{sqlite_file}", connect_args={"check_same_thread": False})
     SQLModel.metadata.create_all(engine)
 
     async_url = str(engine.url).replace("sqlite:///", "sqlite+aiosqlite:///")
-    async_engine = create_async_engine(
-        async_url, connect_args={"check_same_thread": False}
-    )
-    session_factory = async_sessionmaker(
-        async_engine, class_=AsyncSession, expire_on_commit=False
-    )
+    async_engine = create_async_engine(async_url, connect_args={"check_same_thread": False})
+    session_factory = async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
 
     def _override_get_session():
         with Session(engine) as session:

--- a/tests/test_proxmox_actions_migrate_verb.py
+++ b/tests/test_proxmox_actions_migrate_verb.py
@@ -31,18 +31,12 @@ from proxbox_api.services.idempotency import get_idempotency_cache
 @pytest.fixture
 def client(tmp_path: Path):
     sqlite_file = tmp_path / "test.db"
-    engine = create_engine(
-        f"sqlite:///{sqlite_file}", connect_args={"check_same_thread": False}
-    )
+    engine = create_engine(f"sqlite:///{sqlite_file}", connect_args={"check_same_thread": False})
     SQLModel.metadata.create_all(engine)
 
     async_url = str(engine.url).replace("sqlite:///", "sqlite+aiosqlite:///")
-    async_engine = create_async_engine(
-        async_url, connect_args={"check_same_thread": False}
-    )
-    session_factory = async_sessionmaker(
-        async_engine, class_=AsyncSession, expire_on_commit=False
-    )
+    async_engine = create_async_engine(async_url, connect_args={"check_same_thread": False})
+    session_factory = async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
 
     def _override_get_session():
         with Session(engine) as session:
@@ -112,33 +106,20 @@ def _patch_route(
     nb_session = AsyncMock(return_value=object())
     node_mock = AsyncMock(return_value=node_or_response)
     netbox_id_mock = AsyncMock(return_value=netbox_vm_id)
-    preflight_mock = AsyncMock(
-        return_value=preflight_payload, side_effect=preflight_side_effect
-    )
-    migrate_mock = AsyncMock(
-        return_value=migrate_result, side_effect=migrate_side_effect
-    )
+    preflight_mock = AsyncMock(return_value=preflight_payload, side_effect=preflight_side_effect)
+    migrate_mock = AsyncMock(return_value=migrate_result, side_effect=migrate_side_effect)
     cancel_mock = AsyncMock(return_value=None, side_effect=cancel_side_effect)
     task_status_mock = AsyncMock(
-        return_value=task_status_payload
-        or SimpleNamespace(status="stopped", exitstatus="OK")
+        return_value=task_status_payload or SimpleNamespace(status="stopped", exitstatus="OK")
     )
     journal_mock = AsyncMock(return_value=journal_entry)
 
     patches = [
-        patch(
-            "proxbox_api.routes.proxmox_actions._open_proxmox_session", open_session
-        ),
-        patch(
-            "proxbox_api.routes.proxmox_actions.get_netbox_async_session", nb_session
-        ),
+        patch("proxbox_api.routes.proxmox_actions._open_proxmox_session", open_session),
+        patch("proxbox_api.routes.proxmox_actions.get_netbox_async_session", nb_session),
         patch("proxbox_api.routes.proxmox_actions.resolve_proxmox_node", node_mock),
-        patch(
-            "proxbox_api.routes.proxmox_actions.resolve_netbox_vm_id", netbox_id_mock
-        ),
-        patch(
-            "proxbox_api.routes.proxmox_actions.migrate_preflight", preflight_mock
-        ),
+        patch("proxbox_api.routes.proxmox_actions.resolve_netbox_vm_id", netbox_id_mock),
+        patch("proxbox_api.routes.proxmox_actions.migrate_preflight", preflight_mock),
         patch("proxbox_api.routes.proxmox_actions.migrate_vm", migrate_mock),
         patch("proxbox_api.routes.proxmox_actions.cancel_task", cancel_mock),
         patch(
@@ -306,9 +287,7 @@ def test_migrate_qemu_success_returns_202_with_sse_url_and_journal(
     assert body["endpoint_id"] == endpoint_id
     assert body["result"] == "accepted"
     assert body["proxmox_task_upid"] == "UPID:pve-node-01:0001:migrate"
-    assert body["sse_url"] == (
-        "/proxmox/qemu/100/migrate/UPID:pve-node-01:0001:migrate/stream"
-    )
+    assert body["sse_url"] == ("/proxmox/qemu/100/migrate/UPID:pve-node-01:0001:migrate/stream")
     assert body["target"] == "pve-node-02"
     assert body["online"] is False
     assert body["source_node"] == "pve-node-01"
@@ -351,9 +330,7 @@ def test_migrate_qemu_proxmox_dispatch_failure_writes_warning_journal(
     client: TestClient,
 ):
     endpoint_id = _make_endpoint(client)
-    handles = _patch_route(
-        migrate_side_effect=ProxmoxAPIError(message="cluster lock held")
-    )
+    handles = _patch_route(migrate_side_effect=ProxmoxAPIError(message="cluster lock held"))
     for p in handles["patches"]:
         p.start()
     try:
@@ -429,9 +406,7 @@ def test_migrate_qemu_cancel_returns_200_and_writes_journal(client: TestClient):
 
 def test_migrate_qemu_cancel_proxmox_failure_writes_warning(client: TestClient):
     endpoint_id = _make_endpoint(client)
-    handles = _patch_route(
-        cancel_side_effect=ProxmoxAPIError(message="task already gone")
-    )
+    handles = _patch_route(cancel_side_effect=ProxmoxAPIError(message="task already gone"))
     for p in handles["patches"]:
         p.start()
     try:
@@ -460,9 +435,7 @@ def test_migrate_qemu_stream_emits_dispatched_and_succeeded(client: TestClient):
     endpoint_id = _make_endpoint(client)
     # Task is already complete on the first poll → stream emits
     # ``migrate_dispatched`` then ``migrate_succeeded`` and closes.
-    handles = _patch_route(
-        task_status_payload=SimpleNamespace(status="stopped", exitstatus="OK")
-    )
+    handles = _patch_route(task_status_payload=SimpleNamespace(status="stopped", exitstatus="OK"))
     for p in handles["patches"]:
         p.start()
     try:

--- a/tests/test_proxmox_actions_snapshot_verb.py
+++ b/tests/test_proxmox_actions_snapshot_verb.py
@@ -27,18 +27,12 @@ from proxbox_api.services.idempotency import get_idempotency_cache
 @pytest.fixture
 def client(tmp_path: Path):
     sqlite_file = tmp_path / "test.db"
-    engine = create_engine(
-        f"sqlite:///{sqlite_file}", connect_args={"check_same_thread": False}
-    )
+    engine = create_engine(f"sqlite:///{sqlite_file}", connect_args={"check_same_thread": False})
     SQLModel.metadata.create_all(engine)
 
     async_url = str(engine.url).replace("sqlite:///", "sqlite+aiosqlite:///")
-    async_engine = create_async_engine(
-        async_url, connect_args={"check_same_thread": False}
-    )
-    session_factory = async_sessionmaker(
-        async_engine, class_=AsyncSession, expire_on_commit=False
-    )
+    async_engine = create_async_engine(async_url, connect_args={"check_same_thread": False})
+    session_factory = async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
 
     def _override_get_session():
         with Session(engine) as session:
@@ -97,25 +91,15 @@ def _patch_route(
     nb_session = AsyncMock(return_value=object())
     node_mock = AsyncMock(return_value=node_or_response)
     netbox_id_mock = AsyncMock(return_value=netbox_vm_id)
-    snapshot_mock = AsyncMock(
-        return_value=snapshot_result, side_effect=snapshot_side_effect
-    )
+    snapshot_mock = AsyncMock(return_value=snapshot_result, side_effect=snapshot_side_effect)
     journal_mock = AsyncMock(return_value=journal_entry)
 
     patches = [
-        patch(
-            "proxbox_api.routes.proxmox_actions._open_proxmox_session", open_session
-        ),
-        patch(
-            "proxbox_api.routes.proxmox_actions.get_netbox_async_session", nb_session
-        ),
+        patch("proxbox_api.routes.proxmox_actions._open_proxmox_session", open_session),
+        patch("proxbox_api.routes.proxmox_actions.get_netbox_async_session", nb_session),
         patch("proxbox_api.routes.proxmox_actions.resolve_proxmox_node", node_mock),
-        patch(
-            "proxbox_api.routes.proxmox_actions.resolve_netbox_vm_id", netbox_id_mock
-        ),
-        patch(
-            "proxbox_api.routes.proxmox_actions.create_vm_snapshot", snapshot_mock
-        ),
+        patch("proxbox_api.routes.proxmox_actions.resolve_netbox_vm_id", netbox_id_mock),
+        patch("proxbox_api.routes.proxmox_actions.create_vm_snapshot", snapshot_mock),
         patch(
             "proxbox_api.routes.proxmox_actions.write_verb_journal_entry",
             journal_mock,
@@ -164,9 +148,9 @@ def test_snapshot_qemu_success_returns_response_shape_and_writes_journal(
 
     handles["snapshot"].assert_awaited_once()
     call_args = handles["snapshot"].call_args
-    assert "before-upgrade" in call_args.args or call_args.kwargs.get(
-        "snapname"
-    ) == "before-upgrade"
+    assert (
+        "before-upgrade" in call_args.args or call_args.kwargs.get("snapname") == "before-upgrade"
+    )
     handles["journal"].assert_awaited_once()
     journal_kwargs = handles["journal"].call_args.kwargs
     assert journal_kwargs["kind"] == "info"
@@ -207,9 +191,7 @@ def test_snapshot_qemu_default_snapname_with_no_key_uses_utc_stamp(
     for p in handles["patches"]:
         p.start()
     try:
-        resp = client.post(
-            "/proxmox/qemu/100/snapshot", params={"endpoint_id": endpoint_id}
-        )
+        resp = client.post("/proxmox/qemu/100/snapshot", params={"endpoint_id": endpoint_id})
     finally:
         for p in handles["patches"]:
             p.stop()
@@ -256,9 +238,7 @@ def test_snapshot_qemu_proxmox_dispatch_failure_writes_warning_journal(
     client: TestClient,
 ):
     endpoint_id = _make_endpoint(client)
-    handles = _patch_route(
-        snapshot_side_effect=ProxmoxAPIError(message="snapshot name in use")
-    )
+    handles = _patch_route(snapshot_side_effect=ProxmoxAPIError(message="snapshot name in use"))
     for p in handles["patches"]:
         p.start()
     try:
@@ -287,9 +267,7 @@ def test_snapshot_lxc_routes_through_same_dispatch(client: TestClient):
     for p in handles["patches"]:
         p.start()
     try:
-        resp = client.post(
-            "/proxmox/lxc/101/snapshot", params={"endpoint_id": endpoint_id}
-        )
+        resp = client.post("/proxmox/lxc/101/snapshot", params={"endpoint_id": endpoint_id})
     finally:
         for p in handles["patches"]:
             p.stop()
@@ -308,9 +286,7 @@ def test_snapshot_qemu_no_matching_netbox_vm_still_dispatches(client: TestClient
     for p in handles["patches"]:
         p.start()
     try:
-        resp = client.post(
-            "/proxmox/qemu/100/snapshot", params={"endpoint_id": endpoint_id}
-        )
+        resp = client.post("/proxmox/qemu/100/snapshot", params={"endpoint_id": endpoint_id})
     finally:
         for p in handles["patches"]:
             p.stop()

--- a/tests/test_proxmox_actions_start_verb.py
+++ b/tests/test_proxmox_actions_start_verb.py
@@ -32,18 +32,12 @@ from proxbox_api.services.idempotency import get_idempotency_cache
 @pytest.fixture
 def client(tmp_path: Path):
     sqlite_file = tmp_path / "test.db"
-    engine = create_engine(
-        f"sqlite:///{sqlite_file}", connect_args={"check_same_thread": False}
-    )
+    engine = create_engine(f"sqlite:///{sqlite_file}", connect_args={"check_same_thread": False})
     SQLModel.metadata.create_all(engine)
 
     async_url = str(engine.url).replace("sqlite:///", "sqlite+aiosqlite:///")
-    async_engine = create_async_engine(
-        async_url, connect_args={"check_same_thread": False}
-    )
-    session_factory = async_sessionmaker(
-        async_engine, class_=AsyncSession, expire_on_commit=False
-    )
+    async_engine = create_async_engine(async_url, connect_args={"check_same_thread": False})
+    session_factory = async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
 
     def _override_get_session():
         with Session(engine) as session:
@@ -111,25 +105,15 @@ def _patch_route(
     nb_session = AsyncMock(return_value=netbox_session or object())
     node_mock = AsyncMock(return_value=node_or_response)
     netbox_id_mock = AsyncMock(return_value=netbox_vm_id)
-    status_mock = AsyncMock(
-        return_value=status_payload, side_effect=status_side_effect
-    )
+    status_mock = AsyncMock(return_value=status_payload, side_effect=status_side_effect)
     start_mock = AsyncMock(return_value=start_result, side_effect=start_side_effect)
     journal_mock = AsyncMock(return_value=journal_entry)
 
     patches = [
-        patch(
-            "proxbox_api.routes.proxmox_actions._open_proxmox_session", open_session
-        ),
-        patch(
-            "proxbox_api.routes.proxmox_actions.get_netbox_async_session", nb_session
-        ),
-        patch(
-            "proxbox_api.routes.proxmox_actions.resolve_proxmox_node", node_mock
-        ),
-        patch(
-            "proxbox_api.routes.proxmox_actions.resolve_netbox_vm_id", netbox_id_mock
-        ),
+        patch("proxbox_api.routes.proxmox_actions._open_proxmox_session", open_session),
+        patch("proxbox_api.routes.proxmox_actions.get_netbox_async_session", nb_session),
+        patch("proxbox_api.routes.proxmox_actions.resolve_proxmox_node", node_mock),
+        patch("proxbox_api.routes.proxmox_actions.resolve_netbox_vm_id", netbox_id_mock),
         patch("proxbox_api.routes.proxmox_actions.get_vm_status", status_mock),
         patch("proxbox_api.routes.proxmox_actions.start_vm", start_mock),
         patch(
@@ -227,9 +211,7 @@ def test_start_qemu_already_running_skips_dispatch_but_writes_journal(
     for p in handles["patches"]:
         p.start()
     try:
-        resp = client.post(
-            "/proxmox/qemu/100/start", params={"endpoint_id": endpoint_id}
-        )
+        resp = client.post("/proxmox/qemu/100/start", params={"endpoint_id": endpoint_id})
     finally:
         for p in handles["patches"]:
             p.stop()
@@ -248,15 +230,11 @@ def test_start_qemu_proxmox_dispatch_failure_writes_warning_journal(
     client: TestClient,
 ):
     endpoint_id = _make_endpoint(client)
-    handles = _patch_route(
-        start_side_effect=ProxmoxAPIError(message="lock conflict")
-    )
+    handles = _patch_route(start_side_effect=ProxmoxAPIError(message="lock conflict"))
     for p in handles["patches"]:
         p.start()
     try:
-        resp = client.post(
-            "/proxmox/qemu/100/start", params={"endpoint_id": endpoint_id}
-        )
+        resp = client.post("/proxmox/qemu/100/start", params={"endpoint_id": endpoint_id})
     finally:
         for p in handles["patches"]:
             p.stop()
@@ -269,9 +247,7 @@ def test_start_qemu_proxmox_dispatch_failure_writes_warning_journal(
     # Failure path still writes exactly one journal entry, kind=warning (§6.2).
     handles["journal"].assert_awaited_once()
     assert handles["journal"].call_args.kwargs["kind"] == "warning"
-    assert (
-        "error_detail: " in handles["journal"].call_args.kwargs["comments"]
-    )
+    assert "error_detail: " in handles["journal"].call_args.kwargs["comments"]
 
 
 def test_start_lxc_routes_through_same_dispatch(client: TestClient):
@@ -280,9 +256,7 @@ def test_start_lxc_routes_through_same_dispatch(client: TestClient):
     for p in handles["patches"]:
         p.start()
     try:
-        resp = client.post(
-            "/proxmox/lxc/101/start", params={"endpoint_id": endpoint_id}
-        )
+        resp = client.post("/proxmox/lxc/101/start", params={"endpoint_id": endpoint_id})
     finally:
         for p in handles["patches"]:
             p.stop()
@@ -303,9 +277,7 @@ def test_start_qemu_no_matching_netbox_vm_still_dispatches(client: TestClient):
     for p in handles["patches"]:
         p.start()
     try:
-        resp = client.post(
-            "/proxmox/qemu/100/start", params={"endpoint_id": endpoint_id}
-        )
+        resp = client.post("/proxmox/qemu/100/start", params={"endpoint_id": endpoint_id})
     finally:
         for p in handles["patches"]:
             p.stop()

--- a/tests/test_proxmox_actions_stop_verb.py
+++ b/tests/test_proxmox_actions_stop_verb.py
@@ -27,18 +27,12 @@ from proxbox_api.services.idempotency import get_idempotency_cache
 @pytest.fixture
 def client(tmp_path: Path):
     sqlite_file = tmp_path / "test.db"
-    engine = create_engine(
-        f"sqlite:///{sqlite_file}", connect_args={"check_same_thread": False}
-    )
+    engine = create_engine(f"sqlite:///{sqlite_file}", connect_args={"check_same_thread": False})
     SQLModel.metadata.create_all(engine)
 
     async_url = str(engine.url).replace("sqlite:///", "sqlite+aiosqlite:///")
-    async_engine = create_async_engine(
-        async_url, connect_args={"check_same_thread": False}
-    )
-    session_factory = async_sessionmaker(
-        async_engine, class_=AsyncSession, expire_on_commit=False
-    )
+    async_engine = create_async_engine(async_url, connect_args={"check_same_thread": False})
+    session_factory = async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
 
     def _override_get_session():
         with Session(engine) as session:
@@ -103,16 +97,10 @@ def _patch_route(
     journal_mock = AsyncMock(return_value=journal_entry)
 
     patches = [
-        patch(
-            "proxbox_api.routes.proxmox_actions._open_proxmox_session", open_session
-        ),
-        patch(
-            "proxbox_api.routes.proxmox_actions.get_netbox_async_session", nb_session
-        ),
+        patch("proxbox_api.routes.proxmox_actions._open_proxmox_session", open_session),
+        patch("proxbox_api.routes.proxmox_actions.get_netbox_async_session", nb_session),
         patch("proxbox_api.routes.proxmox_actions.resolve_proxmox_node", node_mock),
-        patch(
-            "proxbox_api.routes.proxmox_actions.resolve_netbox_vm_id", netbox_id_mock
-        ),
+        patch("proxbox_api.routes.proxmox_actions.resolve_netbox_vm_id", netbox_id_mock),
         patch("proxbox_api.routes.proxmox_actions.get_vm_status", status_mock),
         patch("proxbox_api.routes.proxmox_actions.stop_vm", stop_mock),
         patch(
@@ -199,9 +187,7 @@ def test_stop_qemu_already_stopped_skips_dispatch_but_writes_journal(
     for p in handles["patches"]:
         p.start()
     try:
-        resp = client.post(
-            "/proxmox/qemu/100/stop", params={"endpoint_id": endpoint_id}
-        )
+        resp = client.post("/proxmox/qemu/100/stop", params={"endpoint_id": endpoint_id})
     finally:
         for p in handles["patches"]:
             p.stop()
@@ -218,15 +204,11 @@ def test_stop_qemu_proxmox_dispatch_failure_writes_warning_journal(
     client: TestClient,
 ):
     endpoint_id = _make_endpoint(client)
-    handles = _patch_route(
-        stop_side_effect=ProxmoxAPIError(message="cannot acquire lock")
-    )
+    handles = _patch_route(stop_side_effect=ProxmoxAPIError(message="cannot acquire lock"))
     for p in handles["patches"]:
         p.start()
     try:
-        resp = client.post(
-            "/proxmox/qemu/100/stop", params={"endpoint_id": endpoint_id}
-        )
+        resp = client.post("/proxmox/qemu/100/stop", params={"endpoint_id": endpoint_id})
     finally:
         for p in handles["patches"]:
             p.stop()
@@ -246,9 +228,7 @@ def test_stop_lxc_routes_through_same_dispatch(client: TestClient):
     for p in handles["patches"]:
         p.start()
     try:
-        resp = client.post(
-            "/proxmox/lxc/101/stop", params={"endpoint_id": endpoint_id}
-        )
+        resp = client.post("/proxmox/lxc/101/stop", params={"endpoint_id": endpoint_id})
     finally:
         for p in handles["patches"]:
             p.stop()
@@ -267,9 +247,7 @@ def test_stop_qemu_no_matching_netbox_vm_still_dispatches(client: TestClient):
     for p in handles["patches"]:
         p.start()
     try:
-        resp = client.post(
-            "/proxmox/qemu/100/stop", params={"endpoint_id": endpoint_id}
-        )
+        resp = client.post("/proxmox/qemu/100/stop", params={"endpoint_id": endpoint_id})
     finally:
         for p in handles["patches"]:
             p.stop()

--- a/tests/test_sync_overwrite_flags.py
+++ b/tests/test_sync_overwrite_flags.py
@@ -1,6 +1,6 @@
 """Tests for the SyncOverwriteFlags Pydantic schema.
 
-Locks in the canonical 23-flag set, the all-True default, and the OpenAPI
+Locks in the canonical 24-flag set, the all-True default, and the OpenAPI
 metadata (title/description) added so Swagger UI renders the flattened query
 parameters correctly. The flag list must stay in lock-step with
 `netbox_proxbox.constants.OVERWRITE_FIELDS` on the plugin side.
@@ -25,6 +25,7 @@ EXPECTED_FLAGS: tuple[str, ...] = (
     "overwrite_vm_tags",
     "overwrite_vm_description",
     "overwrite_vm_custom_fields",
+    "overwrite_vm_cloudinit",
     "overwrite_cluster_tags",
     "overwrite_cluster_description",
     "overwrite_cluster_custom_fields",
@@ -41,8 +42,8 @@ EXPECTED_FLAGS: tuple[str, ...] = (
 
 
 def test_overwrite_flags_field_count() -> None:
-    """Schema exposes exactly 23 fields, mirroring OVERWRITE_FIELDS in the plugin."""
-    assert len(SyncOverwriteFlags.model_fields) == 23
+    """Schema exposes exactly 24 fields, mirroring OVERWRITE_FIELDS in the plugin."""
+    assert len(SyncOverwriteFlags.model_fields) == 24
 
 
 def test_overwrite_flags_field_names_and_order() -> None:

--- a/tests/test_verb_dispatch_helpers.py
+++ b/tests/test_verb_dispatch_helpers.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import re
 from unittest.mock import AsyncMock, patch
 
-import pytest
 from fastapi.responses import JSONResponse
 
 from proxbox_api.exception import ProxmoxAPIError
@@ -135,9 +134,7 @@ async def test_resolve_proxmox_node_returns_node_on_match():
             ]
         ),
     ):
-        node = await verb_dispatch.resolve_proxmox_node(
-            session=object(), vm_type="qemu", vmid=101
-        )
+        node = await verb_dispatch.resolve_proxmox_node(session=object(), vm_type="qemu", vmid=101)
     assert node == "pve-node-01"
 
 
@@ -188,9 +185,7 @@ async def test_resolve_netbox_vm_id_returns_none_when_missing():
 
 async def test_write_verb_journal_entry_posts_payload():
     create_mock = AsyncMock(return_value={"id": 789, "url": "/api/extras/journal-entries/789/"})
-    with patch(
-        "proxbox_api.services.verb_dispatch.rest_create_async", new=create_mock
-    ):
+    with patch("proxbox_api.services.verb_dispatch.rest_create_async", new=create_mock):
         entry = await verb_dispatch.write_verb_journal_entry(
             nb=object(),
             netbox_vm_id=42,


### PR DESCRIPTION
## Summary

Ports [PR #74](https://github.com/emersonfelipesp/proxbox-api/pull/74) (NetBox Branching support, originally merged to `main`) onto the `v0.0.11` release branch.

Threads an optional `netbox_branch_schema_id` query parameter through `/full-update` (sync) and `/full-update/stream` (SSE). When set, the route opens `netbox_session.activate_branch(schema_id)` around the entire run so every NetBox write carries the `X-NetBox-Branch` header and lands on the branch instead of `main`.

## Why a port, not a cherry-pick

PR #74 was authored on `main`, where #71 / #376 / #357 / #358 sub-PRs have refactored helper boundaries (e.g. v0.0.11's stream route still uses `_create_all_virtual_machine_backups` / `_create_all_virtual_machine_snapshots` private helpers; main has moved to the public `create_*` flavors). The structural shape is identical, but adapter glue had to be hand-merged.

## Changes

**`proxbox_api/app/full_update.py`** — sync route is split into three layers to mirror PR #74's structure:
- `full_update_sync` — thin wrapper exposing the query param.
- `_full_update_sync_run` — opens the `activate_branch` scope (or `nullcontext()` when no schema_id).
- `_full_update_sync_impl` — original body, unchanged (240 lines).

Stream route wraps its `event_stream()` generator inside an inner `branched_stream()` so the branch context spans the entire SSE lifetime, not just the request handler.

**`settings_client.py`** — intentionally **not** branched. Settings are read from `main`; per-branch settings caches would pollute the plugin-side runtime. Pinned in a source-level test.

## Tests added

- `tests/test_netbox_branch_header.py` — `activate_branch()` scope semantics (set/reset, nested context), sync-route gating on schema_id presence/absence, plus the source-level guard that `settings_client.py` does not reference branching APIs.
- `tests/test_full_update_stream_branching.py` — stream-route gating on schema_id presence/empty/absence, asserts the branch context enters exactly once and exits cleanly after the stream drains.

## Pre-commit checklist

- [x] `uv run python -m compileall proxbox_api tests` — clean.
- [x] `uv run ruff check tests/test_netbox_branch_header.py tests/test_full_update_stream_branching.py proxbox_api/app/full_update.py` — clean (whole-repo run shows 7 pre-existing diagnostics in unrelated files; none introduced by this PR).
- [x] `uv run ruff format --check ...` — clean on changed files.
- [x] `uv run pytest tests/test_api_routes.py tests/test_full_update_stream_branching.py tests/test_netbox_branch_header.py` — **40/40 pass**, including 8 new branching tests and all existing full_update route tests.
- [x] `uv run ty check proxbox_api/types proxbox_api/utils/retry.py proxbox_api/schemas/sync.py` — clean (narrow-scope per workspace convention; `full_update.py` ships with pre-existing `object`-typed Dep surfaces that ty flags broadly across the whole repo).

## Out of scope

- Plugin-side (`netbox-proxbox` v0.0.15) wiring — separate PR (Phase 1B).
- `SyncContext.netbox_branch` field semantics — separate PR (Phase 2 bridge, per #406).
- Custom-field exemption logic, NetBox→Proxmox reconcile path (#377), reconciler-level activation — explicitly out of scope per #406.

## Test plan

- [ ] Reviewer pulls the branch, runs the test commands above.
- [ ] Reviewer skims that `_full_update_sync_impl`'s 240-line body is byte-equivalent to the pre-port version.
- [ ] Reviewer confirms `settings_client.py` is untouched.

Refs: emersonfelipesp/netbox-proxbox#406, emersonfelipesp/netbox-proxbox#370