### PR TITLE
chore(release): v0.0.11rc3 — NetBox DB_WAIT_TIMEOUT fix

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -393,6 +393,7 @@ jobs:
 
           docker run -d --name netbox-e2e-http --network proxbox-e2e -p 18080:8000 \
             -e DB_HOST=netbox-e2e-postgres \
+            -e DB_WAIT_TIMEOUT=600 \
             -e DB_NAME=netbox \
             -e DB_USER=netbox \
             -e DB_PASSWORD=netbox \
@@ -661,6 +662,7 @@ jobs:
 
           docker run -d --name netbox-e2e-http --network proxbox-e2e -p 18080:8000 \
             -e DB_HOST=netbox-e2e-postgres \
+            -e DB_WAIT_TIMEOUT=600 \
             -e DB_NAME=netbox \
             -e DB_USER=netbox \
             -e DB_PASSWORD=netbox \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ proxbox_api = ["static/*", "static/**/*", "generated/**/*.json", "generated/**/*
 
 [project]
 name = "proxbox_api"
-version = "0.0.11rc2"
+version = "0.0.11rc3"
 description = "Proxbox API service made using FastAPI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1703,7 +1703,7 @@ wheels = [
 
 [[package]]
 name = "proxbox-api"
-version = "0.0.11rc2"
+version = "0.0.11rc3"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- Bump version 0.0.11rc2 → 0.0.11rc3 (rc2 PyPI slot consumed).
- Set `DB_WAIT_TIMEOUT=600` on both `netbox-e2e-http` docker run blocks in `publish-testpypi.yml` so the NetBox docker-entrypoint's 30s default doesn't kill the container before Postgres is reachable.

## Why
rc2 PyPI lane (run 25898549133) failed across all three e2e-pre-publish matrix jobs (v4.5.8, v4.5.9, v4.6.0). Container logs show `Waiting on DB... (0s / 30s)` through `(27s / 30s)` then exit, even though PostgreSQL was healthy throughout. The 30-min outer shell readiness gate is irrelevant once the container is dead. This rc gives the entrypoint 10 minutes of DB-wait headroom.

## Test plan
- [ ] PyPI lane `prepare-release` succeeds
- [ ] `e2e-pre-publish` matrix (v4.5.8, v4.5.9, v4.6.0) succeeds
- [ ] `publish-pypi` uploads rc3
- [ ] `publish-docker` succeeds
- [ ] `e2e-post-publish` succeeds