### PR TITLE
feat(#367): sweep orphan VMs by run stamp

### DIFF
--- a/proxbox_api/app/full_update.py
+++ b/proxbox_api/app/full_update.py
@@ -42,10 +42,15 @@ from proxbox_api.routes.virtualization.virtual_machines.sync_vm import (
     create_only_vm_interfaces,
     create_only_vm_ip_addresses,
 )
+from proxbox_api.runtime_settings import get_bool
 from proxbox_api.schemas.stream_messages import ErrorCategory
 from proxbox_api.schemas.sync import SyncOverwriteFlags
 from proxbox_api.services.sync.backup_routines import sync_all_backup_routines
 from proxbox_api.services.sync.devices import create_proxmox_devices
+from proxbox_api.services.sync.orphan_sweep import (
+    extract_touched_vm_ids,
+    run_orphan_vm_sweep,
+)
 from proxbox_api.services.sync.replications import sync_all_replications
 from proxbox_api.services.sync.storages import create_storages
 from proxbox_api.services.sync.task_history import (
@@ -156,6 +161,7 @@ async def _full_update_sync_impl(  # noqa: C901
     sync_node_interfaces: list = []
     sync_vm_interfaces: list = []
     sync_vm_ip_addresses: list = []
+    orphan_sweep_result: dict[str, object] | None = None
 
     tag_refs = [
         {
@@ -392,7 +398,29 @@ async def _full_update_sync_impl(  # noqa: C901
                 python_exception=str(error),
             ) from error
 
-        return {
+        delete_orphans_enabled = get_bool(
+            settings_key="delete_orphans",
+            env="PROXBOX_DELETE_ORPHANS",
+            default=False,
+        )
+        if delete_orphans_enabled:
+            try:
+                orphan_sweep_result = await run_orphan_vm_sweep(
+                    netbox_session,
+                    run_id=operation_id,
+                    enabled=delete_orphans_enabled,
+                    touched_vm_ids=extract_touched_vm_ids(sync_vms),
+                )
+            except ProxboxException:
+                raise
+            except Exception as error:  # noqa: BLE001
+                logger.exception("Error while sweeping orphan virtual machines during full-update")
+                raise ProxboxException(
+                    message="Error while sweeping orphan virtual machines.",
+                    python_exception=str(error),
+                ) from error
+
+        result = {
             "status": "completed",
             "devices": sync_nodes,
             "storage": sync_storage,
@@ -421,6 +449,9 @@ async def _full_update_sync_impl(  # noqa: C901
             "vm_interfaces_count": len(sync_vm_interfaces),
             "vm_ip_addresses_count": len(sync_vm_ip_addresses),
         }
+        if orphan_sweep_result is not None:
+            result["orphan_sweep"] = orphan_sweep_result
+        return result
     finally:
         await release_active_sync(_active_entry)
 
@@ -436,6 +467,13 @@ async def full_update_sync_stream(  # noqa: C901
     tag: ProxboxTagDep,
     overwrite_flags: ResolvedSyncOverwriteFlagsDep = SyncOverwriteFlags(),
     fetch_max_concurrency: int | None = None,
+    dry_run: bool = Query(
+        default=False,
+        description=(
+            "Preview destructive end-of-run cleanup. When true, orphan VMs are "
+            "reported as would_delete events and no DELETE requests are sent."
+        ),
+    ),
     netbox_branch_schema_id: Annotated[
         str | None,
         Query(
@@ -475,6 +513,7 @@ async def full_update_sync_stream(  # noqa: C901
         sync_vm_ip_addresses: list = []
         sync_replications: dict = {}
         sync_backup_routines: dict = {}
+        orphan_sweep_result: dict[str, object] | None = None
         devices_bridge = WebSocketSSEBridge()
         storage_bridge = WebSocketSSEBridge()
         vm_bridge = WebSocketSSEBridge()
@@ -487,6 +526,7 @@ async def full_update_sync_stream(  # noqa: C901
         vm_ip_addresses_bridge = WebSocketSSEBridge()
         replications_bridge = WebSocketSSEBridge()
         backup_routines_bridge = WebSocketSSEBridge()
+        orphan_sweep_bridge = WebSocketSSEBridge()
 
         tag_refs = [
             {
@@ -1035,39 +1075,101 @@ async def full_update_sync_stream(  # noqa: C901
                     },
                 )
 
+                delete_orphans_enabled = get_bool(
+                    settings_key="delete_orphans",
+                    env="PROXBOX_DELETE_ORPHANS",
+                    default=False,
+                )
+                if delete_orphans_enabled or dry_run:
+                    yield sse_event(
+                        "step",
+                        {
+                            "step": "sweep-orphans",
+                            "status": "started",
+                            "message": (
+                                "Previewing orphan virtual machine sweep."
+                                if dry_run
+                                else "Starting orphan virtual machine sweep."
+                            ),
+                            "metadata": {
+                                "operation_id": operation_id,
+                                "delete_orphans": delete_orphans_enabled,
+                                "dry_run": dry_run,
+                            },
+                        },
+                    )
+
+                    async def _run_orphan_sweep():
+                        try:
+                            return await run_orphan_vm_sweep(
+                                netbox_session,
+                                run_id=operation_id,
+                                enabled=delete_orphans_enabled,
+                                dry_run=dry_run,
+                                stream=orphan_sweep_bridge,
+                                touched_vm_ids=extract_touched_vm_ids(sync_vms),
+                            )
+                        finally:
+                            await orphan_sweep_bridge.close()
+
+                    _orphan_sweep_start = time.monotonic()
+                    orphan_sweep_task = asyncio.create_task(_run_orphan_sweep())
+                    async for frame in orphan_sweep_bridge.iter_sse():
+                        yield frame
+                    orphan_sweep_result = await orphan_sweep_task
+
+                    yield sse_event(
+                        "step",
+                        {
+                            "step": "sweep-orphans",
+                            "status": "completed",
+                            "message": (
+                                "Orphan virtual machine sweep preview finished."
+                                if dry_run
+                                else "Orphan virtual machine sweep finished."
+                            ),
+                            "result": orphan_sweep_result,
+                            "duration_seconds": round(time.monotonic() - _orphan_sweep_start, 3),
+                        },
+                    )
+
+                final_result = {
+                    "devices": sync_nodes,
+                    "storage": sync_storage,
+                    "virtual_machines": sync_vms,
+                    "virtual_disks": sync_disks,
+                    "task_history": sync_task_history,
+                    "backups": sync_backups,
+                    "snapshots": sync_snapshots,
+                    "node_interfaces": sync_node_interfaces,
+                    "vm_interfaces": sync_vm_interfaces,
+                    "vm_ip_addresses": sync_vm_ip_addresses,
+                    "replications": sync_replications,
+                    "backup_routines": sync_backup_routines,
+                    "devices_count": len(sync_nodes),
+                    "storage_count": len(sync_storage),
+                    "virtual_machines_count": len(sync_vms),
+                    "virtual_disks_count": _result_count(sync_disks),
+                    "task_history_count": _result_count(sync_task_history),
+                    "backups_count": len(sync_backups),
+                    "snapshots_count": _result_count(sync_snapshots),
+                    "node_interfaces_count": len(sync_node_interfaces),
+                    "vm_interfaces_count": len(sync_vm_interfaces),
+                    "vm_ip_addresses_count": len(sync_vm_ip_addresses),
+                    "replications_count": sync_replications.get("created", 0)
+                    + sync_replications.get("updated", 0),
+                    "backup_routines_count": sync_backup_routines.get("created", 0)
+                    + sync_backup_routines.get("updated", 0),
+                }
+                if orphan_sweep_result is not None:
+                    final_result["orphan_sweep"] = orphan_sweep_result
+
                 yield sse_event(
                     "complete",
                     {
                         "ok": True,
                         "message": "Full update sync completed.",
-                        "result": {
-                            "devices": sync_nodes,
-                            "storage": sync_storage,
-                            "virtual_machines": sync_vms,
-                            "virtual_disks": sync_disks,
-                            "task_history": sync_task_history,
-                            "backups": sync_backups,
-                            "snapshots": sync_snapshots,
-                            "node_interfaces": sync_node_interfaces,
-                            "vm_interfaces": sync_vm_interfaces,
-                            "vm_ip_addresses": sync_vm_ip_addresses,
-                            "replications": sync_replications,
-                            "backup_routines": sync_backup_routines,
-                            "devices_count": len(sync_nodes),
-                            "storage_count": len(sync_storage),
-                            "virtual_machines_count": len(sync_vms),
-                            "virtual_disks_count": _result_count(sync_disks),
-                            "task_history_count": _result_count(sync_task_history),
-                            "backups_count": len(sync_backups),
-                            "snapshots_count": _result_count(sync_snapshots),
-                            "node_interfaces_count": len(sync_node_interfaces),
-                            "vm_interfaces_count": len(sync_vm_interfaces),
-                            "vm_ip_addresses_count": len(sync_vm_ip_addresses),
-                            "replications_count": sync_replications.get("created", 0)
-                            + sync_replications.get("updated", 0),
-                            "backup_routines_count": sync_backup_routines.get("created", 0)
-                            + sync_backup_routines.get("updated", 0),
-                        },
+                        "result": final_result,
                     },
                 )
             except asyncio.CancelledError:

--- a/proxbox_api/schemas/stream_messages.py
+++ b/proxbox_api/schemas/stream_messages.py
@@ -52,6 +52,7 @@ class ItemOperation(str, Enum):
     CREATED = "created"
     UPDATED = "updated"
     DELETED = "deleted"
+    WOULD_DELETE = "would_delete"
     SKIPPED = "skipped"
     FAILED = "failed"
 

--- a/proxbox_api/services/sync/orphan_sweep.py
+++ b/proxbox_api/services/sync/orphan_sweep.py
@@ -1,0 +1,427 @@
+"""Orphan cleanup for Proxbox-managed NetBox virtual machines."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, cast
+
+from proxbox_api.constants import DISCOVERY_TAG_VM_LXC, DISCOVERY_TAG_VM_QEMU
+from proxbox_api.exception import ProxboxException
+from proxbox_api.logger import logger
+from proxbox_api.netbox_rest import rest_bulk_delete_async, rest_list_paginated_async
+from proxbox_api.schemas.stream_messages import ErrorCategory, ItemOperation
+from proxbox_api.services.sync.vm_helpers import LAST_RUN_ID_CUSTOM_FIELD
+
+VIRTUAL_MACHINES_PATH = "/api/virtualization/virtual-machines/"
+VM_DISCOVERY_TAG_SLUGS: tuple[str, ...] = (DISCOVERY_TAG_VM_QEMU, DISCOVERY_TAG_VM_LXC)
+ORPHAN_SWEEP_PHASE = "sweep_orphans"
+
+
+def _record_to_dict(record: object) -> dict[str, object] | None:
+    if isinstance(record, dict):
+        return cast(dict[str, object], record)
+    for method_name in ("serialize", "dict"):
+        method = getattr(record, method_name, None)
+        if callable(method):
+            try:
+                value = method()
+            except Exception as error:
+                logger.debug("Failed to coerce VM record during orphan sweep: %s", error)
+                return None
+            return cast(dict[str, object], value) if isinstance(value, dict) else None
+    return None
+
+
+def _coerce_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if value is None:
+        return None
+    try:
+        return int(cast(Any, value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _custom_fields(record: dict[str, object]) -> dict[str, object]:
+    value = record.get("custom_fields")
+    return cast(dict[str, object], value) if isinstance(value, dict) else {}
+
+
+def _tag_slugs(record: dict[str, object]) -> list[str]:
+    tags = record.get("tags")
+    if not isinstance(tags, list):
+        return []
+    slugs: list[str] = []
+    for tag in tags:
+        if isinstance(tag, dict):
+            tag_dict = cast(dict[str, object], tag)
+            raw = tag_dict.get("slug") or tag_dict.get("name")
+        else:
+            raw = tag
+        if raw:
+            slugs.append(str(raw))
+    return sorted(dict.fromkeys(slugs))
+
+
+def extract_touched_vm_ids(value: object) -> set[int]:
+    """Extract NetBox VM IDs from nested sync result payloads."""
+    touched: set[int] = set()
+
+    def visit(item: object) -> None:
+        if isinstance(item, dict):
+            item_dict = cast(dict[str, object], item)
+            record_id = _coerce_int(item_dict.get("id") or item_dict.get("netbox_id"))
+            if record_id is not None:
+                touched.add(record_id)
+            for key in ("virtual_machine", "vm", "netbox_object"):
+                if key in item_dict:
+                    visit(item_dict[key])
+        elif isinstance(item, (list, tuple, set)):
+            for child in item:
+                visit(child)
+        else:
+            record = _record_to_dict(item)
+            if record is not None:
+                visit(record)
+
+    visit(value)
+    return touched
+
+
+async def find_orphan_vms(
+    nb: object,
+    run_id: str,
+    *,
+    vm_slugs: Iterable[str] = VM_DISCOVERY_TAG_SLUGS,
+) -> list[dict[str, object]]:
+    """Find Proxbox-discovered VMs not touched by the current run."""
+    if not run_id:
+        raise ValueError("run_id is required for orphan VM discovery")
+
+    candidates_by_id: dict[int, dict[str, object]] = {}
+    run_filter = f"cf_{LAST_RUN_ID_CUSTOM_FIELD}__nie"
+    empty_filter = f"cf_{LAST_RUN_ID_CUSTOM_FIELD}__empty"
+
+    for slug in dict.fromkeys(str(slug) for slug in vm_slugs if str(slug).strip()):
+        queries: tuple[dict[str, object], dict[str, object]] = (
+            {"tag": slug, run_filter: run_id},
+            {"tag": slug, empty_filter: True},
+        )
+        for query in queries:
+            records = await rest_list_paginated_async(
+                nb,
+                VIRTUAL_MACHINES_PATH,
+                base_query=query,
+                page_size=200,
+            )
+            for record in records:
+                data = _record_to_dict(record)
+                if data is None:
+                    continue
+                record_id = _coerce_int(data.get("id"))
+                if record_id is None:
+                    continue
+                candidates_by_id.setdefault(record_id, data)
+
+    return list(candidates_by_id.values())
+
+
+def _candidate_item(candidate: dict[str, object], *, run_id: str) -> dict[str, object]:
+    custom_fields = _custom_fields(candidate)
+    return {
+        "name": str(candidate.get("name") or candidate.get("display") or candidate.get("id")),
+        "type": "virtual_machine",
+        "netbox_id": _coerce_int(candidate.get("id")),
+        "netbox_url": candidate.get("display_url") or candidate.get("url"),
+        "extra": {
+            "reason": "orphan",
+            "run_id": run_id,
+            "stale_run_id": custom_fields.get(LAST_RUN_ID_CUSTOM_FIELD),
+            "tag_slugs": _tag_slugs(candidate),
+            "vmid": custom_fields.get("proxmox_vm_id"),
+        },
+    }
+
+
+def _item_extra(item: dict[str, object]) -> dict[str, object]:
+    extra = item.get("extra")
+    return cast(dict[str, object], extra) if isinstance(extra, dict) else {}
+
+
+def _is_not_found_error(error: Exception) -> bool:
+    if isinstance(error, ProxboxException):
+        text = " ".join(
+            str(part)
+            for part in (getattr(error, "message", ""), getattr(error, "detail", ""))
+            if part
+        ).lower()
+    else:
+        text = str(error).lower()
+    return "404" in text or "not found" in text
+
+
+async def _emit_summary(
+    stream: object | None,
+    *,
+    deleted: int,
+    failed: int,
+    skipped: int,
+    message: str,
+) -> None:
+    if stream is None:
+        return
+    emit_phase_summary = getattr(stream, "emit_phase_summary", None)
+    if not callable(emit_phase_summary):
+        return
+    await emit_phase_summary(
+        phase=ORPHAN_SWEEP_PHASE,
+        deleted=deleted,
+        failed=failed,
+        skipped=skipped,
+        message=message,
+    )
+
+
+async def _emit_item_progress(
+    stream: object | None,
+    *,
+    item: dict[str, object],
+    operation: ItemOperation,
+    status: str,
+    message: str,
+    progress_current: int,
+    progress_total: int,
+    error: str | None = None,
+    warning: str | None = None,
+) -> None:
+    if stream is None:
+        return
+    emit_item_progress = getattr(stream, "emit_item_progress", None)
+    if not callable(emit_item_progress):
+        return
+    await emit_item_progress(
+        phase=ORPHAN_SWEEP_PHASE,
+        item=item,
+        operation=operation,
+        status=status,
+        message=message,
+        progress_current=progress_current,
+        progress_total=progress_total,
+        error=error,
+        warning=warning,
+    )
+
+
+async def _abort_for_touched_candidates(
+    candidates: list[dict[str, object]],
+    *,
+    run_id: str,
+    touched_vm_ids: set[int],
+    stream: object | None,
+) -> None:
+    invalid = [
+        candidate
+        for candidate in candidates
+        if (record_id := _coerce_int(candidate.get("id"))) is not None
+        and record_id in touched_vm_ids
+    ]
+    if not invalid:
+        return
+
+    names = ", ".join(str(candidate.get("name") or candidate.get("id")) for candidate in invalid)
+    detail = (
+        "Refusing to sweep orphan VMs because candidates were also touched "
+        f"by this run_id={run_id}: {names}"
+    )
+    emit_error_detail = getattr(stream, "emit_error_detail", None) if stream is not None else None
+    if callable(emit_error_detail):
+        await emit_error_detail(
+            message="Orphan VM sweep invariant failed",
+            category=ErrorCategory.INTERNAL,
+            phase=ORPHAN_SWEEP_PHASE,
+            detail=detail,
+            suggestion="Check proxbox_last_run_id stamping before enabling orphan deletion.",
+        )
+    raise ProxboxException(message="Orphan VM sweep invariant failed", detail=detail)
+
+
+async def delete_orphan_vms(
+    nb: object,
+    candidates: Iterable[dict[str, object]],
+    *,
+    run_id: str,
+    dry_run: bool = False,
+    stream: object | None = None,
+    touched_vm_ids: set[int] | None = None,
+) -> dict[str, object]:
+    """Delete or preview stale Proxbox-managed VMs."""
+    candidate_list = list(candidates)
+    await _abort_for_touched_candidates(
+        candidate_list,
+        run_id=run_id,
+        touched_vm_ids=touched_vm_ids or set(),
+        stream=stream,
+    )
+
+    deleted = 0
+    failed = 0
+    skipped = 0
+    total = len(candidate_list)
+
+    for index, candidate in enumerate(candidate_list, start=1):
+        record_id = _coerce_int(candidate.get("id"))
+        item = _candidate_item(candidate, run_id=run_id)
+        item_extra = _item_extra(item)
+        name = str(item["name"])
+
+        if record_id is None:
+            skipped += 1
+            await _emit_item_progress(
+                stream,
+                item=item,
+                operation=ItemOperation.SKIPPED,
+                status="skipped",
+                message=f"Skipped orphan VM '{name}' because it has no NetBox ID",
+                progress_current=index,
+                progress_total=total,
+                warning="Missing NetBox object ID",
+            )
+            continue
+
+        if dry_run:
+            skipped += 1
+            await _emit_item_progress(
+                stream,
+                item=item,
+                operation=ItemOperation.WOULD_DELETE,
+                status="completed",
+                message=f"Would delete orphan VM '{name}'",
+                progress_current=index,
+                progress_total=total,
+            )
+            continue
+
+        try:
+            await rest_bulk_delete_async(nb, VIRTUAL_MACHINES_PATH, [record_id])
+        except Exception as error:
+            if _is_not_found_error(error):
+                skipped += 1
+                await _emit_item_progress(
+                    stream,
+                    item=item,
+                    operation=ItemOperation.SKIPPED,
+                    status="skipped",
+                    message=f"Skipped orphan VM '{name}' because it was already gone",
+                    progress_current=index,
+                    progress_total=total,
+                    warning=str(error),
+                )
+                continue
+
+            failed += 1
+            logger.exception(
+                "Failed to delete orphan VM id=%s name=%s run_id=%s stale_run_id=%s",
+                record_id,
+                name,
+                run_id,
+                item_extra.get("stale_run_id"),
+            )
+            await _emit_item_progress(
+                stream,
+                item=item,
+                operation=ItemOperation.FAILED,
+                status="failed",
+                message=f"Failed to delete orphan VM '{name}'",
+                progress_current=index,
+                progress_total=total,
+                error=str(error),
+            )
+            await _emit_summary(
+                stream,
+                deleted=deleted,
+                failed=failed,
+                skipped=skipped,
+                message=(
+                    f"Orphan VM sweep failed after deleting {deleted} of {total} candidate(s)"
+                ),
+            )
+            raise ProxboxException(
+                message="Error while sweeping orphan virtual machines.",
+                detail=str(error),
+            ) from error
+
+        deleted += 1
+        logger.info(
+            "Deleted orphan VM id=%s name=%s run_id=%s stale_run_id=%s tag_slugs=%s",
+            record_id,
+            name,
+            run_id,
+            item_extra.get("stale_run_id"),
+            item_extra.get("tag_slugs"),
+        )
+        await _emit_item_progress(
+            stream,
+            item=item,
+            operation=ItemOperation.DELETED,
+            status="completed",
+            message=f"Deleted orphan VM '{name}'",
+            progress_current=index,
+            progress_total=total,
+        )
+
+    message = (
+        f"Orphan VM sweep dry-run completed: {total} candidate(s), 0 deleted"
+        if dry_run
+        else f"Orphan VM sweep completed: {deleted} deleted, {skipped} skipped"
+    )
+    await _emit_summary(
+        stream,
+        deleted=deleted,
+        failed=failed,
+        skipped=skipped,
+        message=message,
+    )
+    return {
+        "run_id": run_id,
+        "dry_run": dry_run,
+        "candidates": total,
+        "deleted": deleted,
+        "failed": failed,
+        "skipped": skipped,
+    }
+
+
+async def run_orphan_vm_sweep(
+    nb: object,
+    *,
+    run_id: str,
+    enabled: bool,
+    dry_run: bool = False,
+    stream: object | None = None,
+    touched_vm_ids: set[int] | None = None,
+) -> dict[str, object]:
+    """Run the orphan VM sweep when enabled or preview it in dry-run mode."""
+    if not enabled and not dry_run:
+        return {
+            "enabled": False,
+            "run_id": run_id,
+            "dry_run": False,
+            "candidates": 0,
+            "deleted": 0,
+            "failed": 0,
+            "skipped": 0,
+        }
+
+    candidates = await find_orphan_vms(nb, run_id)
+    result = await delete_orphan_vms(
+        nb,
+        candidates,
+        run_id=run_id,
+        dry_run=dry_run,
+        stream=stream,
+        touched_vm_ids=touched_vm_ids,
+    )
+    return {"enabled": enabled, **result}

--- a/tests/test_orphan_sweep.py
+++ b/tests/test_orphan_sweep.py
@@ -1,0 +1,275 @@
+"""Tests for Proxbox-managed VM orphan sweeping."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from proxbox_api.constants import DISCOVERY_TAG_VM_LXC, DISCOVERY_TAG_VM_QEMU
+from proxbox_api.exception import ProxboxException
+from proxbox_api.schemas.stream_messages import ItemOperation
+from proxbox_api.services.sync import orphan_sweep
+from proxbox_api.services.sync.orphan_sweep import (
+    delete_orphan_vms,
+    extract_touched_vm_ids,
+    find_orphan_vms,
+    run_orphan_vm_sweep,
+)
+from proxbox_api.services.sync.vm_helpers import LAST_RUN_ID_CUSTOM_FIELD
+
+
+def _vm(
+    record_id: int,
+    name: str,
+    *,
+    run_id: str | None = "old-run",
+    tag_slug: str = DISCOVERY_TAG_VM_QEMU,
+) -> dict[str, object]:
+    return {
+        "id": record_id,
+        "name": name,
+        "display_url": f"/virtualization/virtual-machines/{record_id}/",
+        "custom_fields": {
+            LAST_RUN_ID_CUSTOM_FIELD: run_id,
+            "proxmox_vm_id": record_id + 1000,
+        },
+        "tags": [{"slug": tag_slug}],
+    }
+
+
+class _Bridge:
+    def __init__(self) -> None:
+        self.item_progress: list[dict[str, Any]] = []
+        self.phase_summary: list[dict[str, Any]] = []
+        self.error_detail: list[dict[str, Any]] = []
+
+    async def emit_item_progress(self, **kwargs: Any) -> None:
+        self.item_progress.append(kwargs)
+
+    async def emit_phase_summary(self, **kwargs: Any) -> None:
+        self.phase_summary.append(kwargs)
+
+    async def emit_error_detail(self, **kwargs: Any) -> None:
+        self.error_detail.append(kwargs)
+
+
+@pytest.mark.asyncio
+async def test_find_orphan_vms_uses_vm_discovery_slugs_and_stamp_filters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Candidates are selected by VM discovery tag and stale/missing run ID."""
+    calls: list[dict[str, object]] = []
+
+    async def _fake_list(_nb: object, _path: str, *, base_query: dict[str, object], **_: Any):
+        calls.append(base_query)
+        if base_query.get("tag") == DISCOVERY_TAG_VM_QEMU and base_query.get(
+            f"cf_{LAST_RUN_ID_CUSTOM_FIELD}__nie"
+        ):
+            return [_vm(1, "stale-qemu")]
+        if base_query.get("tag") == DISCOVERY_TAG_VM_LXC and base_query.get(
+            f"cf_{LAST_RUN_ID_CUSTOM_FIELD}__empty"
+        ):
+            return [_vm(2, "missing-lxc", run_id=None, tag_slug=DISCOVERY_TAG_VM_LXC)]
+        if base_query.get("tag") == DISCOVERY_TAG_VM_LXC and base_query.get(
+            f"cf_{LAST_RUN_ID_CUSTOM_FIELD}__nie"
+        ):
+            return [_vm(1, "duplicate-qemu")]
+        return []
+
+    monkeypatch.setattr(orphan_sweep, "rest_list_paginated_async", _fake_list)
+
+    candidates = await find_orphan_vms(object(), "current-run")
+
+    assert [candidate["id"] for candidate in candidates] == [1, 2]
+    assert {call["tag"] for call in calls} == {
+        DISCOVERY_TAG_VM_QEMU,
+        DISCOVERY_TAG_VM_LXC,
+    }
+    assert all("proxbox-discovered-cluster" not in str(call) for call in calls)
+    assert any(f"cf_{LAST_RUN_ID_CUSTOM_FIELD}__nie" in call for call in calls)
+    assert any(call.get(f"cf_{LAST_RUN_ID_CUSTOM_FIELD}__empty") is True for call in calls)
+
+
+@pytest.mark.asyncio
+async def test_delete_orphan_vms_deletes_candidates_and_emits_progress(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deleted_ids: list[int] = []
+
+    async def _fake_delete(_nb: object, path: str, ids: list[int]) -> int:
+        assert path == orphan_sweep.VIRTUAL_MACHINES_PATH
+        deleted_ids.extend(ids)
+        return len(ids)
+
+    monkeypatch.setattr(orphan_sweep, "rest_bulk_delete_async", _fake_delete)
+    bridge = _Bridge()
+
+    result = await delete_orphan_vms(
+        object(),
+        [_vm(1, "stale-a"), _vm(2, "stale-b", tag_slug=DISCOVERY_TAG_VM_LXC)],
+        run_id="current-run",
+        stream=bridge,
+    )
+
+    assert deleted_ids == [1, 2]
+    assert result == {
+        "run_id": "current-run",
+        "dry_run": False,
+        "candidates": 2,
+        "deleted": 2,
+        "failed": 0,
+        "skipped": 0,
+    }
+    assert [event["operation"] for event in bridge.item_progress] == [
+        ItemOperation.DELETED,
+        ItemOperation.DELETED,
+    ]
+    assert bridge.phase_summary[-1]["deleted"] == 2
+
+
+@pytest.mark.asyncio
+async def test_delete_orphan_vms_dry_run_emits_would_delete_without_delete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _unexpected_delete(*_args: Any, **_kwargs: Any) -> int:
+        raise AssertionError("dry-run must not delete")
+
+    monkeypatch.setattr(orphan_sweep, "rest_bulk_delete_async", _unexpected_delete)
+    bridge = _Bridge()
+
+    result = await delete_orphan_vms(
+        object(),
+        [_vm(1, "preview-a"), _vm(2, "preview-b")],
+        run_id="current-run",
+        dry_run=True,
+        stream=bridge,
+    )
+
+    assert result["deleted"] == 0
+    assert result["skipped"] == 2
+    assert [event["operation"] for event in bridge.item_progress] == [
+        ItemOperation.WOULD_DELETE,
+        ItemOperation.WOULD_DELETE,
+    ]
+    assert bridge.phase_summary[-1]["skipped"] == 2
+
+
+@pytest.mark.asyncio
+async def test_delete_orphan_vms_skips_not_found_delete_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_delete(_nb: object, _path: str, _ids: list[int]) -> int:
+        raise ProxboxException(message="NetBox REST request failed", detail="404 not found")
+
+    monkeypatch.setattr(orphan_sweep, "rest_bulk_delete_async", _fake_delete)
+    bridge = _Bridge()
+
+    result = await delete_orphan_vms(
+        object(),
+        [_vm(1, "already-gone")],
+        run_id="current-run",
+        stream=bridge,
+    )
+
+    assert result["deleted"] == 0
+    assert result["failed"] == 0
+    assert result["skipped"] == 1
+    assert bridge.item_progress[0]["operation"] == ItemOperation.SKIPPED
+
+
+@pytest.mark.asyncio
+async def test_delete_orphan_vms_raises_on_hard_delete_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_delete(_nb: object, _path: str, _ids: list[int]) -> int:
+        raise RuntimeError("permission denied")
+
+    monkeypatch.setattr(orphan_sweep, "rest_bulk_delete_async", _fake_delete)
+    bridge = _Bridge()
+
+    with pytest.raises(ProxboxException, match="Error while sweeping orphan"):
+        await delete_orphan_vms(
+            object(),
+            [_vm(1, "blocked")],
+            run_id="current-run",
+            stream=bridge,
+        )
+
+    assert bridge.item_progress[0]["operation"] == ItemOperation.FAILED
+    assert bridge.phase_summary[-1]["failed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_orphan_vms_aborts_when_candidate_was_touched_this_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _unexpected_delete(*_args: Any, **_kwargs: Any) -> int:
+        raise AssertionError("stamp invariant failure must abort before deleting")
+
+    monkeypatch.setattr(orphan_sweep, "rest_bulk_delete_async", _unexpected_delete)
+    bridge = _Bridge()
+
+    with pytest.raises(ProxboxException, match="invariant failed"):
+        await delete_orphan_vms(
+            object(),
+            [_vm(42, "bad-candidate", run_id=None)],
+            run_id="current-run",
+            stream=bridge,
+            touched_vm_ids={42},
+        )
+
+    assert bridge.error_detail
+    assert bridge.error_detail[0]["phase"] == orphan_sweep.ORPHAN_SWEEP_PHASE
+
+
+@pytest.mark.asyncio
+async def test_run_orphan_vm_sweep_disabled_does_not_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _unexpected_find(*_args: Any, **_kwargs: Any) -> list[dict[str, object]]:
+        raise AssertionError("disabled sweep must not query")
+
+    monkeypatch.setattr(orphan_sweep, "find_orphan_vms", _unexpected_find)
+
+    result = await run_orphan_vm_sweep(object(), run_id="current-run", enabled=False)
+
+    assert result["enabled"] is False
+    assert result["candidates"] == 0
+    assert result["deleted"] == 0
+
+
+@pytest.mark.asyncio
+async def test_run_orphan_vm_sweep_dry_run_previews_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_find(_nb: object, _run_id: str):
+        return [_vm(1, "preview")]
+
+    async def _unexpected_delete(*_args: Any, **_kwargs: Any) -> int:
+        raise AssertionError("dry-run must not delete")
+
+    monkeypatch.setattr(orphan_sweep, "find_orphan_vms", _fake_find)
+    monkeypatch.setattr(orphan_sweep, "rest_bulk_delete_async", _unexpected_delete)
+
+    result = await run_orphan_vm_sweep(
+        object(),
+        run_id="current-run",
+        enabled=False,
+        dry_run=True,
+    )
+
+    assert result["enabled"] is False
+    assert result["dry_run"] is True
+    assert result["candidates"] == 1
+    assert result["deleted"] == 0
+
+
+def test_extract_touched_vm_ids_handles_nested_sync_results() -> None:
+    payload = [
+        {"id": "10", "name": "vm-a"},
+        {"virtual_machine": {"id": 11}},
+        [{"netbox_object": {"id": 12}}],
+    ]
+
+    assert extract_touched_vm_ids(payload) == {10, 11, 12}


### PR DESCRIPTION
## Summary

Implements Sub-PR B for emersonfelipesp/netbox-proxbox#367, stacked on Sub-PR A.

- adds an orphan VM sweep service that selects Proxbox-discovered QEMU/LXC VMs with stale or missing `proxbox_last_run_id`
- deletes candidates at the end of full-update only when `delete_orphans` resolves true
- adds `/full-update/stream?dry_run=true` preview mode that emits `would_delete` item progress and sends zero DELETE requests
- aborts the sweep if any delete candidate was also touched during the current run, which catches stamp failures before destructive cleanup
- reuses `item_progress` and `phase_summary` SSE taxonomy

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check proxbox_api/types proxbox_api/utils/retry.py proxbox_api/schemas/sync.py proxbox_api/services/sync/orphan_sweep.py`
- `uv run pytest tests/test_orphan_sweep.py tests/test_proxbox_last_run_id_stamp.py tests/test_vm_sync.py tests/test_individual_sync.py tests/test_api_routes.py tests/test_patchable_fields.py tests/test_streaming_detailed_messages.py tests/test_sse_stream_output.py tests/test_plugin_integration.py -q`