### PR TITLE
Merge v0.0.12 into main (Proxmox VM tag sync + CI hardening)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,6 +410,22 @@ jobs:
             postgres:16-alpine \
             postgres -c max_connections=300
 
+          echo "Waiting for netbox-e2e-postgres to accept connections from the proxbox-e2e network…"
+          for i in $(seq 1 60); do
+            if docker run --rm --network proxbox-e2e postgres:16-alpine \
+                 pg_isready -h netbox-e2e-postgres -U netbox -d netbox -t 5 -q; then
+              echo "Postgres is ready after ${i} attempts"
+              break
+            fi
+            sleep 1
+            if [ "$i" -eq 60 ]; then
+              echo "❌ netbox-e2e-postgres did not become reachable in 60s"
+              docker logs --tail 200 netbox-e2e-postgres || true
+              docker network inspect proxbox-e2e || true
+              exit 1
+            fi
+          done
+
           docker run -d --name netbox-e2e-redis --network proxbox-e2e \
             redis:7-alpine
 
@@ -514,6 +530,8 @@ jobs:
               -e SECRET_KEY="$SECRET_KEY" \
               -e ALLOWED_HOSTS="* localhost 127.0.0.1 ::1 netbox-e2e-http netbox-e2e-nginx netbox-e2e-granian" \
               -e LOGIN_REQUIRED=False \
+              -e MAX_DB_WAIT_TIME=120 \
+              -e DB_WAIT_DEBUG=1 \
               --entrypoint /bin/bash \
               "${NETBOX_IMAGE}" -ec "uv pip install --no-cache-dir '${{ steps.proxbox_pkg.outputs.target }}' && mkdir -p /etc/netbox/config && printf 'PLUGINS = [\"netbox_proxbox\"]\\n' > /etc/netbox/config/plugins.py && /opt/netbox/docker-entrypoint.sh /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py runserver 0.0.0.0:8000 --insecure"
           elif [ "${{ matrix.netbox_transport }}" = "https_nginx" ]; then
@@ -532,6 +550,8 @@ jobs:
               -e SECRET_KEY="$SECRET_KEY" \
               -e ALLOWED_HOSTS="* localhost 127.0.0.1 ::1 netbox-e2e-http netbox-e2e-nginx netbox-e2e-granian" \
               -e LOGIN_REQUIRED=False \
+              -e MAX_DB_WAIT_TIME=120 \
+              -e DB_WAIT_DEBUG=1 \
               --entrypoint /bin/bash \
               "${NETBOX_IMAGE}" -ec "uv pip install --no-cache-dir '${{ steps.proxbox_pkg.outputs.target }}' && mkdir -p /etc/netbox/config && printf 'PLUGINS = [\"netbox_proxbox\"]\\n' > /etc/netbox/config/plugins.py && /opt/netbox/docker-entrypoint.sh /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py runserver 0.0.0.0:8000 --insecure"
 
@@ -557,6 +577,8 @@ jobs:
               -e PYTHONPATH=/opt/netbox/netbox \
               -e ALLOWED_HOSTS="* localhost 127.0.0.1 ::1 netbox-e2e-http netbox-e2e-nginx netbox-e2e-granian" \
               -e LOGIN_REQUIRED=False \
+              -e MAX_DB_WAIT_TIME=120 \
+              -e DB_WAIT_DEBUG=1 \
               --entrypoint /bin/bash \
               "${NETBOX_IMAGE}" -ec "uv pip install --no-cache-dir '${{ steps.proxbox_pkg.outputs.target }}' granian && mkdir -p /etc/netbox/config && printf 'PLUGINS = [\"netbox_proxbox\"]\\n' > /etc/netbox/config/plugins.py && /opt/netbox/docker-entrypoint.sh /opt/netbox/venv/bin/granian --interface wsgi --host '${NETBOX_GRANIAN_HOST}' --port 8443 --ssl-certificate /certs/netbox.crt --ssl-keyfile /certs/netbox-pkcs8.key netbox.wsgi:application"
           fi
@@ -582,6 +604,7 @@ jobs:
               docker logs netbox-e2e-http || true
               docker logs netbox-e2e-nginx || true
               docker logs netbox-e2e-granian || true
+              docker logs --tail 200 netbox-e2e-postgres 2>/dev/null || true
               exit 1
             fi
           done
@@ -598,6 +621,7 @@ jobs:
               docker logs netbox-e2e-http || true
               docker logs netbox-e2e-nginx || true
               docker logs netbox-e2e-granian || true
+              docker logs --tail 200 netbox-e2e-postgres 2>/dev/null || true
               exit 1
             fi
           done
@@ -705,6 +729,18 @@ jobs:
           curl ${{ matrix.proxbox_curl_flags }} -fsS \
             "${{ matrix.proxbox_base_url }}/extras/extras/custom-fields/create" \
             -H "X-Proxbox-API-Key: ${PROXBOX_API_KEY}"
+
+      - name: Dump proxbox-api logs on custom-fields failure
+        if: failure()
+        run: |
+          echo "=== proxbox-api container logs (last 400 lines) ==="
+          docker logs --tail 400 proxbox-e2e || true
+          echo "=== netbox http container logs (last 200 lines) ==="
+          docker logs --tail 200 netbox-e2e-http 2>/dev/null || true
+          docker logs --tail 200 netbox-e2e-nginx 2>/dev/null || true
+          docker logs --tail 200 netbox-e2e-granian 2>/dev/null || true
+          echo "=== netbox postgres container logs (last 200 lines) ==="
+          docker logs --tail 200 netbox-e2e-postgres 2>/dev/null || true
 
       - name: Run E2E tests (Docker proxmox mock)
         env:

--- a/contracts/overwrite_flags.json
+++ b/contracts/overwrite_flags.json
@@ -11,6 +11,7 @@
     "overwrite_vm_role",
     "overwrite_vm_type",
     "overwrite_vm_tags",
+    "overwrite_vm_proxmox_tags",
     "overwrite_vm_description",
     "overwrite_vm_custom_fields",
     "overwrite_vm_cloudinit",

--- a/proxbox_api/proxmox_to_netbox/__init__.py
+++ b/proxbox_api/proxmox_to_netbox/__init__.py
@@ -1,6 +1,9 @@
 """Proxmox-to-NetBox normalization and schema-driven mapping package."""
 
-from proxbox_api.proxmox_to_netbox.models import ProxmoxToNetBoxVirtualMachine
+from proxbox_api.proxmox_to_netbox.models import (
+    ProxmoxToNetBoxVirtualMachine,
+    parse_proxmox_tags,
+)
 from proxbox_api.proxmox_to_netbox.normalize import build_virtual_machine_transform
 from proxbox_api.proxmox_to_netbox.schemas import (
     ProxmoxDiskEntry,
@@ -14,6 +17,7 @@ __all__ = [
     "ProxmoxToNetBoxVirtualMachine",
     "build_virtual_machine_transform",
     "parse_disk_entry",
+    "parse_proxmox_tags",
     "parse_vm_config_disks",
     "size_str_to_mb",
 ]

--- a/proxbox_api/proxmox_to_netbox/models.py
+++ b/proxbox_api/proxmox_to_netbox/models.py
@@ -70,6 +70,26 @@ def _parse_proxmox_kv_flag(value: object) -> bool:
     return False
 
 
+def parse_proxmox_tags(raw: str | None) -> list[str]:
+    """Parse a Proxmox ``tags`` field into a normalized tag-name list.
+
+    Proxmox stores VM/LXC tags as a single ``;``-separated string
+    (e.g. ``"critical;end-user-impact;production"``). This helper splits,
+    trims, lowercases, and dedupes preserving input order.
+    """
+    if not raw or not isinstance(raw, str):
+        return []
+    seen: set[str] = set()
+    out: list[str] = []
+    for chunk in raw.split(";"):
+        name = chunk.strip().lower()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        out.append(name)
+    return out
+
+
 def _mb_from_bytes(value: object) -> int:
     try:
         as_int = int(value)
@@ -951,6 +971,7 @@ class ProxmoxVmConfigInput(BaseModel):
     sshkeys: str | None = None
     ipconfig0: str | None = None
     sshkeys_truncated: bool = False
+    tags: str | None = None
 
     @field_validator("sshkeys", mode="before")
     @classmethod
@@ -981,6 +1002,11 @@ class ProxmoxVmConfigInput(BaseModel):
     @property
     def start_at_boot(self) -> bool:
         return _as_bool(self.onboot)
+
+    @computed_field(return_type=list[str])
+    @property
+    def proxmox_tags(self) -> list[str]:
+        return parse_proxmox_tags(self.tags)
 
     @computed_field(return_type=bool)
     @property

--- a/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
+++ b/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
@@ -51,6 +51,7 @@ from proxbox_api.services.name_collision import (
     NameResolution,
     resolve_unique_vm_name,
 )
+from proxbox_api.services.proxmox.tag_styles import fetch_tag_color_map
 from proxbox_api.services.proxmox_helpers import (
     fetch_qemu_guest_agent_network_interfaces,
     get_qemu_guest_agent_hostname,
@@ -77,6 +78,7 @@ from proxbox_api.services.sync.storage_links import (
     find_storage_record,
     storage_name_from_volume_id,
 )
+from proxbox_api.services.sync.tag_resolver import resolve_proxmox_tag_ids
 from proxbox_api.services.sync.task_history import (
     sync_virtual_machine_task_history,
 )
@@ -1303,12 +1305,42 @@ async def create_virtual_machines(  # noqa: C901
 
     # Build a mapping from cluster name to Proxmox base URL for populating proxmox_link.
     proxmox_url_by_cluster: dict[str, str] = {}
+    px_by_cluster: dict[str, object] = {}
     for px, cs in zip(pxs, cluster_status):
         cluster_n = getattr(cs, "name", None) or getattr(px, "cluster_name", None)
         px_domain = getattr(px, "domain", None) or getattr(px, "ip_address", None) or ""
         px_port = getattr(px, "http_port", 8006)
         if cluster_n and px_domain:
             proxmox_url_by_cluster[str(cluster_n)] = f"https://{px_domain}:{px_port}"
+        if cluster_n:
+            px_by_cluster[str(cluster_n)] = px
+
+    # Per-cluster color-map cache: fetched once on first VM that needs it.
+    tag_color_map_by_cluster: dict[str, dict[str, str]] = {}
+    tag_color_map_locks: dict[str, asyncio.Lock] = {}
+
+    async def _get_cluster_tag_color_map(cluster_name: str) -> dict[str, str]:
+        if cluster_name in tag_color_map_by_cluster:
+            return tag_color_map_by_cluster[cluster_name]
+        lock = tag_color_map_locks.setdefault(cluster_name, asyncio.Lock())
+        async with lock:
+            if cluster_name in tag_color_map_by_cluster:
+                return tag_color_map_by_cluster[cluster_name]
+            px = px_by_cluster.get(cluster_name)
+            if px is None:
+                tag_color_map_by_cluster[cluster_name] = {}
+                return tag_color_map_by_cluster[cluster_name]
+            tag_color_map_by_cluster[cluster_name] = await fetch_tag_color_map(px)
+            return tag_color_map_by_cluster[cluster_name]
+
+    async def _resolve_vm_proxmox_tag_ids(cluster_name: str, vm_config: dict) -> list[int]:
+        if not overwrite_flags.overwrite_vm_proxmox_tags:
+            return []
+        raw = vm_config.get("tags") if isinstance(vm_config, dict) else None
+        if not raw:
+            return []
+        color_map = await _get_cluster_tag_color_map(cluster_name)
+        return await resolve_proxmox_tag_ids(nb, raw, color_map=color_map)
 
     total_vms = 0  # Track total VMs processed
     successful_vms = 0  # Track successful VM creations
@@ -1597,13 +1629,16 @@ async def create_virtual_machines(  # noqa: C901
         vm_type_id = int(getattr(vm_type_obj, "id", 0) or 0) if vm_type_obj else None
 
         now = datetime.now(timezone.utc)
+        proxmox_tag_ids = await _resolve_vm_proxmox_tag_ids(str(cluster_name), vm_config)
+        proxbox_tag_id = int(getattr(tag, "id", 0) or 0)
+        merged_tag_ids = sorted({proxbox_tag_id, *proxmox_tag_ids} - {0})
         desired_payload = build_netbox_virtual_machine_payload(
             proxmox_resource=resource,
             proxmox_config=vm_config,
             cluster_id=int(getattr(cluster, "id", 0) or 0),
             device_id=int(getattr(device, "id", 0) or 0),
             role_id=None if vm_type_id else int(getattr(role, "id", 0) or 0),
-            tag_ids=[int(getattr(tag, "id", 0) or 0)],
+            tag_ids=merged_tag_ids,
             site_id=int(getattr(cluster_dependencies.get("site"), "id", 0) or 0) or None,
             tenant_id=int(getattr(cluster_dependencies.get("tenant"), "id", 0) or 0) or None,
             virtual_machine_type_id=vm_type_id,
@@ -1922,13 +1957,16 @@ async def create_virtual_machines(  # noqa: C901
             )
 
         now = datetime.now(timezone.utc)
+        proxmox_tag_ids = await _resolve_vm_proxmox_tag_ids(str(cluster_name), vm_config)
+        proxbox_tag_id = int(getattr(tag, "id", 0) or 0)
+        merged_tag_ids = sorted({proxbox_tag_id, *proxmox_tag_ids} - {0})
         netbox_vm_payload = build_netbox_virtual_machine_payload(
             proxmox_resource=resource,
             proxmox_config=vm_config,
             cluster_id=int(getattr(cluster, "id", 0) or 0),
             device_id=int(getattr(device, "id", 0) or 0),
             role_id=None if vm_type_id else int(getattr(role, "id", 0) or 0),
-            tag_ids=[int(getattr(tag, "id", 0) or 0)],
+            tag_ids=merged_tag_ids,
             site_id=int(getattr(cluster_dependencies.get("site"), "id", 0) or 0) or None,
             tenant_id=int(getattr(cluster_dependencies.get("tenant"), "id", 0) or 0) or None,
             virtual_machine_type_id=vm_type_id,

--- a/proxbox_api/schemas/sync.py
+++ b/proxbox_api/schemas/sync.py
@@ -97,6 +97,16 @@ class SyncOverwriteFlags(ProxboxBaseModel):
             "Tags are still applied when a VM is first created."
         ),
     )
+    overwrite_vm_proxmox_tags: bool = Field(
+        default=True,
+        title="Sync Proxmox Tags",
+        description=(
+            "When true, Proxmox VM/LXC ``tags`` are mirrored as NetBox tags and "
+            "attached to the synced VM. Colors come from the Proxmox cluster "
+            "``tag-style`` color-map when available, otherwise from a deterministic "
+            "hash. When false, Proxmox tags are not propagated."
+        ),
+    )
     overwrite_vm_description: bool = Field(
         default=True,
         title="Overwrite VM Description",

--- a/proxbox_api/services/proxmox/tag_styles.py
+++ b/proxbox_api/services/proxmox/tag_styles.py
@@ -1,0 +1,126 @@
+"""Proxmox cluster tag-style helpers.
+
+Reads ``/cluster/options::tag-style`` from a Proxmox session and parses its
+``color-map`` into ``{tag_name_lower: "rrggbb"}`` so sync code can mirror
+Proxmox tag colors into NetBox tags.
+
+Proxmox color-map format (per ``man pvesh`` / cluster.cfg docs):
+
+    color-map=<tag>:<bg>[:<fg>][:<weight>];<tag>:<bg>[:<fg>][:<weight>];...
+
+Color tokens are 3- or 6-char hex without ``#``. The full ``tag-style`` field
+may be just the color-map, or include other style flags before/after it
+separated by ``,`` (e.g. ``case-sensitive=1,color-map=...``). Never raises into
+the sync flow — returns ``{}`` on any failure.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import re
+from typing import Any
+
+from proxbox_api.logger import logger
+from proxbox_api.proxmox_async import resolve_async
+
+_HEX_RE = re.compile(r"^[0-9a-f]{6}$")
+_SHORT_HEX_RE = re.compile(r"^[0-9a-f]{3}$")
+
+
+def _normalize_hex(value: str) -> str | None:
+    token = value.strip().lower().lstrip("#")
+    if _HEX_RE.fullmatch(token):
+        return token
+    if _SHORT_HEX_RE.fullmatch(token):
+        return "".join(ch * 2 for ch in token)
+    return None
+
+
+def _extract_color_map_text(tag_style: str) -> str | None:
+    """Pull the ``color-map=...`` value out of a Proxmox ``tag-style`` string.
+
+    Accepts both the bare ``color-map=...`` form and the longer
+    ``case-sensitive=1,color-map=...,...`` shape.
+    """
+    text = tag_style.strip()
+    if not text:
+        return None
+    # The color-map sub-field uses ``;`` to separate per-tag entries, but its
+    # siblings inside tag-style use ``,``. Split on the outer ``,`` and grab the
+    # sub-field whose key is color-map.
+    for chunk in text.split(","):
+        key, sep, value = chunk.partition("=")
+        if not sep:
+            continue
+        if key.strip().lower() == "color-map":
+            return value.strip()
+    return None
+
+
+def parse_tag_color_map(tag_style: str | None) -> dict[str, str]:
+    """Parse a Proxmox ``tag-style`` field into ``{tag_lower: "rrggbb"}``.
+
+    Invalid color-map entries are skipped. Returns an empty dict when input is
+    missing/invalid or no valid entries exist. Background color is used
+    (Proxmox color-map foreground/weight are ignored for NetBox tag color).
+    """
+    if not tag_style or not isinstance(tag_style, str):
+        return {}
+    color_map_text = _extract_color_map_text(tag_style)
+    if color_map_text is None:
+        return {}
+    result: dict[str, str] = {}
+    for entry in color_map_text.split(";"):
+        entry = entry.strip()
+        if not entry:
+            continue
+        parts = entry.split(":")
+        if len(parts) < 2:
+            continue
+        name = parts[0].strip().lower()
+        if not name:
+            continue
+        color = _normalize_hex(parts[1])
+        if color is None:
+            continue
+        result.setdefault(name, color)
+    return result
+
+
+async def fetch_tag_color_map(proxmox_session: Any) -> dict[str, str]:
+    """Fetch and parse the cluster ``tag-style`` color-map.
+
+    Returns ``{}`` on any error so callers can fall through to deterministic
+    color fallback without breaking the sync flow.
+    """
+    try:
+        options = await resolve_async(proxmox_session.session.cluster.options.get())
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.debug("Failed to fetch /cluster/options for tag-style", exc_info=True)
+        return {}
+
+    if not isinstance(options, dict):
+        return {}
+    tag_style = options.get("tag-style") or options.get("tag_style")
+    if not tag_style:
+        return {}
+    if not isinstance(tag_style, str):
+        return {}
+    return parse_tag_color_map(tag_style)
+
+
+def fallback_color(tag_name: str) -> str:
+    """Deterministic 6-char hex color derived from the tag name.
+
+    Stable across bulk and individual sync paths so re-syncs don't flip
+    colors for tags that aren't in the Proxmox color-map.
+    """
+    data = tag_name.encode("utf-8")
+    try:
+        digest = hashlib.md5(data, usedforsecurity=False).hexdigest()
+    except TypeError:
+        digest = hashlib.md5(data).hexdigest()
+    return digest[:6]

--- a/proxbox_api/services/sync/individual/vm_sync.py
+++ b/proxbox_api/services/sync/individual/vm_sync.py
@@ -16,6 +16,7 @@ from proxbox_api.proxmox_to_netbox.models import (
 )
 from proxbox_api.schemas.sync import SyncOverwriteFlags
 from proxbox_api.services.name_collision import resolve_unique_vm_name
+from proxbox_api.services.proxmox.tag_styles import fetch_tag_color_map
 from proxbox_api.services.proxmox_helpers import (
     get_vm_config_individual,
     get_vm_resource_individual,
@@ -26,6 +27,7 @@ from proxbox_api.services.sync.discovery_tags import (
 )
 from proxbox_api.services.sync.individual.base import BaseIndividualSyncService
 from proxbox_api.services.sync.individual.interface_sync import sync_interface_individual
+from proxbox_api.services.sync.tag_resolver import resolve_proxmox_tag_ids
 from proxbox_api.services.sync.vm_helpers import (
     _compute_vm_patchable_fields,
     normalize_current_virtual_machine_payload,
@@ -58,6 +60,27 @@ def _as_bool(value: object) -> bool:
     if isinstance(value, str):
         return value.strip().lower() in {"1", "true", "yes", "on"}
     return False
+
+
+async def _resolve_individual_proxmox_tag_ids(
+    nb: object,
+    px: object,
+    proxmox_config: object,
+    overwrite_flags: SyncOverwriteFlags | None,
+) -> list[int]:
+    """Resolve Proxmox `tags` from a VM config into NetBox tag IDs.
+
+    Returns an empty list when the overwrite flag is disabled, when the config
+    has no tags, or when the resolver short-circuits on an empty input.
+    """
+    sync_proxmox_tags = overwrite_flags.overwrite_vm_proxmox_tags if overwrite_flags else True
+    if not sync_proxmox_tags:
+        return []
+    raw_proxmox_tags = proxmox_config.get("tags") if isinstance(proxmox_config, dict) else None
+    if not raw_proxmox_tags:
+        return []
+    color_map = await fetch_tag_color_map(px)
+    return await resolve_proxmox_tag_ids(nb, raw_proxmox_tags, color_map=color_map)
 
 
 async def _apply_name_collision_resolution(
@@ -353,7 +376,11 @@ async def sync_vm_individual(
             discovery_id = await resolve_discovery_tag_id(nb, vm_discovery_tag_slug(vm_type))
             if discovery_id is not None:
                 tag_ids.append(discovery_id)
-        merged_tag_ids = sorted(set(tag_ids) | set(existing_tag_ids))
+
+        proxmox_tag_ids = await _resolve_individual_proxmox_tag_ids(
+            nb, px, proxmox_config, overwrite_flags
+        )
+        merged_tag_ids = sorted(set(tag_ids) | set(existing_tag_ids) | set(proxmox_tag_ids))
 
         netbox_vm_payload = _build_netbox_vm_payload(
             resource=proxmox_resource,

--- a/proxbox_api/services/sync/tag_resolver.py
+++ b/proxbox_api/services/sync/tag_resolver.py
@@ -1,0 +1,70 @@
+"""Resolve Proxmox VM/LXC ``tags`` strings to NetBox tag IDs.
+
+Parses the ``;``-separated Proxmox ``tags`` field, ensures each tag exists in
+NetBox (creating it via ``ensure_tag_async`` if not), and returns the resulting
+NetBox tag IDs preserving input order.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+
+from proxbox_api.logger import logger
+from proxbox_api.netbox_rest import ensure_tag_async
+from proxbox_api.proxmox_to_netbox import parse_proxmox_tags
+from proxbox_api.services.proxmox.tag_styles import fallback_color
+
+DEFAULT_TAG_DESCRIPTION = "Synced by Proxbox"
+
+
+def _slugify_tag(value: str) -> str:
+    text = (value or "").strip().lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    return text.strip("-") or "tag"
+
+
+async def resolve_proxmox_tag_ids(
+    nb: object,
+    raw_tags: object,
+    *,
+    color_map: dict[str, str] | None = None,
+    description: str = DEFAULT_TAG_DESCRIPTION,
+) -> list[int]:
+    """Ensure NetBox tags exist for each Proxmox tag and return their IDs.
+
+    Color preference: explicit Proxmox ``color-map`` entry > deterministic
+    md5 fallback so the same tag name always resolves to the same color.
+    """
+    tag_names = parse_proxmox_tags(raw_tags)
+    if not tag_names:
+        return []
+
+    color_lookup = color_map or {}
+    out: list[int] = []
+    for name in tag_names:
+        color = color_lookup.get(name) or fallback_color(name)
+        slug = _slugify_tag(name)
+        try:
+            record = await ensure_tag_async(
+                nb,
+                name=name,
+                slug=slug,
+                color=color,
+                description=description,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("Failed to ensure NetBox tag for Proxmox tag '%s'", name, exc_info=True)
+            continue
+        tag_id = getattr(record, "id", None)
+        if tag_id is None and isinstance(record, dict):
+            tag_id = record.get("id")
+        try:
+            tag_id_int = int(tag_id) if tag_id is not None else None
+        except (TypeError, ValueError):
+            tag_id_int = None
+        if tag_id_int and tag_id_int > 0:
+            out.append(tag_id_int)
+    return out

--- a/tests/test_overwrite_flags_contract.py
+++ b/tests/test_overwrite_flags_contract.py
@@ -40,10 +40,10 @@ def test_manifest_matches_sync_overwrite_flags_model_fields() -> None:
     )
 
 
-def test_manifest_field_count_is_canonical_24() -> None:
+def test_manifest_field_count_is_canonical_25() -> None:
     """Sanity check: any change to flag count is intentional and reviewed."""
     manifest_fields = _load_manifest_fields()
-    assert len(manifest_fields) == 24
+    assert len(manifest_fields) == 25
 
 
 def test_manifest_has_no_duplicate_fields() -> None:

--- a/tests/test_proxmox_vm_config_input.py
+++ b/tests/test_proxmox_vm_config_input.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from proxbox_api.proxmox_to_netbox import parse_proxmox_tags
 from proxbox_api.proxmox_to_netbox.models import (
     ProxmoxVmConfigInput,
     _parse_proxmox_kv_flag,
@@ -78,3 +79,48 @@ def test_qemu_agent_enabled_through_model(agent_value: object, expected: bool) -
 def test_qemu_agent_enabled_default_when_absent() -> None:
     config = ProxmoxVmConfigInput.model_validate({})
     assert config.qemu_agent_enabled is False
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, []),
+        ("", []),
+        ("   ", []),
+        (";;;", []),
+        ("critical", ["critical"]),
+        ("critical;production", ["critical", "production"]),
+        ("  critical ; production  ", ["critical", "production"]),
+        ("Critical;PRODUCTION", ["critical", "production"]),
+        # Duplicates collapse, preserving first-seen order
+        ("critical;critical;production", ["critical", "production"]),
+        ("critical;Production;production", ["critical", "production"]),
+        # Empties between separators are skipped
+        ("critical;;production", ["critical", "production"]),
+        # Wrong type returns empty
+        (123, []),
+        ([], []),
+    ],
+)
+def test_parse_proxmox_tags(raw: object, expected: list[str]) -> None:
+    assert parse_proxmox_tags(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, []),
+        ("", []),
+        ("critical;production", ["critical", "production"]),
+        ("  Critical ; production ; critical ", ["critical", "production"]),
+    ],
+)
+def test_proxmox_tags_through_model(raw: object, expected: list[str]) -> None:
+    """End-to-end through Pydantic: VM config exposes parsed ``proxmox_tags``."""
+    config = ProxmoxVmConfigInput.model_validate({"tags": raw})
+    assert config.proxmox_tags == expected
+
+
+def test_proxmox_tags_default_when_absent() -> None:
+    config = ProxmoxVmConfigInput.model_validate({})
+    assert config.proxmox_tags == []

--- a/tests/test_qemu_guest_agent_sync.py
+++ b/tests/test_qemu_guest_agent_sync.py
@@ -166,6 +166,72 @@ def _install_common_sync_patches(  # noqa: C901
     )
 
 
+def test_vm_sync_fetches_tag_color_map_once_per_cluster_under_concurrency(monkeypatch):
+    data = _vm_sync_inputs({"tags": "critical;production"})
+    base_resource = data["cluster_resources"][0]["lab"][0]
+    data["cluster_resources"][0]["lab"] = [
+        {**base_resource, "name": f"vm{i}", "vmid": 100 + i} for i in range(4)
+    ]
+    ip_payloads: list[dict] = []
+    _install_common_sync_patches(monkeypatch, vm_config=data["vm_config"], ip_payloads=ip_payloads)
+    monkeypatch.setattr(
+        "proxbox_api.routes.virtualization.virtual_machines.sync_vm.resolve_vm_sync_concurrency",
+        lambda: 4,
+    )
+
+    fetch_calls: list[object] = []
+    resolved_color_maps: list[dict[str, str] | None] = []
+
+    async def _fake_fetch_tag_color_map(px):
+        fetch_calls.append(px)
+        await asyncio.sleep(0.01)
+        return {"critical": "ff5722"}
+
+    async def _fake_resolve_proxmox_tag_ids(_nb, _raw, *, color_map=None):
+        resolved_color_maps.append(color_map)
+        return [201]
+
+    async def _fake_rest_create(_nb, _path, payload):
+        vmid = int(payload["custom_fields"]["proxmox_vm_id"])
+        return {"id": 1000 + vmid, **payload}
+
+    async def _fake_task_history(**_kwargs):
+        return 0
+
+    monkeypatch.setattr(
+        "proxbox_api.routes.virtualization.virtual_machines.sync_vm.fetch_tag_color_map",
+        _fake_fetch_tag_color_map,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.routes.virtualization.virtual_machines.sync_vm.resolve_proxmox_tag_ids",
+        _fake_resolve_proxmox_tag_ids,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.routes.virtualization.virtual_machines.sync_vm.rest_create_async",
+        _fake_rest_create,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.routes.virtualization.virtual_machines.sync_vm.sync_virtual_machine_task_history",
+        _fake_task_history,
+    )
+
+    result = asyncio.run(
+        create_virtual_machines(
+            netbox_session=data["netbox_session"],
+            pxs=data["pxs"],
+            cluster_status=data["cluster_status"],
+            cluster_resources=data["cluster_resources"],
+            custom_fields=data["custom_fields"],
+            tag=data["tag"],
+            sync_vm_network=False,
+        )
+    )
+
+    assert len(result) == 4
+    assert len(fetch_calls) == 1
+    assert resolved_color_maps == [{"critical": "ff5722"}] * 4
+
+
 def test_vm_sync_prefers_guest_agent_ip(monkeypatch):
     data = _vm_sync_inputs(
         {

--- a/tests/test_sync_overwrite_flags.py
+++ b/tests/test_sync_overwrite_flags.py
@@ -23,6 +23,7 @@ EXPECTED_FLAGS: tuple[str, ...] = (
     "overwrite_vm_role",
     "overwrite_vm_type",
     "overwrite_vm_tags",
+    "overwrite_vm_proxmox_tags",
     "overwrite_vm_description",
     "overwrite_vm_custom_fields",
     "overwrite_vm_cloudinit",
@@ -42,8 +43,8 @@ EXPECTED_FLAGS: tuple[str, ...] = (
 
 
 def test_overwrite_flags_field_count() -> None:
-    """Schema exposes exactly 24 fields, mirroring OVERWRITE_FIELDS in the plugin."""
-    assert len(SyncOverwriteFlags.model_fields) == 24
+    """Schema exposes exactly 25 fields, mirroring OVERWRITE_FIELDS in the plugin."""
+    assert len(SyncOverwriteFlags.model_fields) == 25
 
 
 def test_overwrite_flags_field_names_and_order() -> None:

--- a/tests/test_tag_resolver.py
+++ b/tests/test_tag_resolver.py
@@ -1,0 +1,155 @@
+"""Tests for the Proxmox-tag → NetBox-tag resolver service."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from proxbox_api.services.proxmox.tag_styles import fallback_color
+from proxbox_api.services.sync import tag_resolver as tag_resolver_module
+from proxbox_api.services.sync.tag_resolver import (
+    DEFAULT_TAG_DESCRIPTION,
+    resolve_proxmox_tag_ids,
+)
+
+
+@dataclass
+class _FakeTag:
+    id: int
+    name: str
+    slug: str
+    color: str
+    description: str
+
+
+class _TagRecorder:
+    def __init__(self, *, fail_for: set[str] | None = None) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._next_id = 100
+        self._fail_for = fail_for or set()
+
+    async def ensure(
+        self,
+        nb: object,
+        *,
+        name: str,
+        slug: str,
+        color: str,
+        description: str,
+    ) -> _FakeTag:
+        self.calls.append(
+            {
+                "nb": nb,
+                "name": name,
+                "slug": slug,
+                "color": color,
+                "description": description,
+            }
+        )
+        if name in self._fail_for:
+            raise RuntimeError(f"simulated NetBox error for {name}")
+        self._next_id += 1
+        return _FakeTag(
+            id=self._next_id,
+            name=name,
+            slug=slug,
+            color=color,
+            description=description,
+        )
+
+
+@pytest.fixture
+def patch_ensure_tag(monkeypatch: pytest.MonkeyPatch) -> _TagRecorder:
+    recorder = _TagRecorder()
+    monkeypatch.setattr(tag_resolver_module, "ensure_tag_async", recorder.ensure)
+    return recorder
+
+
+@pytest.mark.asyncio
+async def test_resolve_empty_returns_empty_list(patch_ensure_tag: _TagRecorder) -> None:
+    assert await resolve_proxmox_tag_ids(object(), None) == []
+    assert await resolve_proxmox_tag_ids(object(), "") == []
+    assert await resolve_proxmox_tag_ids(object(), "   ") == []
+    assert await resolve_proxmox_tag_ids(object(), 123) == []
+    assert await resolve_proxmox_tag_ids(object(), []) == []
+    assert patch_ensure_tag.calls == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_preserves_order_and_dedupes(patch_ensure_tag: _TagRecorder) -> None:
+    nb = object()
+    ids = await resolve_proxmox_tag_ids(
+        nb,
+        "Critical;production;critical;End-User Impact",
+    )
+    # Three distinct tags, in input order
+    names = [call["name"] for call in patch_ensure_tag.calls]
+    assert names == ["critical", "production", "end-user impact"]
+    assert len(ids) == 3
+    assert ids == sorted(ids)  # _next_id increments — order preserved
+
+
+@pytest.mark.asyncio
+async def test_resolve_slugifies_tag_names(patch_ensure_tag: _TagRecorder) -> None:
+    await resolve_proxmox_tag_ids(object(), "End-User Impact;Foo_Bar;tag!!!")
+    slugs = [call["slug"] for call in patch_ensure_tag.calls]
+    assert slugs == ["end-user-impact", "foo-bar", "tag"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_color_map_hit_wins_over_fallback(
+    patch_ensure_tag: _TagRecorder,
+) -> None:
+    color_map = {"critical": "ff5722"}
+    await resolve_proxmox_tag_ids(
+        object(),
+        "critical;production",
+        color_map=color_map,
+    )
+    colors = {call["name"]: call["color"] for call in patch_ensure_tag.calls}
+    assert colors["critical"] == "ff5722"
+    # No color-map entry → deterministic md5 fallback
+    assert colors["production"] == fallback_color("production")
+
+
+@pytest.mark.asyncio
+async def test_resolve_uses_default_description(patch_ensure_tag: _TagRecorder) -> None:
+    await resolve_proxmox_tag_ids(object(), "critical")
+    assert patch_ensure_tag.calls[0]["description"] == DEFAULT_TAG_DESCRIPTION
+    assert DEFAULT_TAG_DESCRIPTION == "Synced by Proxbox"
+
+
+@pytest.mark.asyncio
+async def test_resolve_passes_custom_description(patch_ensure_tag: _TagRecorder) -> None:
+    await resolve_proxmox_tag_ids(object(), "critical", description="from-test")
+    assert patch_ensure_tag.calls[0]["description"] == "from-test"
+
+
+@pytest.mark.asyncio
+async def test_resolve_skips_failed_tags_but_keeps_going(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorder = _TagRecorder(fail_for={"production"})
+    monkeypatch.setattr(tag_resolver_module, "ensure_tag_async", recorder.ensure)
+    ids = await resolve_proxmox_tag_ids(object(), "critical;production;maintenance")
+    # All three were attempted, but only two IDs returned (production failed)
+    assert [c["name"] for c in recorder.calls] == [
+        "critical",
+        "production",
+        "maintenance",
+    ]
+    assert len(ids) == 2
+
+
+@pytest.mark.asyncio
+async def test_resolve_propagates_cancellation(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _cancelled_ensure(*args: object, **kwargs: object) -> object:
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(tag_resolver_module, "ensure_tag_async", _cancelled_ensure)
+
+    with pytest.raises(asyncio.CancelledError):
+        await resolve_proxmox_tag_ids(object(), "critical")

--- a/tests/test_tag_styles.py
+++ b/tests/test_tag_styles.py
@@ -1,0 +1,150 @@
+"""Tests for Proxmox cluster ``tag-style`` color-map parsing."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from proxbox_api.services.proxmox import tag_styles as tag_styles_module
+from proxbox_api.services.proxmox.tag_styles import (
+    fallback_color,
+    fetch_tag_color_map,
+    parse_tag_color_map,
+)
+
+
+@pytest.mark.parametrize(
+    ("tag_style", "expected"),
+    [
+        (None, {}),
+        ("", {}),
+        ("   ", {}),
+        ("case-sensitive=1", {}),
+        # Bare color-map form
+        (
+            "color-map=critical:ff5722:ffffff:1;production:00aa00",
+            {"critical": "ff5722", "production": "00aa00"},
+        ),
+        # Embedded color-map with surrounding kv pairs
+        (
+            "case-sensitive=1,color-map=critical:ff5722:ffffff:1",
+            {"critical": "ff5722"},
+        ),
+        # Short hex expands to long hex
+        ("color-map=foo:f00", {"foo": "ff0000"}),
+        # Leading ``#`` tolerated
+        ("color-map=foo:#abcdef", {"foo": "abcdef"}),
+        # Case-insensitive tag names
+        ("color-map=CRITICAL:ff5722", {"critical": "ff5722"}),
+        # Malformed entries are dropped, valid ones survive
+        ("color-map=bad;good:00ff00;:nocolor;name:zzzzzz", {"good": "00ff00"}),
+        # First win on duplicate tag
+        (
+            "color-map=foo:111111;foo:222222",
+            {"foo": "111111"},
+        ),
+        # Empty color-map value
+        ("color-map=", {}),
+    ],
+)
+def test_parse_tag_color_map(tag_style: object, expected: dict[str, str]) -> None:
+    assert parse_tag_color_map(tag_style) == expected
+
+
+def test_parse_tag_color_map_rejects_non_string() -> None:
+    assert parse_tag_color_map(123) == {}  # type: ignore[arg-type]
+    assert parse_tag_color_map(["color-map=foo:f00"]) == {}  # type: ignore[arg-type]
+
+
+def test_fallback_color_is_deterministic_six_char_hex() -> None:
+    color = fallback_color("critical")
+    assert color == fallback_color("critical")
+    assert len(color) == 6
+    assert all(c in "0123456789abcdef" for c in color)
+
+
+def test_fallback_color_differs_per_tag() -> None:
+    assert fallback_color("critical") != fallback_color("production")
+
+
+def test_fallback_color_handles_md5_without_usedforsecurity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_md5 = tag_styles_module.hashlib.md5
+    calls: list[dict[str, object]] = []
+
+    def _compat_md5(data: bytes, **kwargs: object):
+        calls.append(kwargs)
+        if "usedforsecurity" in kwargs:
+            raise TypeError("usedforsecurity is unsupported")
+        return real_md5(data)
+
+    monkeypatch.setattr(tag_styles_module.hashlib, "md5", _compat_md5)
+
+    assert fallback_color("critical") == real_md5(b"critical").hexdigest()[:6]
+    assert calls == [{"usedforsecurity": False}, {}]
+
+
+class _StubCluster:
+    def __init__(self, options: object) -> None:
+        self._options = options
+
+    @property
+    def options(self) -> "_StubCluster":
+        return self
+
+    def get(self) -> object:
+        return self._options
+
+
+class _StubProxmox:
+    def __init__(self, options: object) -> None:
+        self.cluster = _StubCluster(options)
+
+
+class _StubSession:
+    def __init__(self, options: object) -> None:
+        self.session = _StubProxmox(options)
+
+
+@pytest.mark.asyncio
+async def test_fetch_tag_color_map_returns_parsed_dict() -> None:
+    sess = _StubSession({"tag-style": "color-map=critical:ff5722;production:00aa00"})
+    assert await fetch_tag_color_map(sess) == {
+        "critical": "ff5722",
+        "production": "00aa00",
+    }
+
+
+@pytest.mark.asyncio
+async def test_fetch_tag_color_map_handles_missing_tag_style() -> None:
+    sess = _StubSession({})
+    assert await fetch_tag_color_map(sess) == {}
+
+
+@pytest.mark.asyncio
+async def test_fetch_tag_color_map_handles_non_dict_options() -> None:
+    sess = _StubSession("not a dict")
+    assert await fetch_tag_color_map(sess) == {}
+
+
+@pytest.mark.asyncio
+async def test_fetch_tag_color_map_handles_session_error() -> None:
+    class _BrokenSession:
+        @property
+        def session(self) -> object:
+            raise RuntimeError("upstream offline")
+
+    assert await fetch_tag_color_map(_BrokenSession()) == {}
+
+
+@pytest.mark.asyncio
+async def test_fetch_tag_color_map_propagates_cancellation() -> None:
+    class _CancelledSession:
+        @property
+        def session(self) -> object:
+            raise asyncio.CancelledError()
+
+    with pytest.raises(asyncio.CancelledError):
+        await fetch_tag_color_map(_CancelledSession())


### PR DESCRIPTION
## Summary

Bring `v0.0.12` up into `main`. `v0.0.12` has diverged from `main`: it carries the squashed merge of #90 (Proxmox VM tag sync, plus the cross-container `pg_isready` / `MAX_DB_WAIT_TIME=120` / `DB_WAIT_DEBUG=1` CI hardening), while `main` carries the previous v0.0.12 sync (#91) plus #88 and #89. Fast-forward is impossible; this is a true merge commit.

## Commits being merged into main

- `6a436b5` feat(sync): mirror Proxmox VM tags into NetBox (#421) (#90)

## Test plan

- [ ] CI matrix runs against the merge commit
- [ ] `docs.yml` redeploys MkDocs site to GitHub Pages on push to main