### PR TITLE
ci(publish-testpypi): bump NetBox readiness gate + pin netbox-proxbox to v0.0.15rc4

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -359,7 +359,7 @@ jobs:
           set -eux
           docker network create proxbox-e2e || true
           SECRET_KEY='proxbox-e2e-secret-key-proxbox-e2e-secret-key-proxbox-e2e-secret-key'
-          NETBOX_PROXBOX_TARGET='https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/heads/develop.tar.gz'
+          NETBOX_PROXBOX_TARGET='https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.15rc4.tar.gz'
           DEV_OVERRIDES='git+https://github.com/emersonfelipesp/netbox-sdk.git@main git+https://github.com/emersonfelipesp/proxmox-sdk.git@main'
 
           docker rm -f netbox-e2e-postgres netbox-e2e-redis netbox-e2e-http proxmox-e2e-mock proxbox-e2e 2>/dev/null || true
@@ -421,11 +421,11 @@ jobs:
       - name: Wait for services and verify connectivity
         run: |
           set -eux
-          for i in $(seq 1 600); do
+          for i in $(seq 1 900); do
             http_code="$(curl -sS --max-time 5 -o /dev/null -w '%{http_code}' http://127.0.0.1:18080/api/ 2>/dev/null || true)"
             if [ "$http_code" -ge 200 ] 2>/dev/null && [ "$http_code" -lt 400 ]; then break; fi
             sleep 2
-            if [ "$i" -eq 600 ]; then echo "NetBox did not become ready"; docker logs netbox-e2e-http || true; exit 1; fi
+            if [ "$i" -eq 900 ]; then echo "NetBox did not become ready"; docker logs netbox-e2e-http || true; exit 1; fi
           done
 
           for i in $(seq 1 60); do
@@ -686,11 +686,11 @@ jobs:
       - name: Wait for services and verify connectivity
         run: |
           set -eux
-          for i in $(seq 1 600); do
+          for i in $(seq 1 900); do
             http_code="$(curl -sS --max-time 5 -o /dev/null -w '%{http_code}' http://127.0.0.1:18080/api/ 2>/dev/null || true)"
             if [ "$http_code" -ge 200 ] 2>/dev/null && [ "$http_code" -lt 400 ]; then break; fi
             sleep 2
-            if [ "$i" -eq 600 ]; then echo "NetBox did not become ready"; docker logs netbox-e2e-http || true; exit 1; fi
+            if [ "$i" -eq 900 ]; then echo "NetBox did not become ready"; docker logs netbox-e2e-http || true; exit 1; fi
           done
 
           for i in $(seq 1 60); do


### PR DESCRIPTION
## Summary
- The previous PyPI lane run (25897686683) failed at the 20-min NetBox readiness gate. `uv pip install netbox-proxbox@develop` (resolving to a 0.0.16-dev branch with native-C deps) took ~22 min to compile inside the NetBox container; the install completed ~2 min past the gate cap, so all three matrix slots (v4.5.8 / v4.5.9 / v4.6.0) failed before NetBox could respond on `/api/`.
- Pin `NETBOX_PROXBOX_TARGET` to the `v0.0.15rc4` tag tarball — release-lane validation should pin a stable plugin version, not float on `develop`.
- Bump readiness gate from 600 → 900 iterations (20 → 30 min cap) so install + migrations + search indexing have headroom on GitHub-hosted runners.

## Test plan
- [ ] After merge, re-trigger the PyPI lane (rc2) and confirm `e2e-pre-publish [v4.5.8 / v4.5.9 / v4.6.0]` all succeed.
- [ ] Confirm `publish-pypi` and `publish-docker` then run to completion.

Fixes the NetBox readiness gate timeout that blocked v0.0.11rc1 from reaching PyPI / DockerHub.