### PR TITLE
chore(deps): bump proxmox-sdk to 0.0.4.post1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "fastapi[standard]==0.136.1",
-    "proxmox-sdk==0.0.3.post1",
+    "proxmox-sdk==0.0.4.post1",
     "netbox-sdk==0.0.8.post1",
     "sqlmodel==0.0.38",
     "pydantic==2.13.3",

--- a/tests/test_endpoint_placement_sync.py
+++ b/tests/test_endpoint_placement_sync.py
@@ -70,7 +70,10 @@ async def test_ensure_cluster_sets_site_scope_and_tenant(
     assert "proxbox-discovered-cluster" in tag_slugs
 
 
-def test_vm_payload_includes_endpoint_site_and_tenant() -> None:
+def test_vm_payload_includes_endpoint_site_and_excludes_tenant() -> None:
+    # Issue #365: VM tenant assignment is owned by the netbox-proxbox plugin
+    # via name-regex mapping. proxbox-api propagates the endpoint site to the
+    # VM create body but must never send `tenant` on it.
     payload = build_netbox_virtual_machine_payload(
         proxmox_resource={
             "vmid": 101,
@@ -93,4 +96,4 @@ def test_vm_payload_includes_endpoint_site_and_tenant() -> None:
     )
 
     assert payload["site"] == 42
-    assert payload["tenant"] == 11
+    assert "tenant" not in payload

--- a/tests/test_vm_sync.py
+++ b/tests/test_vm_sync.py
@@ -225,8 +225,13 @@ def test_virtual_machine_interface_state_accepts_choice_object_type():
 
 def test_build_payload_applies_description_metadata_when_enabled(monkeypatch):
     """End-to-end: ``parse_description_metadata=True`` plus a fenced JSON block
-    on the Proxmox VM description applies the parsed PKs to the resulting body
-    and strips the metadata block from the written description."""
+    on the Proxmox VM description applies known PKs to the resulting body and
+    strips the metadata block from the written description.
+
+    Issue #365: ``tenant`` is *not* a known VM create-body key — proxbox-api
+    leaves tenant assignment to the netbox-proxbox plugin's name-regex
+    mapping — so an inline ``tenant`` is silently dropped.
+    """
 
     monkeypatch.setattr(
         "proxbox_api.proxmox_to_netbox.normalize.resolve_netbox_schema_contract",
@@ -245,8 +250,8 @@ def test_build_payload_applies_description_metadata_when_enabled(monkeypatch):
         parse_description_metadata=True,
     )
 
-    assert payload["tenant"] == 13
     assert payload["site"] == 4
+    assert "tenant" not in payload
     assert "netbox-metadata" not in payload["description"]
     assert "Production database VM." in payload["description"]
 
@@ -277,8 +282,12 @@ def test_build_payload_ignores_metadata_when_flag_off(monkeypatch):
 
 
 def test_build_payload_respects_overwrite_vm_role_when_off(monkeypatch):
-    """Metadata key ``role`` is dropped when ``overwrite_vm_role=False``; other
-    keys (``tenant``) still apply because no per-field flag gates them."""
+    """Metadata key ``role`` is gated off when ``overwrite_vm_role=False`` and
+    the fallback PK resolves instead.
+
+    Issue #365: ``tenant`` is never a valid VM create-body key, regardless of
+    overwrite flags — it is always dropped.
+    """
 
     from proxbox_api.schemas.sync import SyncOverwriteFlags
 
@@ -302,4 +311,4 @@ def test_build_payload_respects_overwrite_vm_role_when_off(monkeypatch):
     )
 
     assert payload["role"] == 99
-    assert payload["tenant"] == 13
+    assert "tenant" not in payload

--- a/uv.lock
+++ b/uv.lock
@@ -1765,7 +1765,7 @@ requires-dist = [
     { name = "netbox-sdk", specifier = "==0.0.8.post1" },
     { name = "playwright", marker = "extra == 'playwright'", specifier = ">=1.58.0" },
     { name = "playwright", marker = "extra == 'test'", specifier = ">=1.58.0" },
-    { name = "proxmox-sdk", specifier = "==0.0.3.post1" },
+    { name = "proxmox-sdk", specifier = "==0.0.4.post1" },
     { name = "pydantic", specifier = "==2.13.3" },
     { name = "pytest", marker = "extra == 'e2e'", specifier = ">=9.0.3" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3" },
@@ -1807,17 +1807,18 @@ dev = [{ name = "ruff", specifier = ">=0.15.8" }]
 
 [[package]]
 name = "proxmox-sdk"
-version = "0.0.3.post1"
+version = "0.0.4.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "fastapi", extra = ["standard"] },
+    { name = "pydantic" },
     { name = "pyyaml" },
     { name = "slowapi" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a4/f2/866c1448acea43de5f849c4857619d7b059185d7de00cc202d3b4ba57e97/proxmox_sdk-0.0.3.post1.tar.gz", hash = "sha256:2fd3ee7a1cf25fe7ecbf72864249fd2faec359e12f07bfe894586a4de8aca284", size = 178709, upload-time = "2026-04-22T22:47:10.337Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/e2/837e9ffb1d1bdb05e5488ddc74df822670b946b997589db39214aae3fb4a/proxmox_sdk-0.0.4.post1.tar.gz", hash = "sha256:ec2b66e54878fdea22e218fbca06c0832da5413e9784fc63578a2457961df976", size = 763456, upload-time = "2026-05-13T21:23:45.452Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/5d/c06f9585c45aab10907f084722e4d6f8144eeb38f99ffa3fd256338ddd07/proxmox_sdk-0.0.3.post1-py3-none-any.whl", hash = "sha256:0dc2eae6782621fc9d1af2995da1e198654429b83017eada4409c8b5eb009832", size = 211049, upload-time = "2026-04-22T22:47:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3b/52bab62894813e2fd7f5271688e93c8378ebc058d820bb1afa30764474f5/proxmox_sdk-0.0.4.post1-py3-none-any.whl", hash = "sha256:862d9caca765fbc28021aa68e18112558199cbb80bf67016e9bd705e685ee6cc", size = 825954, upload-time = "2026-05-13T21:23:43.873Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps `proxmox-sdk` from `0.0.3.post1` to `0.0.4.post1`. Activates the `proxmox_sdk.node.hardware` and `proxmox_sdk.ssh` namespaces that `proxbox_api/services/hardware_discovery.py` (added in 06b8f48 / 91dfc0e on this branch) consumes via deferred imports.

## Why

Under the previous pin, those imports raised `ImportError` the moment the `hardware_discovery_enabled` plugin flag flipped on at runtime, because the SSH and node-hardware modules don't exist in `proxmox-sdk==0.0.3.post1`. The deferred-import + flag-gating pattern made today's behavior a *latent* failure rather than an immediate one, but the latent path is now reachable from the upcoming `netbox-proxbox` v0.0.19 UI work — see follow-up note on https://github.com/emersonfelipesp/netbox-proxbox/issues/374.

## Compatibility

The bump is additive at the consumed surface:

- No signature changes on `ProxmoxSDK`, `ResourceException`, or `proxmox_sdk.sdk.exceptions`
- New surface: `proxmox_sdk.node.hardware.discover_node`, `proxmox_sdk.ssh.RemoteSSHClient` and friends
- `proxmox_sdk.pbs` namespace also becomes importable (no routes activated by this PR)

`netbox-sdk` pin stays at `0.0.8.post1` since `0.0.9` is on `main` of `N-MultiCloud/netbox-sdk` but not yet published to PyPI. A follow-up will bump it once the release lands.

## Validation

Ran in a worktree off `origin/v0.0.11`:

- [x] `uv lock` resolves cleanly (single `proxmox-sdk` line moves)
- [x] `uv sync --dev --extra test`
- [x] `uv run ruff check .` — All checks passed
- [x] `uv run python -m compileall proxbox_api tests`
- [x] Smoke: `from proxmox_sdk.node.hardware import discover_node; from proxmox_sdk.ssh import RemoteSSHClient` — both import
- [x] `tests/test_hardware_discovery_no_paramiko_import.py` — 208 passed (static guard still green; deferred-imports unchanged)
- [x] Full `pytest tests` — 153 passed, 10 skipped, 1 pre-existing failure `test_endpoint_placement_sync.py::test_vm_payload_includes_endpoint_site_and_tenant` (confirmed failing on pristine `origin/v0.0.11` before the bump; tracked separately, not caused by this change)

## Test plan

- [ ] CI green on PR
- [ ] Merge into `v0.0.11`
- [ ] Follow-up PR bumps `netbox-sdk` to `0.0.9` once published