### PR TITLE
release: v0.0.11rc4 with workflow contract test aligned

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ proxbox_api = ["static/*", "static/**/*", "generated/**/*.json", "generated/**/*
 
 [project]
 name = "proxbox_api"
-version = "0.0.11rc3"
+version = "0.0.11rc4"
 description = "Proxbox API service made using FastAPI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -43,7 +43,7 @@ def test_netbox_e2e_readiness_is_long_enough_for_migrations_and_api_status():
     assert "NetBox API did not become ready" in ci_workflow
 
     assert publish_workflow.count("timeout-minutes: 45") >= 2
-    assert publish_workflow.count("for i in $(seq 1 600); do") >= 2
+    assert publish_workflow.count("for i in $(seq 1 900); do") >= 2
     assert publish_workflow.count("NetBox API did not become ready") >= 2
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1703,7 +1703,7 @@ wheels = [
 
 [[package]]
 name = "proxbox-api"
-version = "0.0.11rc3"
+version = "0.0.11rc4"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Align `tests/test_release_workflows.py` with the post-rc1 NetBox readiness gate so the static workflow contract test stops failing the `validate-pypi-candidate` matrix.

- rc1 patch (task #6) bumped `publish-testpypi.yml`'s outer NetBox-ready loop from `seq 1 600` to `seq 1 900` to absorb migration time.
- The contract assertion in `test_netbox_e2e_readiness_is_long_enough_for_migrations_and_api_status` still asserted `seq 1 600`, which made rc2 and rc3 `validate-pypi-candidate` jobs fail with `assert 0 >= 2`.
- This commit updates the assertion to expect `seq 1 900` and bumps the package version to rc4 (rc3 slot consumed by the failing run).

## Test plan

- [x] `uv run pytest tests/test_release_workflows.py` (6/6 pass locally)
- [ ] `validate PyPI candidate / py3.{11,12,13}` jobs pass in the rc4 lane
- [ ] `E2E pre-publish (dev deps) [v4.5.8 / v4.5.9 / v4.6.0]` jobs pass (DB_WAIT_TIMEOUT=600 fix from rc3 retained)
- [ ] `publish-pypi` + `publish-docker` succeed