### PR TITLE
feat(#325): read-only PBS subpackage + endpoint registry

### DIFF
--- a/proxbox_api/app/factory.py
+++ b/proxbox_api/app/factory.py
@@ -386,27 +386,44 @@ def create_app() -> FastAPI:
     register_full_update_routes(app)
     register_websocket_routes(app)
 
-    app.include_router(admin_router, prefix="/admin", tags=["admin"])
-    app.include_router(netbox_router, prefix="/netbox", tags=["netbox"])
-    app.include_router(px_nodes_router, prefix="/proxmox/nodes", tags=["proxmox / nodes"])
-    app.include_router(px_cluster_router, prefix="/proxmox/cluster", tags=["proxmox / cluster"])
-    app.include_router(px_ha_router, prefix="/proxmox/cluster", tags=["proxmox / ha"])
-    app.include_router(px_replication_router, prefix="/proxmox", tags=["proxmox / replication"])
-    app.include_router(
-        proxmox_actions_router, prefix="/proxmox", tags=["proxmox / operational verbs"]
-    )
-    app.include_router(proxmox_router, prefix="/proxmox", tags=["proxmox"])
-    app.include_router(dcim_router, prefix="/dcim", tags=["dcim"])
-    app.include_router(virtualization_router, prefix="/virtualization", tags=["virtualization"])
-    app.include_router(
-        virtual_machines_router,
-        prefix="/virtualization/virtual-machines",
-        tags=["virtualization / virtual-machines"],
-    )
-    app.include_router(extras_router, prefix="/extras", tags=["extras"])
-    app.include_router(
-        sync_individual_router, prefix="/sync/individual", tags=["sync / individual"]
-    )
-    app.include_router(sync_active_router)
+    features = {
+        token.strip().lower()
+        for token in os.environ.get("PROXBOX_FEATURES", "").split(",")
+        if token.strip()
+    }
+    pbs_only = features == {"pbs"}
+
+    if not pbs_only:
+        app.include_router(admin_router, prefix="/admin", tags=["admin"])
+        app.include_router(netbox_router, prefix="/netbox", tags=["netbox"])
+        app.include_router(px_nodes_router, prefix="/proxmox/nodes", tags=["proxmox / nodes"])
+        app.include_router(px_cluster_router, prefix="/proxmox/cluster", tags=["proxmox / cluster"])
+        app.include_router(px_ha_router, prefix="/proxmox/cluster", tags=["proxmox / ha"])
+        app.include_router(px_replication_router, prefix="/proxmox", tags=["proxmox / replication"])
+        app.include_router(
+            proxmox_actions_router, prefix="/proxmox", tags=["proxmox / operational verbs"]
+        )
+        app.include_router(proxmox_router, prefix="/proxmox", tags=["proxmox"])
+        app.include_router(dcim_router, prefix="/dcim", tags=["dcim"])
+        app.include_router(virtualization_router, prefix="/virtualization", tags=["virtualization"])
+        app.include_router(
+            virtual_machines_router,
+            prefix="/virtualization/virtual-machines",
+            tags=["virtualization / virtual-machines"],
+        )
+        app.include_router(extras_router, prefix="/extras", tags=["extras"])
+        app.include_router(
+            sync_individual_router, prefix="/sync/individual", tags=["sync / individual"]
+        )
+        app.include_router(sync_active_router)
+
+    try:
+        from proxbox_api.pbs import admin_router as pbs_admin_router  # noqa: PLC0415
+        from proxbox_api.pbs import router as pbs_router  # noqa: PLC0415
+    except ImportError as exc:
+        logger.info("PBS subpackage unavailable; /pbs/* routes disabled (%s)", exc)
+    else:
+        app.include_router(pbs_admin_router, prefix="/pbs", tags=["pbs"])
+        app.include_router(pbs_router, prefix="/pbs", tags=["pbs"])
 
     return app

--- a/proxbox_api/app/factory.py
+++ b/proxbox_api/app/factory.py
@@ -382,9 +382,6 @@ def create_app() -> FastAPI:
 
     app.include_router(root_meta_router)
     app.include_router(auth_router)
-    register_cache_routes(app)
-    register_full_update_routes(app)
-    register_websocket_routes(app)
 
     features = {
         token.strip().lower()
@@ -394,6 +391,9 @@ def create_app() -> FastAPI:
     pbs_only = features == {"pbs"}
 
     if not pbs_only:
+        register_cache_routes(app)
+        register_full_update_routes(app)
+        register_websocket_routes(app)
         app.include_router(admin_router, prefix="/admin", tags=["admin"])
         app.include_router(netbox_router, prefix="/netbox", tags=["netbox"])
         app.include_router(px_nodes_router, prefix="/proxmox/nodes", tags=["proxmox / nodes"])

--- a/proxbox_api/database.py
+++ b/proxbox_api/database.py
@@ -109,6 +109,38 @@ class ProxmoxEndpoint(SQLModel, table=True):
         self.token_value = encrypt_value(value)
 
 
+class PBSEndpoint(SQLModel, table=True):
+    """Proxmox Backup Server (PBS) endpoint record.
+
+    Read-only integration in v1: credentials authorize PBS GET calls only.
+    ``allow_writes`` is reserved for a future write surface and stays False.
+    """
+
+    __table_args__ = {"extend_existing": True}
+
+    id: int | None = Field(default=None, primary_key=True)
+    name: str = Field(index=True, unique=True)
+    host: str = Field(index=True)
+    port: int = Field(default=8007)
+    token_id: str = Field()
+    token_secret: str = Field()
+    fingerprint: str | None = Field(default=None)
+    verify_ssl: bool = Field(default=True)
+    allow_writes: bool = Field(default=False)
+    timeout_seconds: int = Field(default=30)
+    last_seen_at: float | None = Field(default=None)
+
+    @property
+    def url(self) -> str:
+        return f"https://{self.host}:{self.port}"
+
+    def get_decrypted_token_secret(self) -> str | None:
+        return decrypt_value(self.token_secret)
+
+    def set_encrypted_token_secret(self, value: str) -> None:
+        self.token_secret = encrypt_value(value) or value
+
+
 class AuthLockout(SQLModel, table=True):
     __table_args__ = {"extend_existing": True}
 
@@ -314,10 +346,36 @@ def _migrate_netbox_endpoint_columns() -> None:
         )
 
 
+def _migrate_pbs_endpoint_columns() -> None:
+    table = PBSEndpoint.__tablename__
+    try:
+        insp = inspect(engine)
+        if not insp.has_table(table):
+            return
+        existing = {c["name"] for c in insp.get_columns(table)}
+    except Exception:
+        return
+    stmts: list[str] = []
+    if "fingerprint" not in existing:
+        stmts.append(f"ALTER TABLE {table} ADD COLUMN fingerprint VARCHAR")
+    if "allow_writes" not in existing:
+        stmts.append(f"ALTER TABLE {table} ADD COLUMN allow_writes BOOLEAN NOT NULL DEFAULT 0")
+    if "timeout_seconds" not in existing:
+        stmts.append(f"ALTER TABLE {table} ADD COLUMN timeout_seconds INTEGER NOT NULL DEFAULT 30")
+    if "last_seen_at" not in existing:
+        stmts.append(f"ALTER TABLE {table} ADD COLUMN last_seen_at REAL")
+    if not stmts:
+        return
+    with engine.begin() as conn:
+        for stmt in stmts:
+            conn.execute(text(stmt))
+
+
 def create_db_and_tables() -> None:
     SQLModel.metadata.create_all(engine)
     _migrate_proxmox_endpoint_columns()
     _migrate_netbox_endpoint_columns()
+    _migrate_pbs_endpoint_columns()
 
 
 def get_session() -> Generator[Session, None, None]:

--- a/proxbox_api/pbs/__init__.py
+++ b/proxbox_api/pbs/__init__.py
@@ -1,0 +1,17 @@
+"""Proxmox Backup Server (PBS) integration subpackage.
+
+Read-only PBS-to-NetBox surface installed via ``pip install proxbox-api[pbs]``.
+
+Importing this module is cheap; importing :mod:`proxbox_api.pbs.routes` requires
+``proxmox-sdk[pbs]`` (i.e. the ``proxmox_sdk.pbs`` namespace) to be available at
+runtime. The app factory mounts ``router`` lazily inside a try/except so the
+absence of the PBS extras simply disables ``/pbs/*`` rather than crashing
+startup.
+"""
+
+from __future__ import annotations
+
+from proxbox_api.pbs.admin import router as admin_router
+from proxbox_api.pbs.routes import router
+
+__all__ = ["admin_router", "router"]

--- a/proxbox_api/pbs/admin.py
+++ b/proxbox_api/pbs/admin.py
@@ -1,0 +1,140 @@
+"""CRUD routes for local PBS endpoint records (``/pbs/endpoints``)."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, ConfigDict, Field
+from sqlmodel import select
+
+from proxbox_api.database import AsyncDatabaseSessionDep as SessionDep
+from proxbox_api.database import PBSEndpoint
+from proxbox_api.utils.async_compat import maybe_await as _maybe_await
+
+router = APIRouter()
+
+
+class PBSEndpointCreate(BaseModel):
+    name: str = Field(max_length=255)
+    host: str = Field(max_length=255)
+    port: int = Field(default=8007, ge=1, le=65535)
+    token_id: str = Field(max_length=255)
+    token_secret: str = Field(max_length=2000)
+    fingerprint: str | None = Field(default=None, max_length=200)
+    verify_ssl: bool = True
+    timeout_seconds: int = Field(default=30, ge=1, le=600)
+
+
+class PBSEndpointUpdate(BaseModel):
+    name: str | None = Field(default=None, max_length=255)
+    host: str | None = Field(default=None, max_length=255)
+    port: int | None = Field(default=None, ge=1, le=65535)
+    token_id: str | None = Field(default=None, max_length=255)
+    token_secret: str | None = Field(default=None, max_length=2000)
+    fingerprint: str | None = Field(default=None, max_length=200)
+    verify_ssl: bool | None = None
+    timeout_seconds: int | None = Field(default=None, ge=1, le=600)
+
+
+class PBSEndpointPublic(BaseModel):
+    """Public PBS endpoint shape with credentials redacted."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int | None = None
+    name: str
+    host: str
+    port: int
+    token_id: str
+    fingerprint: str | None = None
+    verify_ssl: bool
+    allow_writes: bool
+    timeout_seconds: int
+
+
+def _to_public(endpoint: PBSEndpoint) -> PBSEndpointPublic:
+    return PBSEndpointPublic.model_validate(endpoint)
+
+
+@router.post("/endpoints", response_model=PBSEndpointPublic)
+async def create_pbs_endpoint(
+    endpoint: PBSEndpointCreate,
+    session: SessionDep,
+) -> PBSEndpointPublic:
+    existing_result = await _maybe_await(
+        session.exec(select(PBSEndpoint).where(PBSEndpoint.name == endpoint.name))
+    )
+    if existing_result.first():
+        raise HTTPException(status_code=400, detail="PBS endpoint name already exists")
+
+    db_endpoint = PBSEndpoint(**endpoint.model_dump())
+    db_endpoint.set_encrypted_token_secret(endpoint.token_secret)
+
+    session.add(db_endpoint)
+    await _maybe_await(session.commit())
+    await _maybe_await(session.refresh(db_endpoint))
+    return _to_public(db_endpoint)
+
+
+@router.get("/endpoints", response_model=list[PBSEndpointPublic])
+async def list_pbs_endpoints(
+    session: SessionDep,
+    offset: int = 0,
+    limit: Annotated[int, Query(le=100)] = 100,
+) -> list[PBSEndpointPublic]:
+    result = await _maybe_await(session.exec(select(PBSEndpoint).offset(offset).limit(limit)))
+    return [_to_public(item) for item in result.all()]
+
+
+@router.get("/endpoints/{endpoint_id}", response_model=PBSEndpointPublic)
+async def get_pbs_endpoint(endpoint_id: int, session: SessionDep) -> PBSEndpointPublic:
+    endpoint = await _maybe_await(session.get(PBSEndpoint, endpoint_id))
+    if not endpoint:
+        raise HTTPException(status_code=404, detail="PBS endpoint not found")
+    return _to_public(endpoint)
+
+
+@router.put("/endpoints/{endpoint_id}", response_model=PBSEndpointPublic)
+async def update_pbs_endpoint(
+    endpoint_id: int,
+    endpoint: PBSEndpointUpdate,
+    session: SessionDep,
+) -> PBSEndpointPublic:
+    db_endpoint = await _maybe_await(session.get(PBSEndpoint, endpoint_id))
+    if not db_endpoint:
+        raise HTTPException(status_code=404, detail="PBS endpoint not found")
+
+    update_data = endpoint.model_dump(exclude_unset=True)
+
+    if "name" in update_data:
+        existing_result = await _maybe_await(
+            session.exec(select(PBSEndpoint).where(PBSEndpoint.name == update_data["name"]))
+        )
+        existing = existing_result.first()
+        if existing and existing.id != endpoint_id:
+            raise HTTPException(status_code=400, detail="PBS endpoint name already exists")
+
+    new_secret = update_data.pop("token_secret", None)
+    for key, value in update_data.items():
+        setattr(db_endpoint, key, value)
+    if new_secret is not None:
+        db_endpoint.set_encrypted_token_secret(new_secret)
+
+    session.add(db_endpoint)
+    await _maybe_await(session.commit())
+    await _maybe_await(session.refresh(db_endpoint))
+    return _to_public(db_endpoint)
+
+
+@router.delete("/endpoints/{endpoint_id}")
+async def delete_pbs_endpoint(endpoint_id: int, session: SessionDep) -> dict[str, str]:
+    endpoint = await _maybe_await(session.get(PBSEndpoint, endpoint_id))
+    if not endpoint:
+        raise HTTPException(status_code=404, detail="PBS endpoint not found")
+    await _maybe_await(session.delete(endpoint))
+    await _maybe_await(session.commit())
+    return {"message": "PBS endpoint deleted."}
+
+
+__all__ = ["router"]

--- a/proxbox_api/pbs/routes.py
+++ b/proxbox_api/pbs/routes.py
@@ -1,0 +1,199 @@
+"""Read-only PBS routes mounted under ``/pbs``.
+
+Every handler accepts an optional ``netbox_branch_schema_id`` query parameter so
+PBS-to-NetBox writes can be funnelled into a NetBox-branching schema, mirroring
+the ``/sync/individual/cluster`` contract. v1 does not actually issue NetBox
+writes — the routes fetch from PBS and return summaries — but the parameter is
+threaded through so the surface stays stable when sync wiring lands.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated
+
+from fastapi import APIRouter, HTTPException, Query
+from sqlmodel import select
+
+from proxbox_api.database import AsyncDatabaseSessionDep as SessionDep
+from proxbox_api.database import PBSEndpoint
+from proxbox_api.logger import logger
+from proxbox_api.pbs.schemas import (
+    PBSStatusItem,
+    PBSStatusResponse,
+    PBSSyncResponse,
+    PBSSyncSummary,
+)
+from proxbox_api.utils.async_compat import maybe_await as _maybe_await
+
+if TYPE_CHECKING:
+    from proxmox_sdk.pbs import PBSClient
+
+router = APIRouter()
+
+
+async def _list_endpoints(session: SessionDep) -> list[PBSEndpoint]:
+    result = await _maybe_await(session.exec(select(PBSEndpoint)))
+    return list(result.all())
+
+
+def _client_for(endpoint: PBSEndpoint) -> "PBSClient":
+    """Build a PBS client, converting missing-extras into a 503.
+
+    Importing :mod:`proxbox_api.pbs.session` is safe even without
+    ``proxmox-sdk[pbs]`` installed; the deferred import lives in
+    :func:`build_pbs_client`.
+    """
+    try:
+        from proxbox_api.pbs.session import build_pbs_client  # noqa: PLC0415
+    except ImportError as exc:  # pragma: no cover - defensive
+        raise HTTPException(
+            status_code=503,
+            detail=f"PBS extras unavailable: {exc}",
+        ) from exc
+
+    try:
+        return build_pbs_client(endpoint)
+    except ImportError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail=(f"PBS extras unavailable: install proxmox-sdk[pbs] to enable /pbs/* ({exc})"),
+        ) from exc
+
+
+@router.get("/status", response_model=PBSStatusResponse)
+async def pbs_status(session: SessionDep) -> PBSStatusResponse:
+    """Report reachability for every configured PBSEndpoint."""
+    items: list[PBSStatusItem] = []
+    for endpoint in await _list_endpoints(session):
+        item = PBSStatusItem(
+            endpoint_id=endpoint.id or 0,
+            name=endpoint.name,
+            host=endpoint.host,
+            port=endpoint.port,
+            reachable=False,
+        )
+        try:
+            client = _client_for(endpoint)
+        except HTTPException as http_exc:
+            item.reason = str(http_exc.detail)
+            items.append(item)
+            continue
+
+        try:
+            version = await client.version()
+            item.reachable = True
+            item.version = getattr(version, "version", None)
+        except Exception as exc:  # noqa: BLE001
+            item.reason = f"{type(exc).__name__}: {exc}"
+            logger.info("PBS status probe failed for endpoint %s: %s", endpoint.name, exc)
+        finally:
+            try:
+                await client.close()
+            except Exception:  # noqa: BLE001
+                pass
+        items.append(item)
+    return PBSStatusResponse(items=items)
+
+
+async def _sync_one(  # noqa: C901 — explicit branching keeps the loop linear
+    endpoint: PBSEndpoint,
+    resource: str,
+    netbox_branch_schema_id: str | None,
+) -> PBSSyncSummary:
+    summary = PBSSyncSummary(
+        endpoint_id=endpoint.id or 0,
+        name=endpoint.name,
+        resource=resource,  # type: ignore[arg-type]
+        netbox_branch_schema_id=netbox_branch_schema_id,
+    )
+    try:
+        client = _client_for(endpoint)
+    except HTTPException as http_exc:
+        summary.errors.append(str(http_exc.detail))
+        return summary
+
+    try:
+        if resource in ("datastores", "full"):
+            stores = await client.datastores.list()
+            summary.fetched += len(stores)
+        if resource in ("snapshots", "full"):
+            stores = stores if resource == "full" else await client.datastores.list()
+            snapshot_total = 0
+            for store in stores:
+                snaps = await client.snapshots.list(store.name)
+                snapshot_total += len(snaps)
+            if resource == "snapshots":
+                summary.fetched = snapshot_total
+            else:
+                summary.fetched += snapshot_total
+        if resource in ("jobs", "full"):
+            jobs = await client.jobs.list()
+            if resource == "jobs":
+                summary.fetched = len(jobs)
+            else:
+                summary.fetched += len(jobs)
+        if resource == "node":
+            status = await client.nodes.status("localhost")
+            summary.fetched = 1 if status else 0
+    except Exception as exc:  # noqa: BLE001
+        summary.errors.append(f"{type(exc).__name__}: {exc}")
+    finally:
+        try:
+            await client.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+    return summary
+
+
+async def _sync_all(
+    session: SessionDep,
+    resource: str,
+    netbox_branch_schema_id: str | None,
+) -> PBSSyncResponse:
+    endpoints = await _list_endpoints(session)
+    items = [await _sync_one(ep, resource, netbox_branch_schema_id) for ep in endpoints]
+    return PBSSyncResponse(items=items)
+
+
+@router.get("/sync/full", response_model=PBSSyncResponse)
+async def pbs_sync_full(
+    session: SessionDep,
+    netbox_branch_schema_id: Annotated[str | None, Query()] = None,
+) -> PBSSyncResponse:
+    return await _sync_all(session, "full", netbox_branch_schema_id)
+
+
+@router.get("/sync/datastores", response_model=PBSSyncResponse)
+async def pbs_sync_datastores(
+    session: SessionDep,
+    netbox_branch_schema_id: Annotated[str | None, Query()] = None,
+) -> PBSSyncResponse:
+    return await _sync_all(session, "datastores", netbox_branch_schema_id)
+
+
+@router.get("/sync/snapshots", response_model=PBSSyncResponse)
+async def pbs_sync_snapshots(
+    session: SessionDep,
+    netbox_branch_schema_id: Annotated[str | None, Query()] = None,
+) -> PBSSyncResponse:
+    return await _sync_all(session, "snapshots", netbox_branch_schema_id)
+
+
+@router.get("/sync/jobs", response_model=PBSSyncResponse)
+async def pbs_sync_jobs(
+    session: SessionDep,
+    netbox_branch_schema_id: Annotated[str | None, Query()] = None,
+) -> PBSSyncResponse:
+    return await _sync_all(session, "jobs", netbox_branch_schema_id)
+
+
+@router.get("/sync/node", response_model=PBSSyncResponse)
+async def pbs_sync_node(
+    session: SessionDep,
+    netbox_branch_schema_id: Annotated[str | None, Query()] = None,
+) -> PBSSyncResponse:
+    return await _sync_all(session, "node", netbox_branch_schema_id)
+
+
+__all__ = ["router"]

--- a/proxbox_api/pbs/schemas.py
+++ b/proxbox_api/pbs/schemas.py
@@ -1,0 +1,55 @@
+"""Public response shapes for the ``/pbs/*`` routes.
+
+Internal PBS payloads come from :mod:`proxmox_sdk.pbs.models`; these are the
+serialization wrappers that surface in the FastAPI OpenAPI schema and that the
+NetBox-side mappers consume.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PBSStatusItem(BaseModel):
+    """One PBSEndpoint's reachability snapshot."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    endpoint_id: int
+    name: str
+    host: str
+    port: int
+    reachable: bool
+    reason: str | None = None
+    version: str | None = None
+
+
+class PBSStatusResponse(BaseModel):
+    items: list[PBSStatusItem]
+
+
+class PBSSyncSummary(BaseModel):
+    """Per-endpoint per-resource sync stats returned by ``/pbs/sync/*``."""
+
+    endpoint_id: int
+    name: str
+    resource: Literal["datastores", "snapshots", "jobs", "node", "full"]
+    fetched: int = Field(default=0, ge=0)
+    written: int = Field(default=0, ge=0)
+    errors: list[str] = Field(default_factory=list)
+    netbox_branch_schema_id: str | None = None
+
+
+class PBSSyncResponse(BaseModel):
+    items: list[PBSSyncSummary]
+    raw: dict[str, Any] | None = None
+
+
+__all__ = [
+    "PBSStatusItem",
+    "PBSStatusResponse",
+    "PBSSyncSummary",
+    "PBSSyncResponse",
+]

--- a/proxbox_api/pbs/session.py
+++ b/proxbox_api/pbs/session.py
@@ -1,0 +1,59 @@
+"""PBSClient factory keyed by ``PBSEndpoint`` record id."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from proxbox_api.database import PBSEndpoint
+from proxbox_api.exception import ProxboxException
+
+if TYPE_CHECKING:
+    from proxmox_sdk.pbs import PBSClient
+
+
+def _split_token_id(token_id: str) -> tuple[str, str]:
+    """Split a PBS API token id of the form ``user@realm!tokenname``.
+
+    Returns ``(user, token_name)``. Raises :class:`ProxboxException` on a
+    malformed token id, which signals a misconfigured endpoint record.
+    """
+    if "!" not in token_id:
+        raise ProxboxException(
+            message=f"PBS endpoint token_id missing '!' separator: {token_id!r}",
+            python_exception="ValueError: token_id must look like 'user@realm!tokenname'",
+        )
+    user, _, token_name = token_id.partition("!")
+    if not user or not token_name:
+        raise ProxboxException(
+            message=f"PBS endpoint token_id has empty parts: {token_id!r}",
+            python_exception="ValueError: empty user or token_name",
+        )
+    return user, token_name
+
+
+def build_pbs_client(endpoint: PBSEndpoint) -> "PBSClient":
+    """Construct a :class:`proxmox_sdk.pbs.PBSClient` from a stored endpoint.
+
+    The PBS extra (``proxmox-sdk[pbs]``) must be installed; otherwise an
+    ``ImportError`` propagates and the route handler converts it to a 503.
+    """
+    from proxmox_sdk.pbs import PBSClient  # noqa: PLC0415 — optional extra
+
+    user, token_name = _split_token_id(endpoint.token_id)
+    secret = endpoint.get_decrypted_token_secret()
+    if not secret:
+        raise ProxboxException(
+            message=f"PBS endpoint {endpoint.name!r} has no decryptable token secret.",
+        )
+    return PBSClient(
+        host=endpoint.host,
+        user=user,
+        token_name=token_name,
+        token_value=secret,
+        port=endpoint.port,
+        verify_ssl=endpoint.verify_ssl,
+        timeout=endpoint.timeout_seconds,
+    )
+
+
+__all__ = ["build_pbs_client"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,11 @@ docs = [
 granian = [
     "granian>=2.7.4",
 ]
+# NOTE: the `pbs` optional extra will land once proxmox-sdk 0.0.4 (which adds
+# the `proxmox_sdk.pbs` namespace and its own `[pbs]` extra) is published. The
+# subpackage at `proxbox_api/pbs/` already ships in the wheel; importing
+# `proxbox_api.pbs.session` raises ImportError until the SDK release exposes
+# the namespace, at which point routes start serving against a real PBS.
 
 [dependency-groups]
 dev = [

--- a/tests/pbs/conftest.py
+++ b/tests/pbs/conftest.py
@@ -1,0 +1,45 @@
+"""Shared fixtures for PBS test modules."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from proxbox_api.database import ApiKey, get_async_session, get_session
+from proxbox_api.main import app
+
+
+@pytest.fixture
+def client(tmp_path: Path):
+    sqlite_file = tmp_path / "test.db"
+    engine = create_engine(f"sqlite:///{sqlite_file}", connect_args={"check_same_thread": False})
+    SQLModel.metadata.create_all(engine)
+
+    async_url = str(engine.url).replace("sqlite:///", "sqlite+aiosqlite:///")
+    async_engine = create_async_engine(async_url, connect_args={"check_same_thread": False})
+    session_factory = async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
+
+    def _override_get_session():
+        with Session(engine) as session:
+            yield session
+
+    async def _override_get_async_session():
+        async with session_factory() as session:
+            yield session
+
+    with Session(engine) as session:
+        raw_key = "test-api-key-for-pbs-suite"
+        ApiKey.store_key(session, raw_key, label="test-pbs")
+
+    app.dependency_overrides[get_session] = _override_get_session
+    app.dependency_overrides[get_async_session] = _override_get_async_session
+    with TestClient(app, headers={"X-Proxbox-API-Key": raw_key}) as test_client:
+        yield test_client
+    app.dependency_overrides.clear()
+    asyncio.run(async_engine.dispose())

--- a/tests/pbs/test_endpoint_crud.py
+++ b/tests/pbs/test_endpoint_crud.py
@@ -1,0 +1,85 @@
+"""HTTP CRUD coverage for ``/pbs/endpoints``."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+
+def test_pbs_endpoint_crud_lifecycle(client: TestClient):
+    create_payload = {
+        "name": "pbs-lab-1",
+        "host": "pbs.example.local",
+        "port": 8007,
+        "token_id": "root@pam!sync",
+        "token_secret": "very-secret-token-value",
+        "verify_ssl": False,
+        "timeout_seconds": 45,
+    }
+
+    create_response = client.post("/pbs/endpoints", json=create_payload)
+    assert create_response.status_code == 200
+    created = create_response.json()
+    endpoint_id = created["id"]
+    assert created["name"] == "pbs-lab-1"
+    assert created["host"] == "pbs.example.local"
+    assert created["token_id"] == "root@pam!sync"
+    assert created["allow_writes"] is False
+    assert created["timeout_seconds"] == 45
+    assert "token_secret" not in created
+
+    list_response = client.get("/pbs/endpoints")
+    assert list_response.status_code == 200
+    listed = list_response.json()
+    assert len(listed) == 1
+    assert listed[0]["id"] == endpoint_id
+    assert "token_secret" not in listed[0]
+
+    get_response = client.get(f"/pbs/endpoints/{endpoint_id}")
+    assert get_response.status_code == 200
+
+    update_response = client.put(
+        f"/pbs/endpoints/{endpoint_id}",
+        json={"name": "pbs-lab-1-updated", "verify_ssl": True},
+    )
+    assert update_response.status_code == 200
+    assert update_response.json()["name"] == "pbs-lab-1-updated"
+    assert update_response.json()["verify_ssl"] is True
+
+    delete_response = client.delete(f"/pbs/endpoints/{endpoint_id}")
+    assert delete_response.status_code == 200
+    assert delete_response.json() == {"message": "PBS endpoint deleted."}
+
+    get_deleted = client.get(f"/pbs/endpoints/{endpoint_id}")
+    assert get_deleted.status_code == 404
+
+
+def test_pbs_endpoint_name_unique(client: TestClient):
+    base = {
+        "name": "pbs-lab-1",
+        "host": "pbs.example.local",
+        "port": 8007,
+        "token_id": "root@pam!sync",
+        "token_secret": "secret-1",
+    }
+    first = client.post("/pbs/endpoints", json=base)
+    assert first.status_code == 200
+
+    second = client.post("/pbs/endpoints", json=base)
+    assert second.status_code == 400
+    assert second.json()["detail"] == "PBS endpoint name already exists"
+
+
+def test_pbs_endpoint_token_secret_is_persisted_encrypted(client: TestClient, tmp_path):
+    """The plaintext token secret never round-trips through the public API."""
+    payload = {
+        "name": "pbs-secret-check",
+        "host": "pbs.example.local",
+        "port": 8007,
+        "token_id": "root@pam!sync",
+        "token_secret": "plaintext-do-not-leak",
+    }
+    response = client.post("/pbs/endpoints", json=payload)
+    assert response.status_code == 200
+    body = response.json()
+    assert "token_secret" not in body
+    assert "plaintext-do-not-leak" not in response.text

--- a/tests/pbs/test_factory_gating.py
+++ b/tests/pbs/test_factory_gating.py
@@ -12,6 +12,9 @@ def test_default_app_mounts_pbs_alongside_proxmox():
     assert "/pbs/endpoints" in paths
     # Sanity: non-PBS surface is also present in the default build.
     assert "/proxmox/endpoints" in paths
+    assert "/full-update" in paths
+    assert "/cache" in paths
+    assert "/ws" in paths
 
 
 def test_pbs_only_feature_flag_hides_other_routers(monkeypatch):
@@ -24,3 +27,6 @@ def test_pbs_only_feature_flag_hides_other_routers(monkeypatch):
     assert "/pbs/endpoints" in paths
     assert "/proxmox/endpoints" not in paths
     assert "/dcim" not in {p for p in paths if p.startswith("/dcim")}
+    assert "/full-update" not in paths
+    assert "/cache" not in paths
+    assert "/ws" not in paths

--- a/tests/pbs/test_factory_gating.py
+++ b/tests/pbs/test_factory_gating.py
@@ -1,0 +1,26 @@
+"""When PROXBOX_FEATURES=pbs, only /pbs/* (plus root/auth) are mounted."""
+
+from __future__ import annotations
+
+
+def test_default_app_mounts_pbs_alongside_proxmox():
+    from proxbox_api.app.factory import create_app
+
+    app = create_app()
+    paths = {route.path for route in app.routes}
+    assert "/pbs/status" in paths
+    assert "/pbs/endpoints" in paths
+    # Sanity: non-PBS surface is also present in the default build.
+    assert "/proxmox/endpoints" in paths
+
+
+def test_pbs_only_feature_flag_hides_other_routers(monkeypatch):
+    monkeypatch.setenv("PROXBOX_FEATURES", "pbs")
+    from proxbox_api.app.factory import create_app
+
+    app = create_app()
+    paths = {route.path for route in app.routes}
+    assert "/pbs/status" in paths
+    assert "/pbs/endpoints" in paths
+    assert "/proxmox/endpoints" not in paths
+    assert "/dcim" not in {p for p in paths if p.startswith("/dcim")}

--- a/tests/pbs/test_routes_smoke.py
+++ b/tests/pbs/test_routes_smoke.py
@@ -1,0 +1,189 @@
+"""Smoke tests for the read-only ``/pbs/sync/*`` and ``/pbs/status`` routes."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from proxbox_api.pbs import routes as pbs_routes
+
+
+class _FakeDatastores:
+    def __init__(self, payload):
+        self._payload = payload
+
+    async def list(self):
+        return self._payload
+
+
+class _FakeSnapshots:
+    def __init__(self, by_store: dict[str, list]):
+        self._by_store = by_store
+
+    async def list(self, store, **_kwargs):
+        return self._by_store.get(store, [])
+
+
+class _FakeJobs:
+    def __init__(self, payload):
+        self._payload = payload
+
+    async def list(self, *_args, **_kwargs):
+        return self._payload
+
+
+class _FakeNodes:
+    def __init__(self, payload):
+        self._payload = payload
+
+    async def status(self, _node):
+        return self._payload
+
+
+class _FakeVersion:
+    def __init__(self, version: str):
+        self.version = version
+
+
+class _FakePBSClient:
+    """Stand-in for ``proxmox_sdk.pbs.PBSClient`` used by routes."""
+
+    def __init__(
+        self,
+        *,
+        datastores=None,
+        snapshots=None,
+        jobs=None,
+        node_status=None,
+        version="3.4.2",
+    ):
+        self.datastores = _FakeDatastores(datastores or [])
+        self.snapshots = _FakeSnapshots(snapshots or {})
+        self.jobs = _FakeJobs(jobs or [])
+        self.nodes = _FakeNodes(node_status or {"hostname": "pbs01"})
+        self._version_str = version
+
+    async def version(self):
+        return _FakeVersion(self._version_str)
+
+    async def close(self):
+        return None
+
+
+class _Store:
+    def __init__(self, name: str):
+        self.name = name
+
+
+@pytest.fixture
+def _patched_client(monkeypatch):
+    captured: list[dict] = []
+
+    fake = _FakePBSClient(
+        datastores=[_Store("primary"), _Store("offsite")],
+        snapshots={"primary": [object(), object()], "offsite": [object()]},
+        jobs=[object(), object(), object()],
+        node_status={"hostname": "pbs01"},
+    )
+
+    def _client_for(endpoint):
+        captured.append({"endpoint": endpoint})
+        return fake
+
+    monkeypatch.setattr(pbs_routes, "_client_for", _client_for)
+    return captured
+
+
+def _create_endpoint(client: TestClient) -> int:
+    response = client.post(
+        "/pbs/endpoints",
+        json={
+            "name": "pbs-smoke",
+            "host": "pbs.example.local",
+            "port": 8007,
+            "token_id": "root@pam!sync",
+            "token_secret": "shhh",
+        },
+    )
+    assert response.status_code == 200
+    return response.json()["id"]
+
+
+def test_pbs_status_reports_reachable(client: TestClient, _patched_client):
+    _create_endpoint(client)
+    response = client.get("/pbs/status")
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["items"]) == 1
+    item = body["items"][0]
+    assert item["reachable"] is True
+    assert item["version"] == "3.4.2"
+
+
+def test_pbs_status_empty_when_no_endpoints(client: TestClient):
+    response = client.get("/pbs/status")
+    assert response.status_code == 200
+    assert response.json() == {"items": []}
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_fetched"),
+    [
+        ("/pbs/sync/datastores", 2),
+        ("/pbs/sync/snapshots", 3),
+        ("/pbs/sync/jobs", 3),
+        ("/pbs/sync/node", 1),
+        ("/pbs/sync/full", 2 + 3 + 3),
+    ],
+)
+def test_pbs_sync_routes_summary(
+    client: TestClient, _patched_client, path: str, expected_fetched: int
+):
+    _create_endpoint(client)
+    response = client.get(path)
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["items"]) == 1
+    summary = body["items"][0]
+    assert summary["errors"] == []
+    assert summary["fetched"] == expected_fetched
+
+
+def test_pbs_sync_threads_branch_query_into_summary(client: TestClient, _patched_client):
+    _create_endpoint(client)
+    response = client.get(
+        "/pbs/sync/datastores",
+        params={"netbox_branch_schema_id": "br_abc123"},
+    )
+    assert response.status_code == 200
+    item = response.json()["items"][0]
+    assert item["netbox_branch_schema_id"] == "br_abc123"
+
+
+def test_pbs_sync_records_client_errors(client: TestClient, monkeypatch):
+    class _BrokenClient(_FakePBSClient):
+        async def version(self):
+            raise RuntimeError("connection refused")
+
+        async def close(self):
+            return None
+
+    fake = _BrokenClient()
+    fake.datastores = _FakeDatastores([])
+
+    async def _boom(self):
+        raise RuntimeError("connection refused")
+
+    fake.datastores.list = _boom.__get__(fake.datastores)  # type: ignore[attr-defined]
+
+    def _client_for(_endpoint):
+        return fake
+
+    monkeypatch.setattr(pbs_routes, "_client_for", _client_for)
+
+    _create_endpoint(client)
+    response = client.get("/pbs/sync/datastores")
+    assert response.status_code == 200
+    item = response.json()["items"][0]
+    assert item["fetched"] == 0
+    assert any("connection refused" in err for err in item["errors"])


### PR DESCRIPTION
## Summary

Phase B of [issue #325](https://github.com/emersonfelipesp/netbox-proxbox/issues/325) — first-class PBS (Proxmox Backup Server) integration. Adds a read-only `proxbox_api/pbs/` subpackage mounted under `/pbs`, persisted `PBSEndpoint` records, and a `PROXBOX_FEATURES=pbs` gate to support the future `pbs-raw` container image.

The integration is read-only by design (PBS → NetBox direction only — no edit/update/remove paths) and `netbox-branching`-aware from day one: every read route accepts `netbox_branch_schema_id`, mirroring the contract on `/sync/individual/cluster` shipped by #406.

### Routes added under `/pbs`

| Method | Path | Purpose |
|---|---|---|
| GET | `/pbs/status` | Reachability + version per `PBSEndpoint`. |
| GET | `/pbs/sync/full` | Datastores + snapshots + jobs summary. |
| GET | `/pbs/sync/datastores` | Datastores only. |
| GET | `/pbs/sync/snapshots` | Backup snapshots across datastores. |
| GET | `/pbs/sync/jobs` | Verify/prune/GC/sync/tape job summary. |
| GET | `/pbs/sync/node` | Per-host node status. |
| POST | `/pbs/endpoints` | Register a PBS endpoint (token secret encrypted at rest). |
| GET | `/pbs/endpoints` | List endpoints (secrets redacted). |
| GET | `/pbs/endpoints/{id}` | Fetch a single endpoint. |
| PUT | `/pbs/endpoints/{id}` | Update endpoint (re-encrypts if `token_secret` set). |
| DELETE | `/pbs/endpoints/{id}` | Remove an endpoint. |

### Persistence

`PBSEndpoint` SQLModel with `_migrate_pbs_endpoint_columns()` ALTER-TABLE helper for in-place upgrades. Token secret stored Fernet-encrypted; `allow_writes` is locked `False` in v1.

### Factory gate

`PROXBOX_FEATURES=pbs` in `create_app()` mounts only `/pbs/*` — used by the upcoming `pbs-raw` Docker target. Default behavior unchanged.

### Deferred to follow-up PRs

- The `[pbs]` optional extra is **deferred** until proxmox-sdk 0.0.4 (Phase A) is published — the base pin `proxmox-sdk==0.0.3.post1` conflicts with `proxmox-sdk[pbs]>=0.0.4`. The PBS subpackage already ships in the wheel; routes return HTTP 503 with an actionable message until the SDK namespace is installed. See `pyproject.toml` NOTE.
- Dockerfile `pbs-raw` target and CI matrix entry will land separately.

## Test plan

- [x] `uv run pytest tests/pbs -x` — 14 tests pass (CRUD lifecycle, name uniqueness, token redaction, status + every sync route, branch_schema_id threading, error capture, `PROXBOX_FEATURES=pbs` gating)
- [x] `uv run pre-commit run --files <changed>` — clean (ruff, ruff-format, ty)
- [ ] Smoke `/pbs/status` against a host with `proxmox-sdk[pbs]` installed
- [ ] Confirm `PROXBOX_FEATURES=pbs` boot path on a real container