### PR TITLE
ci(publish-testpypi): allow uv to resolve RC versions from TestPyPI

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -212,6 +212,7 @@ jobs:
               --python .package-smoke/bin/python \
               --index-url https://test.pypi.org/simple/ \
               --extra-index-url https://pypi.org/simple/ \
+              --index-strategy unsafe-best-match \
               "${PACKAGE_NAME}==${PACKAGE_VERSION}"; then
               installed=1
               break


### PR DESCRIPTION
## Summary
- validate-testpypi failed on v0.0.11rc1 because uv's default first-index strategy refuses to look at TestPyPI once it finds an older version of \`proxbox-api\` on PyPI (dependency-confusion guard).
- The uv error message itself suggests \`--index-strategy unsafe-best-match\`; adding it lets uv pick the requested exact version from whichever index has it.
- Confirmed locally: \`uv pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ --index-strategy unsafe-best-match proxbox-api==0.0.11rc1\` installs the RC and \`load_proxmox_generated_openapi()\` returns 428 paths.

## Test plan
- [ ] Re-trigger publish-testpypi workflow_dispatch with \`publish_target=testpypi\` on a fresh RC tag, or verify on the next RC release that validate-testpypi succeeds across py3.11/3.12/3.13.