### PR TITLE
docs: sync EN + pt-BR with v0.0.11 surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ rtk ruff format --check .
 uv run python -m compileall proxbox_api tests
 uv run python -c "import proxbox_api.main"
 uv run python -c "from proxbox_api.proxmox_to_netbox.proxmox_schema import load_proxmox_generated_openapi; assert load_proxmox_generated_openapi().get('paths')"
+uv run ty check proxbox_api/types proxbox_api/utils/retry.py proxbox_api/schemas/sync.py
 rtk pytest tests
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,18 @@
 
 `proxbox-api` is a FastAPI backend that connects Proxmox inventory and lifecycle data to NetBox objects. It serves REST, SSE, and WebSocket endpoints for discovery, synchronization, endpoint management, and generated Proxmox proxy routes. The same repository also includes a standalone `nextjs-ui/` frontend for endpoint administration.
 
+### Companion repos (cross-link map)
+
+- **`netbox-proxbox` v0.0.15+** — the NetBox plugin that consumes this backend.
+  Source: <https://github.com/emersonfelipesp/netbox-proxbox>. The HA tab,
+  cluster-wide HA Status page, and the runtime tunables surface all require
+  `proxbox-api >= 0.0.11`.
+- **Workspace note**:
+  `personal-context/claude-reference/proxbox-api.md` (deep-dive index of this
+  repo) and `personal-context/claude-reference/netbox-proxbox.md` (deep-dive
+  index of the plugin) live in the AI workspace and should be kept in sync
+  when route prefixes, env vars, or required dependency floors change.
+
 ## Use This Index First
 
 Open the nearest scoped guide for the code you are changing.

--- a/docs/api/cluster-ha.md
+++ b/docs/api/cluster-ha.md
@@ -135,3 +135,9 @@ Run them with:
 ```bash
 uv run pytest tests/test_proxmox_ha_routes.py -q
 ```
+
+## See Also
+
+- [HTTP API Reference — High-Availability (read-only)](http-reference.md#high-availability-read-only) for the consolidated route listing alongside the rest of the `/proxmox/*` surface.
+- [HTTP API Reference — VM Operational Verbs](http-reference.md#vm-operational-verbs) for the companion write surface (start/stop/snapshot/migrate) that depends on `ProxmoxEndpoint.allow_writes`.
+- `netbox-proxbox/docs/api/ha.md` for the plugin-side consumer of these endpoints.

--- a/docs/api/http-reference.md
+++ b/docs/api/http-reference.md
@@ -101,6 +101,64 @@ out of scope and may be added in a follow-up release.
 - `GET /proxmox/cluster/ha/groups/{group}` - Single group detail across clusters; returns `null` when no cluster has the group.
 - `GET /proxmox/cluster/ha/summary` - Single envelope (`{status, groups, resources}`) composed in parallel via `asyncio.gather`. Used by the NetBox cluster-wide HA page so a render only triggers one round-trip.
 
+### VM Operational Verbs
+
+POST verbs that act on a single QEMU VM or LXC container. Implemented in `proxbox_api/routes/proxmox_actions.py`. Each handler is gated by [`ProxmoxEndpoint.allow_writes`](../getting-started/configuration.md#proxmox-endpoints); the gate runs before any NetBox or Proxmox call, so a write-disabled endpoint returns 403 even when the downstream services are unreachable.
+
+All verb routes accept:
+
+- `endpoint_id` (query parameter, required) — selects the target Proxmox cluster among many.
+- `Idempotency-Key` (header, optional) — 60-second cache window per `(endpoint_id, verb, vmid)`. A second POST with the same key returns the cached body without re-dispatching.
+- `X-Proxbox-Actor` (header, optional) — actor label written to the NetBox journal entry. Defaults to `proxbox-api`.
+
+Every invocation (success, failure, or no-op) writes exactly one journal entry on the linked NetBox `VirtualMachine` resolved by the `proxmox_vm_id` custom field.
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/proxmox/qemu/{vmid}/start` | Start a QEMU VM. State-based no-op when already `running` (`result: "already_running"`). |
+| `POST` | `/proxmox/lxc/{vmid}/start` | Start an LXC container. Same no-op rule. |
+| `POST` | `/proxmox/qemu/{vmid}/stop` | Stop a QEMU VM. State-based no-op when already `stopped` (`result: "already_stopped"`). |
+| `POST` | `/proxmox/lxc/{vmid}/stop` | Stop an LXC container. Same no-op rule. |
+| `POST` | `/proxmox/qemu/{vmid}/snapshot` | Create a QEMU snapshot. Optional JSON body `{snapname, description}`; when `snapname` is omitted the route generates `proxbox-{idempotency_key[:8]}` or `proxbox-{utc_stamp}`. Always dispatched (no state-based no-op). |
+| `POST` | `/proxmox/lxc/{vmid}/snapshot` | Create an LXC snapshot. Same body and default rules. |
+| `POST` | `/proxmox/qemu/{vmid}/migrate` | Migrate a QEMU VM. Required body `{target, online}`. Runs a preflight against `/nodes/{node}/qemu/{vmid}/migrate` and rejects when the target is not allowed or `online=true` would hit local disks/resources. Returns **202 Accepted** with `proxmox_task_upid` and `sse_url` (the cancel/stream endpoints below). |
+| `POST` | `/proxmox/lxc/{vmid}/migrate` | Migrate an LXC container. Same body and 202 shape. |
+| `DELETE` | `/proxmox/qemu/{vmid}/migrate/{task_upid}` | Best-effort cancel of an in-flight migrate task. Journals the cancel intent even if Proxmox refuses. |
+| `DELETE` | `/proxmox/lxc/{vmid}/migrate/{task_upid}` | Best-effort cancel for LXC migrate. |
+| `GET` | `/proxmox/qemu/{vmid}/migrate/{task_upid}/stream` | SSE stream emitting `migrate_dispatched`, repeated `migrate_progress`, then `migrate_succeeded` xor `migrate_failed`. |
+| `GET` | `/proxmox/lxc/{vmid}/migrate/{task_upid}/stream` | SSE stream for LXC migrate task progress. |
+
+#### `allow_writes` gate (403 shape)
+
+When `endpoint_id` is missing, the endpoint does not exist, or `ProxmoxEndpoint.allow_writes` is `false`, the handler returns HTTP 403 with one of three `reason` codes:
+
+```json
+{
+  "reason": "endpoint_writes_disabled",
+  "detail": "Operational verbs are disabled on this endpoint. Enable ProxmoxEndpoint.allow_writes on the NetBox side after granting core.run_proxmox_action to the operator group.",
+  "endpoint_id": 7
+}
+```
+
+Other 403 shapes use `reason: "endpoint_id_required"` or `reason: "endpoint_not_found"` and omit `endpoint_id`. The gate is the load-bearing trust boundary documented in `docs/design/operational-verbs.md` §2.3 layer 3 — it must remain the first check in every handler.
+
+#### Response shape (success / no-op)
+
+```json
+{
+  "verb": "start",
+  "vmid": 100,
+  "vm_type": "qemu",
+  "endpoint_id": 7,
+  "result": "ok",
+  "dispatched_at": "2026-05-13T14:22:08Z",
+  "proxmox_task_upid": "UPID:pve1:00012E34:...",
+  "journal_entry_url": "/api/extras/journal-entries/42/"
+}
+```
+
+`result` is one of `ok`, `already_running`, `already_stopped`, `accepted` (migrate dispatch), `cancel_requested`, `cancel_failed`, `rejected`, or `failed`. Error paths add `reason` and `detail`. The migrate 202 response also carries `sse_url`, `target`, `online`, and `source_node`.
+
 ### Viewer and generated contract helpers
 
 - `POST /proxmox/viewer/generate` - Crawl the Proxmox API Viewer and generate OpenAPI + Pydantic artifacts. Accepts `version_tag`, `workers`, `persist`, and other tuning query parameters.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -35,12 +35,17 @@ Cache invalidation is precise (not prefix-based): updating `/api/dcim/devices/55
   - `/ws`
   - `/ws/virtual-machines`
   - `/admin`
+  - `/admin/encryption` — encryption key inspection and rotation surface.
+  - `/auth` — bootstrap and API-key management.
   - `/netbox`
   - `/proxmox`
+  - `/proxmox/cluster/ha/*` — read-only High-Availability aggregation across configured clusters; see [Cluster HA API](../api/cluster-ha.md).
+  - `/proxmox/{qemu,lxc}/{vmid}/{start,stop,snapshot,migrate}` — operational write verbs (plus DELETE-to-cancel and GET-stream for migrate). Gated by `ProxmoxEndpoint.allow_writes`. See [HTTP API Reference — VM Operational Verbs](../api/http-reference.md#vm-operational-verbs).
   - `/dcim`
   - `/virtualization`
   - `/extras`
   - `/sync/individual`
+  - `/sync/active` — process-local probe for an in-flight `/full-update` run.
 - SQLite-backed endpoint configuration and bootstrap state.
 - NetBox API access via `netbox-sdk` sync and async clients.
 - Proxmox API access via `proxmox-sdk` sync SDK sessions and typed helper wrappers.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -34,6 +34,24 @@ For the current route and docs contract surface:
 pytest tests/test_generated_proxmox_routes.py tests/test_proxmox_codegen_docs.py tests/test_api_routes.py tests/test_stub_routes.py tests/test_admin_logs.py
 ```
 
+For the v0.0.11 surface specifically (HA routes, operational verbs, the
+`allow_writes` gate, and supporting helpers):
+
+```bash
+pytest \
+  tests/test_proxmox_ha_routes.py \
+  tests/test_proxmox_actions_gate.py \
+  tests/test_proxmox_actions_start.py \
+  tests/test_proxmox_actions_stop.py \
+  tests/test_proxmox_actions_snapshot.py \
+  tests/test_proxmox_actions_migrate_verb.py \
+  tests/test_verb_dispatch_helpers.py \
+  tests/test_sync_active.py \
+  tests/test_name_collision.py \
+  tests/test_vm_cloudinit_mapping.py \
+  tests/test_description_metadata.py
+```
+
 ## Proxmox Mock Testing
 
 All tests use `proxmox-sdk` mock features to validate Proxmox API integration. The test suite supports three mock modes:

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -71,6 +71,17 @@ Authentication rules for create and update:
 - `token_name` and `token_value` must be provided together.
 - Endpoint names must be unique.
 
+### `allow_writes` field
+
+`ProxmoxEndpoint.allow_writes` (boolean, default `false`) is the trust boundary
+for the [VM operational verbs](../api/http-reference.md#vm-operational-verbs)
+(`start`, `stop`, `snapshot`, `migrate`). The gate runs before any NetBox or
+Proxmox call: with the flag off, every write verb returns HTTP 403 with
+`reason: "endpoint_writes_disabled"`. Read-only sync paths are not affected.
+Toggle the flag from the NetBox plugin's ProxmoxEndpoint detail page; the
+column was added by migration `0037_proxmoxendpoint_allow_writes` and is
+backfilled to `false` for existing rows.
+
 ### Password-based example
 
 ```json
@@ -183,12 +194,19 @@ A handful of variables stay process-level only because they are read before the 
 | `PROXBOX_BACKUP_BATCH_DELAY_MS` | `200` | Delay in milliseconds between backup batches. |
 | `PROXBOX_BULK_BATCH_SIZE` | `50` | Per-batch size for bulk VM-related sync requests (volumes, backups). |
 | `PROXBOX_BULK_BATCH_DELAY_MS` | `500` | Delay in milliseconds between bulk batches. |
+| `PROXBOX_NETBOX_GET_CACHE_TTL` | `60` | TTL (seconds) for the in-memory NetBox GET response cache. Set `0` to disable caching. |
+| `PROXBOX_NETBOX_GET_CACHE_MAX_ENTRIES` | `4096` | Maximum entries kept in the NetBox GET cache before LRU eviction kicks in. |
+| `PROXBOX_NETBOX_GET_CACHE_MAX_BYTES` | `52428800` (50 MiB) | Maximum total bytes held in the NetBox GET cache before LRU eviction kicks in. |
+| `PROXBOX_DEBUG_CACHE` | unset | When set to `1`, `true`, or `yes`, the NetBox GET cache emits per-hit/miss debug log lines. |
+| `PROXBOX_CUSTOM_FIELDS_REQUEST_DELAY` | `0.5` | Per-request pause (seconds) between custom-field creations during the extras bootstrap to avoid hammering NetBox. |
 | `PROXBOX_GENERATED_DIR` | `$XDG_DATA_HOME/proxbox/generated/proxmox` | Override output directory for the schema generator CLI (`proxbox-schema generate`). |
 | `PROXBOX_CORS_EXTRA_ORIGINS` | (empty) | Comma-separated extra CORS origins added to the runtime allowlist. |
 | `PROXBOX_EXPOSE_INTERNAL_ERRORS` | unset | When set to `1`, `true`, or `yes`, HTTP 500 responses include internal exception details. |
 | `PROXBOX_STRICT_STARTUP` | unset | When set to `1`, `true`, or `yes`, startup fails if generated Proxmox routes cannot be mounted. |
 | `PROXBOX_SKIP_NETBOX_BOOTSTRAP` | unset | When set to `1`, `true`, or `yes`, skips creating the default NetBox client during app startup. |
 | `PROXBOX_ENCRYPTION_KEY` | unset | Secret key for encrypting credentials at rest. See [Credential Encryption](#credential-encryption) below. |
+| `PROXBOX_ENCRYPTION_KEY_FILE` | unset | Path to a file containing the Fernet encryption key. Takes precedence over `PROXBOX_ENCRYPTION_KEY` when set; lets operators mount the key as a file/secret instead of an environment variable. |
+| `PROXBOX_ALLOW_PLAINTEXT_CREDENTIALS` | unset | When set to `1`, `true`, or `yes`, the backend boots even with no encryption key configured. Off by default — the backend refuses to start so credentials are never written plaintext in production. |
 
 ### Handling NetBox Overwhelmed Errors
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,8 @@ This documentation covers installation, configuration, architecture, API referen
 - Proxmox endpoint CRUD with password or token-pair auth.
 - Cluster, node, storage, VM, backup, snapshot, and replication data collection.
 - Virtual machine, interface, IP, disk, storage, and backup synchronization toward NetBox.
+- High-Availability readout across every configured cluster — see [Cluster HA API](api/cluster-ha.md).
+- VM operational verbs (start / stop / snapshot / migrate) gated by `ProxmoxEndpoint.allow_writes`, with idempotency, journal auditing, and SSE progress for migrate — see [HTTP API Reference — VM Operational Verbs](api/http-reference.md#vm-operational-verbs).
 - Admin log inspection, cache inspection, and full-update orchestration.
 
 ## Audience

--- a/docs/pt-BR/api/cluster-ha.md
+++ b/docs/pt-BR/api/cluster-ha.md
@@ -135,3 +135,9 @@ Para executar:
 ```bash
 uv run pytest tests/test_proxmox_ha_routes.py -q
 ```
+
+## Veja Tambem
+
+- [Referencia HTTP — Alta Disponibilidade (somente leitura)](http-reference.md#alta-disponibilidade-somente-leitura) — listagem consolidada das rotas dentro do restante do surface `/proxmox/*`.
+- [Referencia HTTP — Verbos Operacionais de VM](http-reference.md#verbos-operacionais-de-vm) — surface de escrita complementar (start/stop/snapshot/migrate) que depende de `ProxmoxEndpoint.allow_writes`.
+- `netbox-proxbox/docs/api/ha.md` para o consumidor do lado do plugin.

--- a/docs/pt-BR/api/http-reference.md
+++ b/docs/pt-BR/api/http-reference.md
@@ -95,6 +95,64 @@ Endpoints agregados entre todos os clusters Proxmox configurados. Atendem a aba 
 - `GET /proxmox/cluster/ha/groups/{group}` - Detalhe de um grupo unico; retorna `null` quando nenhum cluster possui o grupo.
 - `GET /proxmox/cluster/ha/summary` - Envelope unico (`{status, groups, resources}`) composto em paralelo via `asyncio.gather`. Usado pela pagina HA do cluster para que cada render gere apenas um round-trip.
 
+### Verbos Operacionais de VM
+
+Verbos POST que atuam sobre uma unica VM QEMU ou container LXC. Implementados em `proxbox_api/routes/proxmox_actions.py`. Cada handler e protegido por [`ProxmoxEndpoint.allow_writes`](../getting-started/configuration.md#endpoints-proxmox); o gate roda antes de qualquer chamada ao NetBox ou ao Proxmox, entao um endpoint com escritas desabilitadas retorna 403 mesmo que os servicos a jusante estejam fora do ar.
+
+Todos os verbos aceitam:
+
+- `endpoint_id` (query parameter, obrigatorio) — seleciona o cluster Proxmox alvo entre varios.
+- `Idempotency-Key` (header, opcional) — janela de cache de 60 segundos por `(endpoint_id, verb, vmid)`. Um segundo POST com a mesma chave retorna o corpo em cache sem re-despachar.
+- `X-Proxbox-Actor` (header, opcional) — rotulo do ator gravado no journal entry do NetBox. Default: `proxbox-api`.
+
+Toda invocacao (sucesso, falha ou no-op) escreve exatamente um journal entry no `VirtualMachine` correspondente do NetBox, resolvido pelo custom field `proxmox_vm_id`.
+
+| Method | Path | Proposito |
+|---|---|---|
+| `POST` | `/proxmox/qemu/{vmid}/start` | Inicia uma VM QEMU. No-op por estado quando ja `running` (`result: "already_running"`). |
+| `POST` | `/proxmox/lxc/{vmid}/start` | Inicia um container LXC. Mesma regra de no-op. |
+| `POST` | `/proxmox/qemu/{vmid}/stop` | Para uma VM QEMU. No-op por estado quando ja `stopped` (`result: "already_stopped"`). |
+| `POST` | `/proxmox/lxc/{vmid}/stop` | Para um container LXC. Mesma regra de no-op. |
+| `POST` | `/proxmox/qemu/{vmid}/snapshot` | Cria snapshot QEMU. Corpo JSON opcional `{snapname, description}`; quando `snapname` e omitido a rota gera `proxbox-{idempotency_key[:8]}` ou `proxbox-{utc_stamp}`. Sempre despachado (sem no-op por estado). |
+| `POST` | `/proxmox/lxc/{vmid}/snapshot` | Cria snapshot LXC. Mesmas regras de corpo e default. |
+| `POST` | `/proxmox/qemu/{vmid}/migrate` | Migra uma VM QEMU. Corpo obrigatorio `{target, online}`. Executa um preflight contra `/nodes/{node}/qemu/{vmid}/migrate` e rejeita quando o target nao e permitido ou `online=true` esbarra em discos/recursos locais. Retorna **202 Accepted** com `proxmox_task_upid` e `sse_url` (endpoints de cancel/stream abaixo). |
+| `POST` | `/proxmox/lxc/{vmid}/migrate` | Migra um container LXC. Mesmo corpo e shape 202. |
+| `DELETE` | `/proxmox/qemu/{vmid}/migrate/{task_upid}` | Cancel best-effort de uma migracao em andamento. Audita a intencao de cancel mesmo que o Proxmox recuse. |
+| `DELETE` | `/proxmox/lxc/{vmid}/migrate/{task_upid}` | Cancel best-effort para migrate de LXC. |
+| `GET` | `/proxmox/qemu/{vmid}/migrate/{task_upid}/stream` | Stream SSE emitindo `migrate_dispatched`, varios `migrate_progress`, depois `migrate_succeeded` xor `migrate_failed`. |
+| `GET` | `/proxmox/lxc/{vmid}/migrate/{task_upid}/stream` | Stream SSE para progresso de migrate de LXC. |
+
+#### Gate `allow_writes` (formato do 403)
+
+Quando `endpoint_id` falta, o endpoint nao existe ou `ProxmoxEndpoint.allow_writes` esta `false`, o handler retorna HTTP 403 com um dos tres codigos em `reason`:
+
+```json
+{
+  "reason": "endpoint_writes_disabled",
+  "detail": "Operational verbs are disabled on this endpoint. Enable ProxmoxEndpoint.allow_writes on the NetBox side after granting core.run_proxmox_action to the operator group.",
+  "endpoint_id": 7
+}
+```
+
+Outros formatos de 403 usam `reason: "endpoint_id_required"` ou `reason: "endpoint_not_found"` e omitem `endpoint_id`. O gate e a fronteira de confianca documentada em `docs/design/operational-verbs.md` §2.3 layer 3 — deve permanecer como o primeiro check de cada handler.
+
+#### Shape da resposta (sucesso / no-op)
+
+```json
+{
+  "verb": "start",
+  "vmid": 100,
+  "vm_type": "qemu",
+  "endpoint_id": 7,
+  "result": "ok",
+  "dispatched_at": "2026-05-13T14:22:08Z",
+  "proxmox_task_upid": "UPID:pve1:00012E34:...",
+  "journal_entry_url": "/api/extras/journal-entries/42/"
+}
+```
+
+`result` e um de `ok`, `already_running`, `already_stopped`, `accepted` (dispatch de migrate), `cancel_requested`, `cancel_failed`, `rejected` ou `failed`. Caminhos de erro adicionam `reason` e `detail`. A resposta 202 do migrate carrega tambem `sse_url`, `target`, `online` e `source_node`.
+
 ### Helpers do viewer e do contrato gerado
 
 - `POST /proxmox/viewer/generate`

--- a/docs/pt-BR/architecture/overview.md
+++ b/docs/pt-BR/architecture/overview.md
@@ -21,12 +21,17 @@
   - `/ws`
   - `/ws/virtual-machines`
   - `/admin`
+  - `/admin/encryption` — superficie de inspecao e rotacao da chave de criptografia.
+  - `/auth` — bootstrap e gerenciamento de chaves de API.
   - `/netbox`
   - `/proxmox`
+  - `/proxmox/cluster/ha/*` — leitura agregada de High-Availability entre clusters; ver [API de HA do cluster](../api/cluster-ha.md).
+  - `/proxmox/{qemu,lxc}/{vmid}/{start,stop,snapshot,migrate}` — verbos operacionais de escrita (mais DELETE-para-cancelar e GET-stream para migrate). Gate em `ProxmoxEndpoint.allow_writes`. Ver [Referencia HTTP — Verbos Operacionais de VM](../api/http-reference.md#verbos-operacionais-de-vm).
   - `/dcim`
   - `/virtualization`
   - `/extras`
   - `/sync/individual`
+  - `/sync/active` — probe local-ao-processo para um `/full-update` em andamento.
 - Configuracao de endpoints persistida em SQLite.
 - Acesso ao NetBox via clientes `netbox-sdk` sync e async.
 - Acesso ao Proxmox via sessoes do SDK sync `proxmox-sdk` e wrappers tipados.

--- a/docs/pt-BR/development/testing.md
+++ b/docs/pt-BR/development/testing.md
@@ -34,6 +34,23 @@ Para a superficie atual de rotas e contratos de docs:
 pytest tests/test_generated_proxmox_routes.py tests/test_proxmox_codegen_docs.py tests/test_api_routes.py tests/test_stub_routes.py tests/test_admin_logs.py
 ```
 
+Para os modulos novos da v0.0.11 (HA, verbos operacionais, sync-active, parsing de metadata e resolucao de colisao de nomes):
+
+```bash
+pytest \
+  tests/test_proxmox_ha_routes.py \
+  tests/test_proxmox_actions_gate.py \
+  tests/test_proxmox_actions_start.py \
+  tests/test_proxmox_actions_stop.py \
+  tests/test_proxmox_actions_snapshot.py \
+  tests/test_proxmox_actions_migrate_verb.py \
+  tests/test_verb_dispatch_helpers.py \
+  tests/test_sync_active.py \
+  tests/test_name_collision.py \
+  tests/test_vm_cloudinit_mapping.py \
+  tests/test_description_metadata.py
+```
+
 ## Testes com Mock Proxmox
 
 Todos os testes usam recursos mock do `proxmox-sdk` para validar a integracao com a API Proxmox. A suite de testes suporta tres modos mock:

--- a/docs/pt-BR/getting-started/configuration.md
+++ b/docs/pt-BR/getting-started/configuration.md
@@ -71,6 +71,10 @@ Regras de autenticacao para create/update:
 - `token_name` e `token_value` devem ser enviados juntos.
 - Os nomes dos endpoints devem ser unicos.
 
+### Campo `allow_writes`
+
+`ProxmoxEndpoint.allow_writes` (boolean, padrao `false`) atua como um gate de confianca para os [Verbos Operacionais de VM](../api/http-reference.md#verbos-operacionais-de-vm). Quando `false`, qualquer `POST` para `/proxmox/{qemu|lxc}/{vmid}/{start,stop,snapshot,migrate}` retorna `403` com `reason="writes_disabled_for_endpoint"`, mesmo que a chave de API e o `X-Proxbox-Actor` sejam validos. O campo so pode ser alterado por administradores e e auditado via journal entry. Adicionado na migracao `0037_proxmoxendpoint_allow_writes`.
+
 ### Exemplo com senha
 
 ```json
@@ -172,12 +176,19 @@ Algumas variaveis permanecem somente em nivel de processo porque sao lidas antes
 | `PROXBOX_BACKUP_BATCH_DELAY_MS` | `200` | Delay em milissegundos entre lotes de backup. |
 | `PROXBOX_BULK_BATCH_SIZE` | `50` | Tamanho do lote para requisicoes em massa relacionadas a VMs (volumes, backups). |
 | `PROXBOX_BULK_BATCH_DELAY_MS` | `500` | Delay em milissegundos entre lotes em massa. |
+| `PROXBOX_NETBOX_GET_CACHE_TTL` | `60` | TTL em segundos do cache de GETs no NetBox. `0` desabilita o cache. |
+| `PROXBOX_NETBOX_GET_CACHE_MAX_ENTRIES` | `4096` | Maximo de entradas armazenadas no cache de GETs do NetBox antes de eviccao LRU. |
+| `PROXBOX_NETBOX_GET_CACHE_MAX_BYTES` | `52428800` (50 MiB) | Tamanho total maximo em bytes do cache de GETs do NetBox. |
+| `PROXBOX_DEBUG_CACHE` | nao definido | Quando `1`, `true` ou `yes`, emite logs detalhados de hit/miss/evict do cache. |
+| `PROXBOX_CUSTOM_FIELDS_REQUEST_DELAY` | `0.5` | Delay em segundos entre requisicoes na criacao de custom fields no NetBox, para evitar overruns no PostgreSQL. |
 | `PROXBOX_GENERATED_DIR` | `$XDG_DATA_HOME/proxbox/generated/proxmox` | Override do diretorio de saida da CLI geradora de schema (`proxbox-schema generate`). |
 | `PROXBOX_CORS_EXTRA_ORIGINS` | (vazio) | Lista de origens CORS extras, separadas por virgula. |
 | `PROXBOX_EXPOSE_INTERNAL_ERRORS` | nao definido | Quando `1`, `true` ou `yes`, respostas HTTP 500 incluem detalhes internos da excecao. |
 | `PROXBOX_STRICT_STARTUP` | nao definido | Quando `1`, `true` ou `yes`, falha no mount de rotas Proxmox geradas interrompe o startup. |
 | `PROXBOX_SKIP_NETBOX_BOOTSTRAP` | nao definido | Quando `1`, `true` ou `yes`, nao cria o cliente NetBox padrao no startup. |
 | `PROXBOX_ENCRYPTION_KEY` | nao definido | Chave secreta para criptografar credenciais em repouso. Veja [Criptografia de credenciais](#criptografia-de-credenciais) abaixo. |
+| `PROXBOX_ENCRYPTION_KEY_FILE` | nao definido | Caminho para um arquivo contendo a chave Fernet. Alternativa a `PROXBOX_ENCRYPTION_KEY` para deploys onde a chave nao deve ficar no ambiente. |
+| `PROXBOX_ALLOW_PLAINTEXT_CREDENTIALS` | nao definido | Quando `1`, `true` ou `yes`, permite startup mesmo sem chave de criptografia configurada. Apenas para labs — emite log `CRITICAL` e nunca deve ser usado em producao. |
 
 ### Tratando erros de NetBox sobrecarregado
 

--- a/docs/pt-BR/index.md
+++ b/docs/pt-BR/index.md
@@ -18,6 +18,8 @@ Esta documentacao cobre instalacao, configuracao, arquitetura, referencias de AP
 - CRUD de endpoints Proxmox com senha ou par de token.
 - Coleta de dados de cluster, node, storage, VM, backup, snapshot e replication.
 - Sincronizacao de VM, interfaces, IPs, discos, storages e backups para o NetBox.
+- Leitura de High-Availability agregada por cluster — ver [API de HA do cluster](api/cluster-ha.md).
+- Verbos operacionais de VM (start / stop / snapshot / migrate) com gate `ProxmoxEndpoint.allow_writes`, idempotencia, auditoria em journal e progresso SSE no migrate — ver [Referencia HTTP — Verbos Operacionais de VM](api/http-reference.md#verbos-operacionais-de-vm).
 - Inspecao de logs do admin, cache e fluxo full-update.
 
 ## Idioma

--- a/docs/pt-BR/sync/workflows.md
+++ b/docs/pt-BR/sync/workflows.md
@@ -86,6 +86,27 @@ Nao permitido em paralelo:
 - Reconciliar estado da VM no NetBox antes de buscar os dados da VM no Proxmox.
 - Criar device antes de manufacturer/device type/site/cluster estarem prontos.
 
+### Reflexao das chaves do cloud-init
+
+Para VMs QEMU que bootam com cloud-init, o sync de VM reflete as chaves SSH
+configuradas, o usuario e o bag de IP/Gateway/DNS para a metadata Proxbox da
+VM no NetBox para que operadores auditem o estado do cloud-init sem abrir a
+UI do Proxmox. O mapeamento fica em `proxbox_api/proxmox_to_netbox/` e e
+coberto por `tests/test_vm_cloudinit_mapping.py`; a aba correspondente no
+plugin NetBox renderiza o mesmo payload. Rastreado em
+[netbox-proxbox#363](https://github.com/emersonfelipesp/netbox-proxbox/issues/363).
+
+### Parsing de `netbox-metadata` a partir das descricoes do Proxmox
+
+Operadores podem embutir um bloco JSON com cerca (`netbox-metadata`) dentro
+da descricao da VM no Proxmox. O sync extrai o bloco, valida-o por um schema
+Pydantic permissivo e usa o resultado para semear campos do NetBox geridos
+por usuario (description, tags, custom fields) antes do payload Proxmox-derivado
+normal mesclar. A logica de parsing fica centralizada em
+`proxbox_api/proxmox_to_netbox/description_metadata.py` e e travada por
+`tests/test_description_metadata.py`. JSON invalido ou violacoes de schema
+sao logadas mas nao falham o sync — o sync cai para a string bruta da descricao.
+
 ## Fluxo de Backup
 
 Endpoints:

--- a/docs/sync/workflows.md
+++ b/docs/sync/workflows.md
@@ -90,6 +90,28 @@ Not allowed in parallel:
 
 When `overwrite_vm_tags=False` (the default), the VM sync merges Proxmox-derived tags with the user-managed NetBox tags already on the object instead of replacing them. The `Proxbox` tag is always retained so the plugin can identify objects it owns. Setting `overwrite_vm_tags=True` switches to a destructive replacement that drops any tags the sync did not produce. The same merge-vs-replace contract applies to the cluster, storage, node-interface, and IP tag groups via `overwrite_cluster_tags`, `overwrite_storage_tags`, `overwrite_node_interface_tags`, and `overwrite_ip_tags`. See [Overwrite Flags](./overwrite-flags.md).
 
+### Cloud-init key reflection
+
+For QEMU VMs that boot with cloud-init, the VM sync reflects the configured
+SSH keys, user, and IP/Gateway/DNS bag into the NetBox VM's Proxbox metadata
+so operators can audit cloud-init state without opening the Proxmox UI. The
+mapping lives in `proxbox_api/proxmox_to_netbox/` and is covered by
+`tests/test_vm_cloudinit_mapping.py`; the corresponding NetBox plugin tab
+renders the same payload. Tracked under
+[netbox-proxbox#363](https://github.com/emersonfelipesp/netbox-proxbox/issues/363).
+
+### `netbox-metadata` JSON parsing from Proxmox descriptions
+
+Operators can stash a fenced JSON block (`netbox-metadata`) inside the Proxmox
+VM description. The sync extracts the block, validates it through a permissive
+Pydantic schema, and uses it to seed user-managed NetBox fields (description,
+tags, custom fields) before the normal Proxmox-derived payload merges in. The
+parsing logic is centralized in
+`proxbox_api/proxmox_to_netbox/description_metadata.py` and locked in by
+`tests/test_description_metadata.py`. Invalid JSON or schema violations are
+logged but do not fail the sync — the sync falls back to the raw description
+string.
+
 ## Backup Sync Flow
 
 Endpoints:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ nav:
   - Synchronization:
       - Workflows: sync/workflows.md
       - VM Reconciliation Architecture: sync/reconciliation-architecture.md
+      - Name Collision Resolver: sync/name-collision-resolver.md
       - Overwrite Flags: sync/overwrite-flags.md
   - Development:
       - Schema Management: development/schema-management.md


### PR DESCRIPTION
## Summary
- Document new v0.0.11 surface that the docs hadn't caught up to: VM operational verbs (start/stop/snapshot/migrate, with the `allow_writes` 403 gate), aggregated HA routes in the architecture overview, and seven previously-undocumented env vars.
- Add cloud-init key reflection and `netbox-metadata` JSON parsing subsections to `docs/sync/workflows.md`.
- Cross-link `docs/api/cluster-ha.md` ↔ `docs/api/http-reference.md` and out to the netbox-proxbox HA page; add `sync/name-collision-resolver.md` to mkdocs nav; align `AGENTS.md` checks with `CLAUDE.md`.
- All EN edits mirrored into `docs/pt-BR/`.

## Test plan
- [x] `mkdocs build --strict` passes on both `en` and `pt-BR` mirrors.
- [x] Grep confirmed every new env var name and route claim against `proxbox_api/` source.