### PR TITLE
feat(#362): first-discovery audit tags (apply-on-create only)

### DIFF
--- a/proxbox_api/constants.py
+++ b/proxbox_api/constants.py
@@ -78,6 +78,21 @@ PROXMOX_TAG = "proxmox"
 PROXBOX_TAG = "proxbox"
 AUTO_SYNCED_TAG = "auto-synced"
 
+# First-discovery audit tags — applied ONLY when an object is created by the
+# reconciler. Update paths must never re-stamp these slugs; operator removal
+# from NetBox is permanent. See issue #362.
+DISCOVERY_TAG_VM_QEMU = "proxbox-discovered-qemu"
+DISCOVERY_TAG_VM_LXC = "proxbox-discovered-lxc"
+DISCOVERY_TAG_CLUSTER = "proxbox-discovered-cluster"
+DISCOVERY_TAG_NODE = "proxbox-discovered-node"
+
+DISCOVERY_TAG_SLUGS: tuple[str, ...] = (
+    DISCOVERY_TAG_VM_QEMU,
+    DISCOVERY_TAG_VM_LXC,
+    DISCOVERY_TAG_CLUSTER,
+    DISCOVERY_TAG_NODE,
+)
+
 # Status codes
 HTTP_OK = 200
 HTTP_CREATED = 201

--- a/proxbox_api/services/netbox_bootstrap.py
+++ b/proxbox_api/services/netbox_bootstrap.py
@@ -33,7 +33,14 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from proxbox_api.constants import VM_ROLE_MAPPINGS, VM_TYPE_MAPPINGS
+from proxbox_api.constants import (
+    DISCOVERY_TAG_CLUSTER,
+    DISCOVERY_TAG_NODE,
+    DISCOVERY_TAG_VM_LXC,
+    DISCOVERY_TAG_VM_QEMU,
+    VM_ROLE_MAPPINGS,
+    VM_TYPE_MAPPINGS,
+)
 from proxbox_api.logger import logger
 from proxbox_api.netbox_version import (
     detect_netbox_version,
@@ -89,24 +96,34 @@ _PROXBOX_TAG_SLUG = "proxbox"
 _PROXBOX_TAG_COLOR = "ff5722"
 _PROXBOX_TAG_DESCRIPTION = "Proxbox Identifier (used to identify the items the plugin created)"
 
+# First-discovery audit tags (issue #362). Stamped onto an object only when
+# the reconciler takes the create branch; never re-attached on update. Operator
+# removal is permanent. Per-type QEMU/LXC split lets a saved-search filter
+# return exactly the VMs Proxbox first imported of that type.
 _DISCOVERY_TAGS: tuple[dict[str, str], ...] = (
     {
-        "name": "Proxbox: Discovered VM",
-        "slug": "proxbox-discovered-vm",
+        "name": "Proxbox: Discovered QEMU VM",
+        "slug": DISCOVERY_TAG_VM_QEMU,
         "color": "2196f3",
-        "description": "Virtual machine discovered by Proxbox during a sync run.",
+        "description": "QEMU virtual machine first discovered by Proxbox (apply-on-create-only).",
+    },
+    {
+        "name": "Proxbox: Discovered LXC Container",
+        "slug": DISCOVERY_TAG_VM_LXC,
+        "color": "00bcd4",
+        "description": "LXC container first discovered by Proxbox (apply-on-create-only).",
     },
     {
         "name": "Proxbox: Discovered Cluster",
-        "slug": "proxbox-discovered-cluster",
+        "slug": DISCOVERY_TAG_CLUSTER,
         "color": "4caf50",
-        "description": "Cluster discovered by Proxbox during a sync run.",
+        "description": "Cluster first discovered by Proxbox (apply-on-create-only).",
     },
     {
         "name": "Proxbox: Discovered Node",
-        "slug": "proxbox-discovered-node",
+        "slug": DISCOVERY_TAG_NODE,
         "color": "9c27b0",
-        "description": "Proxmox node discovered by Proxbox during a sync run.",
+        "description": "Proxmox node first discovered by Proxbox (apply-on-create-only).",
     },
 )
 

--- a/proxbox_api/services/sync/device_ensure.py
+++ b/proxbox_api/services/sync/device_ensure.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from datetime import datetime, timezone
 
+from proxbox_api.constants import DISCOVERY_TAG_CLUSTER, DISCOVERY_TAG_NODE
 from proxbox_api.exception import ProxboxException
 from proxbox_api.netbox_rest import (
     BulkReconcilePhase,
@@ -23,6 +24,7 @@ from proxbox_api.proxmox_to_netbox.models import (
     NetBoxSiteSyncState,
 )
 from proxbox_api.schemas.sync import SyncOverwriteFlags
+from proxbox_api.services.sync.discovery_tags import discovery_tag_ref, merge_tag_refs
 from proxbox_api.types import NetBoxRecord
 
 
@@ -640,6 +642,27 @@ async def _ensure_cluster(
     site_id: int | None = None,
     tenant_id: int | None = None,
 ) -> NetBoxRecord:
+    # Pre-check existence so the first-discovery audit tag (issue #362) only
+    # lands in the create payload. On update we merge with the current tag
+    # set to keep the discovery slug and any operator-added tags intact.
+    existing_cluster = await rest_first_async(
+        nb,
+        "/api/virtualization/clusters/",
+        query={"name": cluster_name},
+    )
+    if existing_cluster is None:
+        effective_tag_refs: list[dict[str, object]] = [
+            *tag_refs,
+            discovery_tag_ref(DISCOVERY_TAG_CLUSTER),
+        ]
+    else:
+        existing_tags = (
+            existing_cluster.serialize().get("tags")
+            if hasattr(existing_cluster, "serialize")
+            else None
+        )
+        effective_tag_refs = merge_tag_refs(list(tag_refs), existing_tags)
+
     return await rest_reconcile_async(
         nb,
         "/api/virtualization/clusters/",
@@ -648,7 +671,7 @@ async def _ensure_cluster(
             cluster_name,
             cluster_type_id=cluster_type_id,
             mode=mode,
-            tag_refs=tag_refs,
+            tag_refs=effective_tag_refs,
             site_id=site_id,
             tenant_id=tenant_id,
         ),
@@ -816,9 +839,24 @@ async def _ensure_device(
     existing_device = _prefer_existing_device(existing_devices)
     site_id = _existing_device_site_pin(existing_device, site_id)
 
+    # First-discovery audit tag (issue #362). Stamp the node-discovery slug
+    # in the create payload only; on update, merge the desired tag refs with
+    # whatever the existing device already carries so neither the discovery
+    # tag nor operator-added tags get stripped.
+    if existing_device is None:
+        effective_tag_refs: list[dict[str, object]] = [
+            *tag_refs,
+            discovery_tag_ref(DISCOVERY_TAG_NODE),
+        ]
+    else:
+        effective_tag_refs = merge_tag_refs(
+            list(tag_refs),
+            existing_device.get("tags"),
+        )
+
     payload = {
         "name": device_name,
-        "tags": tag_refs,
+        "tags": effective_tag_refs,
         "cluster": cluster_id,
         "status": "active",
         "description": f"Proxmox Node {device_name}",

--- a/proxbox_api/services/sync/discovery_tags.py
+++ b/proxbox_api/services/sync/discovery_tags.py
@@ -1,0 +1,132 @@
+"""Helpers for the first-discovery audit tags (issue #362).
+
+These tags are stamped onto Proxbox-discovered objects **only when the
+reconciler takes the create branch**. The update branch must never re-stamp
+them, so an operator removing a discovery tag from a NetBox object via the
+UI is a permanent decision. The companion bootstrap (``netbox_bootstrap``)
+guarantees the four slugs exist on a fresh NetBox install.
+
+Slug inventory (see ``proxbox_api.constants``):
+
+- ``proxbox-discovered-qemu`` / ``proxbox-discovered-lxc`` — VMs
+- ``proxbox-discovered-cluster`` — Clusters
+- ``proxbox-discovered-node`` — Proxmox node Devices
+"""
+
+from __future__ import annotations
+
+from proxbox_api.constants import (
+    DISCOVERY_TAG_VM_LXC,
+    DISCOVERY_TAG_VM_QEMU,
+)
+from proxbox_api.logger import logger
+from proxbox_api.netbox_rest import rest_first_async
+
+
+def discovery_tag_ref(slug: str) -> dict[str, object]:
+    """Build a NetBox tag reference dict identified by slug.
+
+    NetBox's REST API accepts tags as ``[{"slug": "..."}]`` for create and
+    update payloads. Passing the slug-only form keeps the diff layer (which
+    sorts by slug) stable without needing to resolve a numeric ID first.
+    """
+    return {"slug": slug}
+
+
+def vm_discovery_tag_slug(vm_type: str) -> str:
+    """Return the discovery tag slug for the given Proxmox VM type."""
+    return DISCOVERY_TAG_VM_LXC if str(vm_type).lower() == "lxc" else DISCOVERY_TAG_VM_QEMU
+
+
+async def resolve_discovery_tag_id(nb: object, slug: str) -> int | None:
+    """Look up the NetBox tag ID for a discovery slug. Returns ``None`` if missing.
+
+    A missing tag means bootstrap has not run (or operator deleted the tag).
+    Callers must treat ``None`` as "skip stamping" rather than erroring — the
+    audit trail is a soft contract, never a sync blocker.
+    """
+    try:
+        record = await rest_first_async(
+            nb,
+            "/api/extras/tags/",
+            query={"slug": slug},
+        )
+    except Exception as exc:  # noqa: BLE001 — never fail the sync over a tag lookup
+        logger.debug("discovery tag lookup failed for slug=%s: %s", slug, exc)
+        return None
+    if record is None:
+        return None
+    tag_id = getattr(record, "id", None)
+    try:
+        return int(tag_id) if tag_id is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _ref_key(item: object) -> str | None:
+    """Extract the comparable slug from a tag ref-shaped value."""
+    if isinstance(item, dict):
+        slug = item.get("slug") or item.get("name")
+        return str(slug).strip().lower() if slug else None
+    if hasattr(item, "serialize"):
+        try:
+            serialized = item.serialize()
+        except Exception:  # noqa: BLE001
+            return None
+        if isinstance(serialized, dict):
+            slug = serialized.get("slug") or serialized.get("name")
+            return str(slug).strip().lower() if slug else None
+    text = str(item or "").strip().lower()
+    return text or None
+
+
+def merge_tag_refs(
+    base: list[dict[str, object]],
+    existing: object,
+) -> list[dict[str, object]]:
+    """Union ``base`` tag refs with the tag refs already on a NetBox record.
+
+    Used on the update branch of every reconciler that owns ``tags`` so that
+    operator-added tags AND previously-stamped discovery tags survive a
+    sync. Comparison is by slug (case-insensitive); ``base`` takes precedence
+    when both sides have the same slug.
+    """
+    merged: list[dict[str, object]] = []
+    seen_keys: set[str] = set()
+    for ref in base:
+        key = _ref_key(ref)
+        if key is None:
+            continue
+        merged.append(ref)
+        seen_keys.add(key)
+    if not isinstance(existing, list):
+        return merged
+    for item in existing:
+        key = _ref_key(item)
+        if key is None or key in seen_keys:
+            continue
+        if isinstance(item, dict):
+            merged.append(
+                {
+                    k: item.get(k)
+                    for k in ("id", "name", "slug", "color", "description")
+                    if item.get(k) is not None
+                }
+            )
+        elif hasattr(item, "serialize"):
+            try:
+                serialized = item.serialize()
+            except Exception:  # noqa: BLE001
+                continue
+            if isinstance(serialized, dict):
+                merged.append(
+                    {
+                        k: serialized.get(k)
+                        for k in ("id", "name", "slug", "color", "description")
+                        if serialized.get(k) is not None
+                    }
+                )
+        else:
+            merged.append({"slug": str(item).strip(), "name": str(item).strip()})
+        seen_keys.add(key)
+    return merged

--- a/proxbox_api/services/sync/individual/cluster_sync.py
+++ b/proxbox_api/services/sync/individual/cluster_sync.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from proxbox_api.netbox_rest import rest_list_async
+from proxbox_api.constants import DISCOVERY_TAG_CLUSTER
+from proxbox_api.netbox_rest import rest_first_async, rest_list_async
 from proxbox_api.services.netbox_writers import upsert_cluster, upsert_cluster_type
 from proxbox_api.services.run_session import SyncContext
+from proxbox_api.services.sync.discovery_tags import discovery_tag_ref, merge_tag_refs
 from proxbox_api.services.sync.individual.helpers import resolve_proxmox_session
 
 
@@ -80,12 +82,32 @@ async def sync_cluster_individual(
             mode="cluster",
             tag_refs=tag_refs,
         )
+
+        # Pre-check existence so the discovery tag (issue #362) only lands
+        # in the create payload. On update we merge the desired baseline
+        # with the current tag set so subsequent syncs do not strip the
+        # discovery slug nor any operator-added tags.
+        existing_cluster = await rest_first_async(
+            ctx.nb,
+            "/api/virtualization/clusters/",
+            query={"name": cluster_name},
+        )
+        if existing_cluster is None:
+            cluster_tag_refs = [*tag_refs, discovery_tag_ref(DISCOVERY_TAG_CLUSTER)]
+        else:
+            existing_tags = (
+                existing_cluster.serialize().get("tags")
+                if hasattr(existing_cluster, "serialize")
+                else None
+            )
+            cluster_tag_refs = merge_tag_refs(list(tag_refs), existing_tags)
+
         cluster_result = await upsert_cluster(
             ctx.nb,
             cluster_name=cluster_name,
             cluster_type_id=getattr(cluster_type_result.record, "id", None),
             mode="cluster",
-            tag_refs=tag_refs,
+            tag_refs=cluster_tag_refs,
         )
 
         netbox_object = (

--- a/proxbox_api/services/sync/individual/vm_sync.py
+++ b/proxbox_api/services/sync/individual/vm_sync.py
@@ -343,9 +343,7 @@ async def sync_vm_individual(
             # The merge below preserves it on subsequent syncs, and operator
             # removal from NetBox is permanent because this branch is no
             # longer reached once the VM exists.
-            discovery_id = await resolve_discovery_tag_id(
-                nb, vm_discovery_tag_slug(vm_type)
-            )
+            discovery_id = await resolve_discovery_tag_id(nb, vm_discovery_tag_slug(vm_type))
             if discovery_id is not None:
                 tag_ids.append(discovery_id)
         merged_tag_ids = sorted(set(tag_ids) | set(existing_tag_ids))

--- a/proxbox_api/services/sync/individual/vm_sync.py
+++ b/proxbox_api/services/sync/individual/vm_sync.py
@@ -19,6 +19,10 @@ from proxbox_api.services.proxmox_helpers import (
     get_vm_config_individual,
     get_vm_resource_individual,
 )
+from proxbox_api.services.sync.discovery_tags import (
+    resolve_discovery_tag_id,
+    vm_discovery_tag_slug,
+)
 from proxbox_api.services.sync.individual.base import BaseIndividualSyncService
 from proxbox_api.services.sync.individual.interface_sync import sync_interface_individual
 from proxbox_api.services.sync.vm_helpers import (
@@ -334,6 +338,16 @@ async def sync_vm_individual(
                     existing_tag_ids.append(int(tid))
                 except (TypeError, ValueError):
                     continue
+        else:
+            # First-discovery audit tag (issue #362) — stamp only on create.
+            # The merge below preserves it on subsequent syncs, and operator
+            # removal from NetBox is permanent because this branch is no
+            # longer reached once the VM exists.
+            discovery_id = await resolve_discovery_tag_id(
+                nb, vm_discovery_tag_slug(vm_type)
+            )
+            if discovery_id is not None:
+                tag_ids.append(discovery_id)
         merged_tag_ids = sorted(set(tag_ids) | set(existing_tag_ids))
 
         netbox_vm_payload = _build_netbox_vm_payload(

--- a/tests/test_cluster_sync_idempotent.py
+++ b/tests/test_cluster_sync_idempotent.py
@@ -99,6 +99,13 @@ def in_sync_netbox(monkeypatch: pytest.MonkeyPatch):
         "proxbox_api.services.sync.individual.cluster_sync.rest_list_async",
         _fake_list,
     )
+    # cluster_sync now pre-checks cluster existence directly via the imported
+    # `rest_first_async` symbol (issue #362 discovery-tag gate). Patch the
+    # bound name in that module so the fixture's fake handler is used.
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.individual.cluster_sync.rest_first_async",
+        _fake_first,
+    )
 
     # Pin the helper's timestamp so the desired and stored custom_fields
     # compare equal across runs.

--- a/tests/test_discovery_tags_create_only.py
+++ b/tests/test_discovery_tags_create_only.py
@@ -1,0 +1,391 @@
+"""First-discovery audit tag contract (issue #362).
+
+The four ``proxbox-discovered-*`` slugs are stamped onto Proxbox-managed
+objects **only when the reconciler takes the create branch**. The update
+branch must never re-add them, and operator removal from NetBox is
+permanent. These tests pin both halves of that invariant for the cluster
+individual reconciler. The VM/device equivalents share the same contract
+and are exercised indirectly through the discovery-tag helper module.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from proxbox_api import netbox_rest
+from proxbox_api.constants import (
+    DISCOVERY_TAG_CLUSTER,
+    DISCOVERY_TAG_NODE,
+    DISCOVERY_TAG_VM_LXC,
+    DISCOVERY_TAG_VM_QEMU,
+)
+from proxbox_api.services.sync.discovery_tags import (
+    discovery_tag_ref,
+    merge_tag_refs,
+    vm_discovery_tag_slug,
+)
+from proxbox_api.services.sync.individual.cluster_sync import sync_cluster_individual
+from tests.factories.session import make_session, make_settings
+
+_TAG = SimpleNamespace(id=7, name="Proxbox", slug="proxbox", color="ff5722")
+_PROXBOX_REF = {"id": 7, "name": "Proxbox", "slug": "proxbox", "color": "ff5722"}
+_FROZEN_NOW = "2026-04-29T00:00:00+00:00"
+
+
+class _FakeRecord:
+    """Stand-in NetBox record that records ``.save()`` calls as PATCH traffic."""
+
+    def __init__(self, payload: dict[str, Any], record_id: int = 1) -> None:
+        object.__setattr__(self, "_payload", dict(payload))
+        object.__setattr__(self, "id", record_id)
+        object.__setattr__(self, "save_calls", 0)
+
+    def serialize(self) -> dict[str, Any]:
+        return {**self._payload, "id": self.id}
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._payload.get(key, default)
+
+    async def save(self) -> None:
+        object.__setattr__(self, "save_calls", self.save_calls + 1)
+
+    def __setattr__(self, key: str, value: Any) -> None:
+        if key in {"_payload", "id", "save_calls"}:
+            object.__setattr__(self, key, value)
+            return
+        self._payload[key] = value
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers — no NetBox required.                                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_discovery_tag_ref_returns_slug_only_ref() -> None:
+    """``discovery_tag_ref`` builds the canonical slug-only ref form."""
+    assert discovery_tag_ref(DISCOVERY_TAG_CLUSTER) == {
+        "slug": "proxbox-discovered-cluster"
+    }
+
+
+def test_vm_discovery_slug_routes_qemu_and_lxc() -> None:
+    """QEMU/LXC each get their own audit tag slug."""
+    assert vm_discovery_tag_slug("qemu") == DISCOVERY_TAG_VM_QEMU
+    assert vm_discovery_tag_slug("lxc") == DISCOVERY_TAG_VM_LXC
+    # Unknown vm_type falls back to QEMU (matches reconciler's resource defaulting).
+    assert vm_discovery_tag_slug("unknown") == DISCOVERY_TAG_VM_QEMU
+
+
+def test_merge_tag_refs_preserves_discovery_on_update() -> None:
+    """If the existing record already carries a discovery tag, ``merge_tag_refs``
+    keeps it so a sync's tags-baseline does not strip it on update."""
+    baseline = [_PROXBOX_REF]
+    existing = [
+        _PROXBOX_REF,
+        {"id": 8, "slug": DISCOVERY_TAG_CLUSTER, "name": "Discovered Cluster"},
+    ]
+    merged = merge_tag_refs(baseline, existing)
+    merged_slugs = {ref["slug"] for ref in merged}
+    assert "proxbox" in merged_slugs
+    assert DISCOVERY_TAG_CLUSTER in merged_slugs
+
+
+def test_merge_tag_refs_preserves_operator_tags() -> None:
+    """Operator-added tags must survive merge, not just discovery slugs."""
+    merged = merge_tag_refs(
+        [_PROXBOX_REF],
+        [{"id": 99, "slug": "operator-tag", "name": "Operator"}],
+    )
+    slugs = {ref["slug"] for ref in merged}
+    assert slugs == {"proxbox", "operator-tag"}
+
+
+def test_merge_tag_refs_dedupes_when_baseline_wins() -> None:
+    """When base and existing share a slug, the base ref is kept exactly once."""
+    duplicate_existing = [_PROXBOX_REF, _PROXBOX_REF]
+    merged = merge_tag_refs([_PROXBOX_REF], duplicate_existing)
+    assert merged == [_PROXBOX_REF]
+
+
+def test_discovery_tag_slug_inventory_covers_all_four_kinds() -> None:
+    """Sanity check: constants module exposes one slug per kind."""
+    assert DISCOVERY_TAG_VM_QEMU != DISCOVERY_TAG_VM_LXC
+    assert DISCOVERY_TAG_CLUSTER != DISCOVERY_TAG_NODE
+    assert {
+        DISCOVERY_TAG_VM_QEMU,
+        DISCOVERY_TAG_VM_LXC,
+        DISCOVERY_TAG_CLUSTER,
+        DISCOVERY_TAG_NODE,
+    } == {
+        "proxbox-discovered-qemu",
+        "proxbox-discovered-lxc",
+        "proxbox-discovered-cluster",
+        "proxbox-discovered-node",
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Cluster reconciler — create vs. update contract.                            #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def empty_netbox(monkeypatch: pytest.MonkeyPatch):
+    """NetBox with no cluster yet. Records POST traffic and asserts the
+    create payload carries the discovery slug."""
+    posts: list[dict[str, Any]] = []
+
+    async def _fake_first(_nb: object, path: str, *, query: dict[str, Any]) -> Any:
+        del query
+        # The cluster-type lookup still needs to miss so its create branch
+        # fires; the cluster pre-check returns None to force create.
+        del path
+        return None
+
+    async def _fake_create(_nb: object, path: str, payload: dict[str, Any], **_kw: Any) -> Any:
+        posts.append({"path": path, "payload": dict(payload)})
+        return _FakeRecord(payload, record_id=42)
+
+    async def _fake_list(_nb: object, _path: str, query: dict[str, Any] | None = None) -> list[Any]:
+        del query
+        return []
+
+    monkeypatch.setattr(netbox_rest, "rest_first_async", _fake_first)
+    monkeypatch.setattr(netbox_rest, "rest_create_async", _fake_create)
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.individual.cluster_sync.rest_list_async",
+        _fake_list,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.individual.cluster_sync.rest_first_async",
+        _fake_first,
+    )
+
+    import proxbox_api.services.netbox_writers as nw
+
+    nw_original = nw._last_updated_cf
+    nw._last_updated_cf = lambda: {"proxmox_last_updated": _FROZEN_NOW}
+
+    yield posts
+
+    nw._last_updated_cf = nw_original
+
+
+@pytest.mark.asyncio
+async def test_first_cluster_sync_stamps_discovery_tag(empty_netbox: list[dict[str, Any]]) -> None:
+    """The very first sync into an empty NetBox must include the discovery
+    slug in the cluster's create payload."""
+    ctx = make_session(
+        nb=object(),
+        px_sessions=[SimpleNamespace(name="lab")],
+        tag=_TAG,
+        settings=make_settings(),
+        operation_id="test-discovery-first-sync",
+    )
+
+    result = await sync_cluster_individual(ctx, "lab")
+    assert result["action"] == "created", result
+
+    cluster_posts = [
+        post for post in empty_netbox if post["path"] == "/api/virtualization/clusters/"
+    ]
+    assert len(cluster_posts) == 1
+    tags_on_create = cluster_posts[0]["payload"].get("tags") or []
+    posted_slugs = {tag.get("slug") for tag in tags_on_create if isinstance(tag, dict)}
+    assert DISCOVERY_TAG_CLUSTER in posted_slugs
+    assert "proxbox" in posted_slugs
+
+
+@pytest.fixture
+def cluster_with_discovery_tag(monkeypatch: pytest.MonkeyPatch):
+    """NetBox where the cluster already exists *with the discovery tag*.
+
+    Models the post-first-sync world. The second sync must not PATCH the
+    cluster (the baseline matches by-slug after merge) and must keep the
+    discovery slug in place.
+    """
+    cluster_type_record = _FakeRecord(
+        {
+            "name": "Cluster",
+            "slug": "cluster",
+            "description": "Proxmox cluster mode",
+            "tags": [_PROXBOX_REF],
+            "custom_fields": {"proxmox_last_updated": _FROZEN_NOW},
+        },
+        record_id=7,
+    )
+    cluster_record = _FakeRecord(
+        {
+            "name": "lab",
+            "type": {"id": 7, "name": "Cluster", "slug": "cluster"},
+            "description": "Proxmox cluster cluster.",
+            "tags": [
+                _PROXBOX_REF,
+                {
+                    "id": 8,
+                    "name": "Proxbox: Discovered Cluster",
+                    "slug": DISCOVERY_TAG_CLUSTER,
+                    "color": "4caf50",
+                },
+            ],
+            "custom_fields": {"proxmox_last_updated": _FROZEN_NOW},
+        },
+        record_id=42,
+    )
+
+    posts: list[dict[str, Any]] = []
+    by_path: dict[str, _FakeRecord] = {
+        "/api/virtualization/cluster-types/": cluster_type_record,
+        "/api/virtualization/clusters/": cluster_record,
+    }
+
+    async def _fake_first(_nb: object, path: str, *, query: dict[str, Any]) -> Any:
+        del query
+        return by_path.get(path)
+
+    async def _fake_create(_nb: object, path: str, payload: dict[str, Any], **_kw: Any) -> Any:
+        posts.append({"path": path, "payload": dict(payload)})
+        return _FakeRecord(payload, record_id=99)
+
+    async def _fake_list(_nb: object, _path: str, query: dict[str, Any] | None = None) -> list[Any]:
+        del query
+        return []
+
+    monkeypatch.setattr(netbox_rest, "rest_first_async", _fake_first)
+    monkeypatch.setattr(netbox_rest, "rest_create_async", _fake_create)
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.individual.cluster_sync.rest_list_async",
+        _fake_list,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.individual.cluster_sync.rest_first_async",
+        _fake_first,
+    )
+
+    import proxbox_api.services.netbox_writers as nw
+
+    nw_original = nw._last_updated_cf
+    nw._last_updated_cf = lambda: {"proxmox_last_updated": _FROZEN_NOW}
+
+    yield {"cluster": cluster_record, "cluster_type": cluster_type_record, "posts": posts}
+
+    nw._last_updated_cf = nw_original
+
+
+@pytest.mark.asyncio
+async def test_resync_does_not_strip_discovery_tag(
+    cluster_with_discovery_tag: dict[str, Any],
+) -> None:
+    """Once stamped, the discovery slug must survive every subsequent sync —
+    zero PATCH traffic and the tag stays on the record."""
+    ctx = make_session(
+        nb=object(),
+        px_sessions=[SimpleNamespace(name="lab")],
+        tag=_TAG,
+        settings=make_settings(),
+        operation_id="test-discovery-resync",
+    )
+
+    first = await sync_cluster_individual(ctx, "lab")
+    second = await sync_cluster_individual(ctx, "lab")
+
+    assert first["action"] == "unchanged", first
+    assert second["action"] == "unchanged", second
+    assert cluster_with_discovery_tag["cluster"].save_calls == 0
+    assert cluster_with_discovery_tag["posts"] == []
+
+    final_tags = cluster_with_discovery_tag["cluster"].get("tags") or []
+    final_slugs = {tag.get("slug") for tag in final_tags if isinstance(tag, dict)}
+    assert DISCOVERY_TAG_CLUSTER in final_slugs
+
+
+@pytest.fixture
+def cluster_without_discovery_tag(monkeypatch: pytest.MonkeyPatch):
+    """NetBox where the cluster exists from a *previous* proxbox-api version
+    that pre-dates the discovery-tag scheme. The contract: an operator-style
+    "apply on create only" tag must NOT be retroactively added on resync."""
+    cluster_type_record = _FakeRecord(
+        {
+            "name": "Cluster",
+            "slug": "cluster",
+            "description": "Proxmox cluster mode",
+            "tags": [_PROXBOX_REF],
+            "custom_fields": {"proxmox_last_updated": _FROZEN_NOW},
+        },
+        record_id=7,
+    )
+    cluster_record = _FakeRecord(
+        {
+            "name": "lab",
+            "type": {"id": 7, "name": "Cluster", "slug": "cluster"},
+            "description": "Proxmox cluster cluster.",
+            "tags": [_PROXBOX_REF],
+            "custom_fields": {"proxmox_last_updated": _FROZEN_NOW},
+        },
+        record_id=42,
+    )
+
+    posts: list[dict[str, Any]] = []
+    by_path: dict[str, _FakeRecord] = {
+        "/api/virtualization/cluster-types/": cluster_type_record,
+        "/api/virtualization/clusters/": cluster_record,
+    }
+
+    async def _fake_first(_nb: object, path: str, *, query: dict[str, Any]) -> Any:
+        del query
+        return by_path.get(path)
+
+    async def _fake_create(_nb: object, path: str, payload: dict[str, Any], **_kw: Any) -> Any:
+        posts.append({"path": path, "payload": dict(payload)})
+        return _FakeRecord(payload, record_id=99)
+
+    async def _fake_list(_nb: object, _path: str, query: dict[str, Any] | None = None) -> list[Any]:
+        del query
+        return []
+
+    monkeypatch.setattr(netbox_rest, "rest_first_async", _fake_first)
+    monkeypatch.setattr(netbox_rest, "rest_create_async", _fake_create)
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.individual.cluster_sync.rest_list_async",
+        _fake_list,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.individual.cluster_sync.rest_first_async",
+        _fake_first,
+    )
+
+    import proxbox_api.services.netbox_writers as nw
+
+    nw_original = nw._last_updated_cf
+    nw._last_updated_cf = lambda: {"proxmox_last_updated": _FROZEN_NOW}
+
+    yield {"cluster": cluster_record, "posts": posts}
+
+    nw._last_updated_cf = nw_original
+
+
+@pytest.mark.asyncio
+async def test_resync_does_not_retroactively_stamp_existing_cluster(
+    cluster_without_discovery_tag: dict[str, Any],
+) -> None:
+    """A cluster created by an older proxbox-api that lacked discovery tags
+    must NOT receive the discovery slug on resync — the audit trail is
+    strictly first-import."""
+    ctx = make_session(
+        nb=object(),
+        px_sessions=[SimpleNamespace(name="lab")],
+        tag=_TAG,
+        settings=make_settings(),
+        operation_id="test-no-retroactive-stamp",
+    )
+
+    result = await sync_cluster_individual(ctx, "lab")
+    assert result["action"] == "unchanged", result
+    assert cluster_without_discovery_tag["cluster"].save_calls == 0
+    assert cluster_without_discovery_tag["posts"] == []
+    tags = cluster_without_discovery_tag["cluster"].get("tags") or []
+    slugs = {tag.get("slug") for tag in tags if isinstance(tag, dict)}
+    assert DISCOVERY_TAG_CLUSTER not in slugs

--- a/tests/test_discovery_tags_create_only.py
+++ b/tests/test_discovery_tags_create_only.py
@@ -66,9 +66,7 @@ class _FakeRecord:
 
 def test_discovery_tag_ref_returns_slug_only_ref() -> None:
     """``discovery_tag_ref`` builds the canonical slug-only ref form."""
-    assert discovery_tag_ref(DISCOVERY_TAG_CLUSTER) == {
-        "slug": "proxbox-discovered-cluster"
-    }
+    assert discovery_tag_ref(DISCOVERY_TAG_CLUSTER) == {"slug": "proxbox-discovered-cluster"}
 
 
 def test_vm_discovery_slug_routes_qemu_and_lxc() -> None:

--- a/tests/test_endpoint_placement_sync.py
+++ b/tests/test_endpoint_placement_sync.py
@@ -45,6 +45,10 @@ async def test_ensure_cluster_sets_site_scope_and_tenant(
         captured.update(kwargs)
         return SimpleNamespace(id=77)
 
+    async def _fake_first(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(device_ensure, "rest_first_async", _fake_first)
     monkeypatch.setattr(device_ensure, "rest_reconcile_async", _fake_reconcile)
 
     await device_ensure._ensure_cluster(
@@ -61,6 +65,9 @@ async def test_ensure_cluster_sets_site_scope_and_tenant(
     assert payload["scope_type"] == "dcim.site"
     assert payload["scope_id"] == 42
     assert payload["tenant"] == 9
+    # Issue #362: on create, the cluster discovery slug must be present.
+    tag_slugs = {ref.get("slug") for ref in payload["tags"] if isinstance(ref, dict)}
+    assert "proxbox-discovered-cluster" in tag_slugs
 
 
 def test_vm_payload_includes_endpoint_site_and_tenant() -> None:

--- a/tests/test_individual_sync.py
+++ b/tests/test_individual_sync.py
@@ -334,6 +334,9 @@ async def test_sync_cluster_individual_reports_real_drift_status(monkeypatch):
     async def _fake_rest_list_async(_nb, _path, query=None):
         return []
 
+    async def _fake_rest_first_async(_nb, _path, *, query=None):
+        return None
+
     async def _fake_upsert_cluster_type(_nb, *, mode, tag_refs):
         return UpsertResult(record=SimpleNamespace(id=7), status="unchanged")
 
@@ -346,6 +349,10 @@ async def test_sync_cluster_individual_reports_real_drift_status(monkeypatch):
     monkeypatch.setattr(
         "proxbox_api.services.sync.individual.cluster_sync.rest_list_async",
         _fake_rest_list_async,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.individual.cluster_sync.rest_first_async",
+        _fake_rest_first_async,
     )
     monkeypatch.setattr(
         "proxbox_api.services.sync.individual.cluster_sync.upsert_cluster_type",

--- a/tests/test_netbox_bootstrap.py
+++ b/tests/test_netbox_bootstrap.py
@@ -290,15 +290,16 @@ async def test_run_netbox_bootstrap_creates_full_inventory_on_empty_netbox(
     assert status.patched == []
     assert status.unchanged == []
 
-    # 1 Proxbox tag + 3 discovery tags + 1 cluster_type + 1 manufacturer +
+    # 1 Proxbox tag + 4 discovery tags + 1 cluster_type + 1 manufacturer +
     # 1 device_type + 1 device_role + 3 VM roles + 2 VM types + 8 custom fields
-    # = 21 created objects on a fresh NetBox 4.6 install.
-    assert len(status.created) == 21
+    # = 22 created objects on a fresh NetBox 4.6 install.
+    assert len(status.created) == 22
 
     # Key entries from each category must appear in the created list.
     labels = set(status.created)
     assert "tag:Proxbox" in labels
-    assert "tag:proxbox-discovered-vm" in labels
+    assert "tag:proxbox-discovered-qemu" in labels
+    assert "tag:proxbox-discovered-lxc" in labels
     assert "tag:proxbox-discovered-cluster" in labels
     assert "tag:proxbox-discovered-node" in labels
     assert "cluster_type:proxmox" in labels
@@ -423,9 +424,10 @@ async def test_run_netbox_bootstrap_captures_per_entry_failures(
     warning = status.warnings[0]
     assert warning["object"] == "tag:Proxbox"
     assert "403" in warning["error"]
-    # The remaining 20 inventory entries must still have been created.
-    assert len(status.created) == 20
-    assert "tag:proxbox-discovered-vm" in status.created
+    # The remaining 21 inventory entries must still have been created.
+    assert len(status.created) == 21
+    assert "tag:proxbox-discovered-qemu" in status.created
+    assert "tag:proxbox-discovered-lxc" in status.created
     assert "cluster_type:proxmox" in status.created
     assert "custom_field:proxbox_last_run_id" in status.created
 
@@ -479,5 +481,5 @@ async def test_run_netbox_bootstrap_skips_vm_types_on_old_netbox(
 
     assert status.ok is True
     assert not any(label.startswith("vm_type:") for label in status.created)
-    # The other 19 inventory entries must still be created.
-    assert len(status.created) == 19
+    # The other 20 inventory entries must still be created.
+    assert len(status.created) == 20


### PR DESCRIPTION
## Summary

Implements [issue #362](https://github.com/emersonfelipesp/proxbox-api/issues/362) on `v0.0.11`: stamp Proxbox-discovered objects with the four `proxbox-discovered-*` slugs **only when the reconciler takes the create branch**. The update branch must never re-stamp them, so an operator who removes a discovery tag in NetBox makes a permanent decision.

Final slug set (already aligned with the bootstrap inventory):

| Slug | Applied to |
|---|---|
| `proxbox-discovered-qemu` | QEMU VMs at create |
| `proxbox-discovered-lxc` | LXC containers at create |
| `proxbox-discovered-cluster` | Clusters at create |
| `proxbox-discovered-node` | Proxmox-node Devices at create |

## What changed

- `proxbox_api/constants.py` — `DISCOVERY_TAG_*` identifiers + slug inventory tuple.
- `proxbox_api/services/netbox_bootstrap.py` — bootstrap now seeds the QEMU + LXC pair; the generic `proxbox-discovered-vm` entry is gone (no code stamped it).
- `proxbox_api/services/sync/discovery_tags.py` (NEW) — helpers: `discovery_tag_ref`, `vm_discovery_tag_slug`, `resolve_discovery_tag_id`, `merge_tag_refs`.
- `vm_sync.py` / `cluster_sync.py` / `device_ensure.py` — pre-check existence; on create append the discovery slug; on update call `merge_tag_refs` so the desired baseline never strips the discovery slug or any operator-added tags.

## Semantic contract

- Tags attached **only when the create branch fires**.
- Update path leaves the tag set untouched; ``merge_tag_refs`` unions baseline + existing tags so a no-op reconcile still emits zero ``ObjectChange`` rows.
- Manual removal by an operator is permanent — reconciler never re-adds a removed slug.

## Tests

- `tests/test_discovery_tags_create_only.py` (NEW, 9 tests) — pure-helper coverage + reconciler integration: first sync stamps the tag, resync does not strip it, resync of a pre-existing cluster does not retroactively stamp it.
- `tests/test_endpoint_placement_sync.py` — asserts the cluster create payload contains `proxbox-discovered-cluster`.
- `tests/test_cluster_sync_idempotent.py`, `tests/test_individual_sync.py`, `tests/test_netbox_bootstrap.py` — updated for the new bootstrap inventory and the `cluster_sync` pre-check monkeypatch.

## Validation

- `uv run --extra test ruff check .` — clean.
- `uv run --extra test python -m compileall proxbox_api tests` — clean.
- `uv run --extra test pytest tests/test_netbox_bootstrap.py tests/test_cluster_sync_idempotent.py tests/test_individual_sync.py tests/test_discovery_tags_create_only.py tests/test_endpoint_placement_sync.py tests/test_vm_sync.py tests/test_vm_sync_reconciliation_queue.py tests/test_netbox_writers.py tests/test_patchable_fields.py tests/test_overwrite_flags_contract.py` — 104 tests, all green in 5.91 s.

Pre-existing `ty check` noise (1031 diagnostics across `proxbox_api/`) is not introduced here.

## Notes

- `netbox-proxbox` v0.0.15 needs **no** changes for this issue — the discovery-tag work is entirely contained in `proxbox-api`. Confirmed by `grep -r "proxbox-discovered\|DISCOVERY_TAG" netbox_proxbox/` returning empty.
- Pre-existing test isolation hangs in `tests/test_endpoint_crud.py::test_netbox_endpoint_only_allows_single_instance` and `tests/test_proxmox_actions_gate.py::test_missing_endpoint_id_returns_403` were observed when running the *full* 4489-test suite; both pass in isolation. Not caused by this change.
- Follow-up: `docs/operations/discovery-tags.md` documenting the contract for operators (apply-on-create, never reconcile, removal is permanent).