### PR TITLE
fix(session): PVE 9 401 detail + close abandoned SDK sessions (#417)

### DIFF
--- a/docs/development/troubleshooting.md
+++ b/docs/development/troubleshooting.md
@@ -111,6 +111,21 @@ Resolution:
 - Confirm API user/token permissions in Proxmox.
 - For multi-endpoint deployments, confirm the correct `source` and endpoint target selection values are being passed.
 
+### Reading the new PVE 9 auth-failure detail (issue #417)
+
+Symptom:
+
+- `HTTP 401 Authentication failed!` against a Proxmox VE 9.x cluster, with a `Detail` field that used to read `"Unknown error."`.
+
+Resolution:
+
+- The `Detail` shown in the NetBox UI now mirrors the upstream PVE response. Read it as `HTTP <code> <status> — <body> — <errors JSON>`:
+  - `no such realm` → the `user@realm` you typed is wrong (`root@pam` vs `root@pve` vs the realm name configured on the cluster).
+  - `permission check failed` → role is missing `VM.GuestAgent.Audit` (PVE 9), `Datastore.Audit`, `Sys.Audit`, or `VM.Audit`.
+  - `authentication failure` → password or token value is wrong, or has expired / been rotated on the Proxmox side.
+- Stored credentials are no longer leaked into auth attempts after a credential switch: on the NetBox-side endpoint edit form, use the **"Clear stored API token on save"** and **"Clear stored password on save"** checkboxes to wipe the unused secret before saving. The form rejects rows that end up with neither a password nor a complete `(token name, token value)` pair.
+- The aiohttp `ClientSession` is now closed on every auth failure path (domain probe, IP fallback, both attempts failing). If you still see `Unclosed client session` warnings in proxbox-api logs after an auth failure, you are running an older build — re-check the installed package version.
+
 ## Sync endpoints return partial data
 
 Symptom:

--- a/proxbox_api/session/proxmox_core.py
+++ b/proxbox_api/session/proxmox_core.py
@@ -259,11 +259,13 @@ class ProxmoxSession:
         if self.domain:
             logger.info("Using %s to authenticate with Proxmox", auth_method)
             logger.info("Using domain %s to authenticate with Proxmox", self.domain)
+            proxmox_session = None
             try:
                 proxmox_session = _proxmox_api_factory()(self.domain, **kwargs)
                 self.version = await resolve_async(proxmox_session.version.get())
                 return proxmox_session
             except Exception as error:
+                await self._close_abandoned_sdk(proxmox_session)
                 logger.info(
                     "Proxmox connection using domain failed, trying IP %s: %s",
                     self.ip_address,
@@ -271,17 +273,74 @@ class ProxmoxSession:
                 )
 
         # Fallback to IP address
+        logger.info("Using IP %s to authenticate with Proxmox", self.ip_address)
+        proxmox_session = None
         try:
-            logger.info("Using IP %s to authenticate with Proxmox", self.ip_address)
             proxmox_session = _proxmox_api_factory()(self.ip_address, **kwargs)
             self.version = await resolve_async(proxmox_session.version.get())
             return proxmox_session
         except Exception as error:
+            await self._close_abandoned_sdk(proxmox_session)
+            detail = self._describe_auth_error(error)
             raise ProxboxException(
                 message=error_message,
-                detail="Unknown error.",
+                detail=detail,
                 python_exception=f"{error}",
             ) from error
+
+    @staticmethod
+    async def _close_abandoned_sdk(sdk: ProxmoxSDK | None) -> None:
+        """Close an SDK instance whose initial probe failed.
+
+        Mirrors :meth:`aclose` for an SDK that never became ``self.session``.
+        Without this, the underlying ``aiohttp.ClientSession`` leaks on every
+        retry and floods the log with ``Unclosed client session`` errors.
+        """
+        if sdk is None or not hasattr(sdk, "close"):
+            return
+        try:
+            close_result = sdk.close()
+            if inspect.isawaitable(close_result):
+                await close_result
+        except Exception as close_error:  # pragma: no cover - defensive
+            logger.debug("Error closing abandoned Proxmox SDK session: %s", close_error)
+
+    @staticmethod
+    def _describe_auth_error(error: Exception) -> str:
+        """Map a Proxmox SDK auth failure to a user-visible detail string.
+
+        When the SDK raises ``ResourceException``, surface the upstream
+        status code, the Proxmox response body, and any structured
+        ``errors`` dict so operators can distinguish wrong-realm,
+        expired-token, missing-privilege, and connection failures.
+        """
+        try:
+            from proxmox_sdk.sdk.exceptions import ResourceException
+        except Exception:  # pragma: no cover - defensive import guard
+            ResourceException = ()  # type: ignore[assignment]
+
+        if isinstance(error, ResourceException):
+            status_code = getattr(error, "status_code", None)
+            status_message = getattr(error, "status_message", "") or ""
+            content = (getattr(error, "content", "") or "").strip()
+            errors = getattr(error, "errors", None)
+            parts: list[str] = []
+            if status_code:
+                parts.append(f"HTTP {status_code} {status_message}".strip())
+            elif status_message:
+                parts.append(status_message)
+            if content:
+                parts.append(content)
+            if errors:
+                try:
+                    parts.append(json.dumps(errors, sort_keys=True))
+                except (TypeError, ValueError):
+                    parts.append(str(errors))
+            if parts:
+                return " — ".join(parts)
+
+        text = str(error).strip()
+        return text or "Unknown error."
 
     def _build_auth_kwargs(self, auth_method: str) -> dict[str, object]:
         """Build authentication kwargs for Proxmox API."""

--- a/scripts/pve9_live_smoketest.py
+++ b/scripts/pve9_live_smoketest.py
@@ -1,0 +1,156 @@
+"""Live PVE 9.1.1 smoke-test for the issue #417 auth fixes.
+
+Runs scenarios against the real Proxmox VE 9.1.1 host so we can confirm the
+three on-our-side regressions are gone:
+
+1. Token auth, valid credentials — expect Authentication: Success, version 9.x.
+2. Token auth, deliberately broken secret — expect the new structured detail
+   (PVE upstream error text), not "Unknown error."; and zero
+   "Unclosed client session" lines from aiohttp.
+
+The host secret is read from environment variables that the wrapper exports
+from .hosts-env. The secret is never echoed, logged, or written to disk.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+import warnings
+from typing import Any
+
+LOG_BUFFER: list[str] = []
+
+
+class _BufferHandler(logging.Handler):
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            LOG_BUFFER.append(self.format(record))
+        except Exception:
+            self.handleError(record)
+
+
+def _install_log_capture() -> None:
+    fmt = logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s")
+    handler = _BufferHandler()
+    handler.setFormatter(fmt)
+    handler.setLevel(logging.DEBUG)
+    root = logging.getLogger()
+    root.addHandler(handler)
+    root.setLevel(logging.DEBUG)
+    logging.captureWarnings(True)
+    warnings.simplefilter("always", ResourceWarning)
+
+
+def _scrub(value: str) -> str:
+    secret = os.environ.get("PROXMOX_SECRET", "")
+    return value.replace(secret, "<redacted>") if secret else value
+
+
+def _build_cluster_config(*, sabotage_token: bool) -> dict[str, Any]:
+    host = os.environ["PROXMOX_HOST"]
+    user = os.environ["PROXMOX_USER"]
+    token_name = os.environ["PROXMOX_TOKEN_ID"]
+    token_value = os.environ["PROXMOX_SECRET"]
+    if sabotage_token:
+        token_value = "00000000-0000-0000-0000-000000000000"
+    return {
+        "name": "pve9-live",
+        "ip_address": host,
+        "domain": host,
+        "http_port": 8006,
+        "user": user,
+        "password": None,
+        "token": {"name": token_name, "value": token_value},
+        "ssl": False,
+        "timeout": 10,
+    }
+
+
+async def _run_scenario(name: str, *, sabotage_token: bool = False) -> dict[str, Any]:
+    from proxbox_api.session.proxmox_core import ProxmoxSession
+
+    cluster_config = _build_cluster_config(sabotage_token=sabotage_token)
+
+    result: dict[str, Any] = {
+        "scenario": name,
+        "ok": False,
+        "version": None,
+        "auth_method": None,
+        "detail": None,
+        "exception_type": None,
+    }
+    session = None
+    before_logs = len(LOG_BUFFER)
+    try:
+        session = await ProxmoxSession.create(cluster_config)
+        result["ok"] = True
+        result["version"] = session.version
+        result["auth_method"] = (
+            "token" if cluster_config["token"]["name"] and cluster_config["token"]["value"] else "password"
+        )
+    except Exception as exc:
+        result["exception_type"] = type(exc).__name__
+        result["detail"] = _scrub(str(exc))[:800]
+    finally:
+        if session is not None:
+            try:
+                await session.aclose()
+            except Exception:
+                pass
+
+    new_lines = LOG_BUFFER[before_logs:]
+    result["unclosed_session_log_lines"] = sum(
+        1 for line in new_lines if "Unclosed client session" in line
+    )
+    result["unclosed_connector_log_lines"] = sum(
+        1 for line in new_lines if "Unclosed connector" in line
+    )
+    return result
+
+
+async def main() -> int:
+    _install_log_capture()
+    scenarios = [
+        ("token_valid", False),
+        ("token_sabotaged", True),
+    ]
+    print("=" * 60)
+    print(f"PVE host: {os.environ.get('PROXMOX_HOST')}   user: {os.environ.get('PROXMOX_USER')}")
+    print(f"Token ID: {os.environ.get('PROXMOX_TOKEN_ID')}   secret: <redacted>")
+    print("=" * 60)
+    overall_ok = True
+    for sname, sabotage in scenarios:
+        res = await _run_scenario(sname, sabotage_token=sabotage)
+        print(f"\n--- scenario: {sname} ---")
+        for k, v in res.items():
+            if k == "version" and isinstance(v, dict):
+                trimmed = {kk: v.get(kk) for kk in ("version", "release", "repoid") if kk in v}
+                print(f"  {k}: {trimmed}")
+            else:
+                print(f"  {k}: {v}")
+        if sname == "token_valid":
+            ver = res["version"]
+            ver_str = ""
+            if isinstance(ver, dict):
+                ver_str = str(ver.get("version", ""))
+            elif ver is not None:
+                ver_str = str(ver)
+            overall_ok &= bool(res["ok"]) and ver_str.startswith("9.")
+        if sname == "token_sabotaged":
+            overall_ok &= (
+                not res["ok"]
+                and "Unknown error" not in (res["detail"] or "")
+                and res["unclosed_session_log_lines"] == 0
+                and res["unclosed_connector_log_lines"] == 0
+            )
+    print("\n" + "=" * 60)
+    print(f"OVERALL: {'PASS' if overall_ok else 'FAIL'}")
+    print("=" * 60)
+    return 0 if overall_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/scripts/pve9_live_smoketest.py
+++ b/scripts/pve9_live_smoketest.py
@@ -89,7 +89,9 @@ async def _run_scenario(name: str, *, sabotage_token: bool = False) -> dict[str,
         result["ok"] = True
         result["version"] = session.version
         result["auth_method"] = (
-            "token" if cluster_config["token"]["name"] and cluster_config["token"]["value"] else "password"
+            "token"
+            if cluster_config["token"]["name"] and cluster_config["token"]["value"]
+            else "password"
         )
     except Exception as exc:
         result["exception_type"] = type(exc).__name__

--- a/tests/test_proxmox_auth_pve9.py
+++ b/tests/test_proxmox_auth_pve9.py
@@ -1,0 +1,196 @@
+"""Mock-driven Proxmox VE 9 auth regression tests.
+
+Covers the three compounding bugs documented in
+``emersonfelipesp/netbox-proxbox#417``:
+
+* the abandoned ``aiohttp.ClientSession`` is closed on every retry path
+  in :meth:`ProxmoxSession._auth_async`;
+* a 401 from PVE 9 surfaces the upstream status, body, and structured
+  ``errors`` dict in :class:`~proxbox_api.exception.ProxboxException`
+  instead of ``"Unknown error."``;
+* the session reports the PVE 9 version when the version probe succeeds.
+"""
+
+from __future__ import annotations
+
+import pytest
+from proxmox_sdk.sdk.exceptions import ResourceException
+
+from proxbox_api.exception import ProxboxException
+from proxbox_api.session.proxmox import ProxmoxSession
+
+
+class FakeVersionResource:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def get(self):
+        return self.payload
+
+
+class FakeClusterStatusResource:
+    def get(self):
+        return [
+            {"type": "cluster", "name": "pve9-lab"},
+            {"type": "node", "name": "pve9-node01"},
+        ]
+
+
+class FakeJoinResource:
+    def get(self):
+        return {"nodelist": [{"pve_fp": "PVE9-FINGERPRINT"}]}
+
+
+class FakePve9ProxmoxAPI:
+    """SDK fake that advertises PVE 9.1.11 and records close() calls."""
+
+    instances: list[FakePve9ProxmoxAPI] = []
+
+    def __init__(self, host, **kwargs):
+        self.host = host
+        self.kwargs = kwargs
+        self.closed = False
+        self.version = FakeVersionResource(
+            {"version": "9.1.11", "release": "9.1-11", "repoid": "abc123"}
+        )
+        FakePve9ProxmoxAPI.instances.append(self)
+
+    def __call__(self, path):
+        if path == "cluster/status":
+            return FakeClusterStatusResource()
+        if path == "cluster/config/join":
+            return FakeJoinResource()
+        raise AssertionError(f"unexpected path {path}")
+
+    async def close(self):
+        self.closed = True
+
+
+class FakePve9AuthRejectedAPI(FakePve9ProxmoxAPI):
+    """SDK fake that raises a PVE 9 styled 401 on the version probe."""
+
+    def __init__(self, host, **kwargs):
+        super().__init__(host, **kwargs)
+        self.version = self  # raise on ``.get()``
+
+    def get(self):
+        raise ResourceException(
+            status_code=401,
+            status_message="Authentication failed",
+            content='{"data":null,"errors":{"PVE":"Authentication failed"}}',
+            errors={"PVE": "Authentication failed"},
+        )
+
+
+class FakeDomainFailsThenIpSucceedsAPI(FakePve9ProxmoxAPI):
+    """Domain attempt raises so the IP attempt fallback runs."""
+
+    def __init__(self, host, **kwargs):
+        super().__init__(host, **kwargs)
+        if host == "pve9.example.com":
+            self.version = self  # raise on ``.get()`` for the domain attempt
+
+    def get(self):  # only used for the domain attempt
+        raise RuntimeError("simulated domain DNS failure")
+
+
+@pytest.fixture(autouse=True)
+def reset_instances():
+    FakePve9ProxmoxAPI.instances.clear()
+    yield
+    FakePve9ProxmoxAPI.instances.clear()
+
+
+def test_session_reports_pve9_version_via_token_auth(monkeypatch):
+    monkeypatch.setattr("proxbox_api.session.proxmox.ProxmoxAPI", FakePve9ProxmoxAPI)
+
+    session = ProxmoxSession(
+        {
+            "ip_address": "10.0.30.10",
+            "domain": "pve9.example.com",
+            "http_port": 8006,
+            "user": "root@pam",
+            "password": None,
+            "token": {"name": "proxbox", "value": "pve9-secret"},
+            "ssl": False,
+        }
+    )
+
+    assert session.CONNECTED is True
+    assert session.version == {
+        "version": "9.1.11",
+        "release": "9.1-11",
+        "repoid": "abc123",
+    }
+    assert session.name == "pve9-lab"
+
+
+def test_auth_failure_surfaces_upstream_pve_error(monkeypatch):
+    monkeypatch.setattr("proxbox_api.session.proxmox.ProxmoxAPI", FakePve9AuthRejectedAPI)
+
+    with pytest.raises(ProxboxException) as exc_info:
+        ProxmoxSession(
+            {
+                "ip_address": "10.0.30.10",
+                "domain": None,
+                "http_port": 8006,
+                "user": "root@pam",
+                "password": None,
+                "token": {"name": "proxbox", "value": "stale-token"},
+                "ssl": False,
+            }
+        )
+
+    detail = exc_info.value.detail or ""
+    assert "Unknown error." not in detail
+    assert "401" in detail
+    assert "Authentication failed" in detail
+    assert "PVE" in detail
+
+
+def test_abandoned_sdk_is_closed_on_domain_fallback(monkeypatch):
+    monkeypatch.setattr(
+        "proxbox_api.session.proxmox.ProxmoxAPI", FakeDomainFailsThenIpSucceedsAPI
+    )
+
+    session = ProxmoxSession(
+        {
+            "ip_address": "10.0.30.10",
+            "domain": "pve9.example.com",
+            "http_port": 8006,
+            "user": "root@pam",
+            "password": None,
+            "token": {"name": "proxbox", "value": "pve9-secret"},
+            "ssl": False,
+        }
+    )
+
+    assert session.CONNECTED is True
+    domain_attempts = [
+        sdk for sdk in FakePve9ProxmoxAPI.instances if sdk.host == "pve9.example.com"
+    ]
+    ip_attempts = [sdk for sdk in FakePve9ProxmoxAPI.instances if sdk.host == "10.0.30.10"]
+    assert len(domain_attempts) == 1, "exactly one domain attempt expected"
+    assert len(ip_attempts) == 1, "exactly one IP attempt expected"
+    assert domain_attempts[0].closed is True, "abandoned domain SDK must be aclose()-ed"
+    assert ip_attempts[0].closed is False, "successful SDK is owned by the caller"
+
+
+def test_abandoned_sdk_is_closed_when_both_attempts_fail(monkeypatch):
+    monkeypatch.setattr("proxbox_api.session.proxmox.ProxmoxAPI", FakePve9AuthRejectedAPI)
+
+    with pytest.raises(ProxboxException):
+        ProxmoxSession(
+            {
+                "ip_address": "10.0.30.10",
+                "domain": "pve9.example.com",
+                "http_port": 8006,
+                "user": "root@pam",
+                "password": None,
+                "token": {"name": "proxbox", "value": "bad-token"},
+                "ssl": False,
+            }
+        )
+
+    assert len(FakePve9ProxmoxAPI.instances) == 2
+    assert all(sdk.closed for sdk in FakePve9ProxmoxAPI.instances)

--- a/tests/test_proxmox_auth_pve9.py
+++ b/tests/test_proxmox_auth_pve9.py
@@ -149,9 +149,7 @@ def test_auth_failure_surfaces_upstream_pve_error(monkeypatch):
 
 
 def test_abandoned_sdk_is_closed_on_domain_fallback(monkeypatch):
-    monkeypatch.setattr(
-        "proxbox_api.session.proxmox.ProxmoxAPI", FakeDomainFailsThenIpSucceedsAPI
-    )
+    monkeypatch.setattr("proxbox_api.session.proxmox.ProxmoxAPI", FakeDomainFailsThenIpSucceedsAPI)
 
     session = ProxmoxSession(
         {


### PR DESCRIPTION
## Summary

Fixes the on-our-side regressions reported in [`netbox-proxbox#417`](https://github.com/emersonfelipesp/netbox-proxbox/issues/417) (Proxmox VE 9.1.x auth failure).

- `ProxmoxSession._auth_async` now calls a new `_close_abandoned_sdk()` helper in both the domain and IP fallback failure branches, so a failed token-auth attempt no longer leaks an aiohttp `ClientSession` (`Unclosed client session` log flood gone).
- A new `_describe_auth_error()` helper extracts `status_code`, `status_message`, `content`, and `errors` from `proxmox-sdk`'s `ResourceException`, replacing the opaque `"Unknown error."` detail with the real upstream PVE message.

## Live verification (PVE 9.1.11 @ 10.0.30.91)

`scripts/pve9_live_smoketest.py` (Phase B):

```
--- token_valid ---
  ok: True
  version: {'version': '9.1.11', 'release': '9.1', 'repoid': '8eac2c86f015bdda'}
  unclosed_session_log_lines: 0

--- token_sabotaged ---
  ok: False
  detail: Error trying to initialize Proxmox API connection to '10.0.30.91:8006'
          using token authentication | HTTP 401 Authentication failed! - None
  unclosed_session_log_lines: 0

OVERALL: PASS
```

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run python -m compileall proxbox_api tests`
- [x] `uv run pytest tests/test_proxmox_auth_pve9.py tests/test_session_and_helpers.py` (58 passed)
- [x] Live PVE 9.1.11 smoketest (above)
- [ ] Plugin-side companion PR: `emersonfelipesp/netbox-proxbox` `claude/issue-417-pve9-auth` (clean-credential UX)