### PR TITLE
chore(release): cut v0.0.11rc2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ proxbox_api = ["static/*", "static/**/*", "generated/**/*.json", "generated/**/*
 
 [project]
 name = "proxbox_api"
-version = "0.0.11rc1"
+version = "0.0.11rc2"
 description = "Proxbox API service made using FastAPI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1703,7 +1703,7 @@ wheels = [
 
 [[package]]
 name = "proxbox-api"
-version = "0.0.11rc1"
+version = "0.0.11rc2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- Bump version to `0.0.11rc2` (pyproject.toml + uv.lock).
- rc1 PyPI slot was consumed when run 25897686683 failed all three `e2e-pre-publish` matrix slots at the 20-min NetBox readiness gate.
- Builds on PR #103 (raised gate to 30 min + pinned netbox-proxbox to v0.0.15rc4) so the rc2 lane should reach PyPI + DockerHub.

## Test plan
- [ ] PyPI lane triggered by tag `v0.0.11rc2` passes `e2e-pre-publish` matrix on v4.5.8 / v4.5.9 / v4.6.0.
- [ ] `publish-pypi` and `publish-docker` complete successfully.
- [ ] Then cut v0.0.11 final.