### PR TITLE
release: v0.0.11rc5 with e2e-post-publish netbox-proxbox pin

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -630,6 +630,7 @@ jobs:
           set -eux
           docker network create proxbox-e2e || true
           SECRET_KEY='proxbox-e2e-secret-key-proxbox-e2e-secret-key-proxbox-e2e-secret-key'
+          NETBOX_PROXBOX_TARGET='https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.15rc4.tar.gz'
 
           docker rm -f netbox-e2e-postgres netbox-e2e-redis netbox-e2e-http proxmox-e2e-mock proxbox-e2e 2>/dev/null || true
 
@@ -676,7 +677,7 @@ jobs:
             -e ALLOWED_HOSTS="* localhost 127.0.0.1 ::1 netbox-e2e-http" \
             -e LOGIN_REQUIRED=False \
             --entrypoint /bin/bash \
-            "${NETBOX_IMAGE}" -ec "uv pip install --no-cache-dir netbox-proxbox && mkdir -p /etc/netbox/config && printf 'PLUGINS = [\"netbox_proxbox\"]\\n' > /etc/netbox/config/plugins.py && /opt/netbox/docker-entrypoint.sh /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py runserver 0.0.0.0:8000 --insecure"
+            "${NETBOX_IMAGE}" -ec "uv pip install --no-cache-dir '${NETBOX_PROXBOX_TARGET}' && mkdir -p /etc/netbox/config && printf 'PLUGINS = [\"netbox_proxbox\"]\\n' > /etc/netbox/config/plugins.py && /opt/netbox/docker-entrypoint.sh /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py runserver 0.0.0.0:8000 --insecure"
 
           docker pull "${PROXBOX_API_IMAGE}:${RELEASE_VERSION}"
           docker run -d --name proxbox-e2e --network proxbox-e2e -p 18081:8000 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ proxbox_api = ["static/*", "static/**/*", "generated/**/*.json", "generated/**/*
 
 [project]
 name = "proxbox_api"
-version = "0.0.11rc4"
+version = "0.0.11rc5"
 description = "Proxbox API service made using FastAPI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1703,7 +1703,7 @@ wheels = [
 
 [[package]]
 name = "proxbox-api"
-version = "0.0.11rc4"
+version = "0.0.11rc5"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Pin `netbox-proxbox` in the e2e-post-publish bootstrap to the same `v0.0.15rc4` GitHub tarball that e2e-pre-publish already uses.

## Why

- Latest `netbox-proxbox` on PyPI is `v0.0.9`.
- v0.0.9 declares `min_version=4.5.0, max_version=4.5.99` in its `PluginConfig`.
- e2e-post-publish matrix tests against NetBox v4.5.8, v4.5.9, **and v4.6.0**.
- On v4.6.0, NetBox refuses to load the plugin → startup crash → readiness gate times out at 30 minutes → e2e-post-publish v4.6.0 fails.

Pinning to `v0.0.15rc4` (which supports NetBox 4.5.8–4.6.99) keeps the published-artifacts smoke check honest while unblocking the v4.6.0 slot.

## Test plan

- [x] Both bootstrap commands (lines 410 + 680) now install from the same tarball URL
- [x] `uv lock --check` passes
- [ ] rc5 PyPI lane passes validate-pypi-candidate × 3
- [ ] rc5 PyPI lane passes e2e-pre-publish × 3
- [ ] rc5 PyPI lane reaches publish-pypi → publish-docker → e2e-post-publish × 3 successfully