### PR TITLE
release: v0.0.11

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -35,7 +35,7 @@ ci.yml (push/PR — dev mode E2E only)
 ├── setup             (generates E2E matrix)
 ├── build-netbox-image (only uploads an artifact when the public NetBox image cannot be pulled)
 └── e2e-docker        (needs: test + setup + build-netbox-image; transport × NetBox version matrix)
-    - dev mode:  netbox-proxbox from GitHub develop tarball
+    - dev mode:  netbox-proxbox from pinned GitHub release tag tarball (currently v0.0.15)
                  proxbox-api built from local checkout with DEV_OVERRIDES (netbox-sdk + proxmox-sdk from GitHub)
     - pypi mode: netbox-proxbox from PyPI; proxbox-api built from local checkout without overrides
     - NetBox image handling: each E2E job pulls the public image first and only downloads the source-built artifact when the registry pull fails.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,7 +344,7 @@ jobs:
         id: proxbox_pkg
         run: |
           if [ "${{ matrix.netbox_proxbox_mode }}" = "dev" ]; then
-            echo "target=https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.15rc12.tar.gz" >> "$GITHUB_OUTPUT"
+            echo "target=https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.15.tar.gz" >> "$GITHUB_OUTPUT"
           else
             echo "target=netbox-proxbox" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,7 +344,7 @@ jobs:
         id: proxbox_pkg
         run: |
           if [ "${{ matrix.netbox_proxbox_mode }}" = "dev" ]; then
-            echo "target=https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/heads/develop.tar.gz" >> "$GITHUB_OUTPUT"
+            echo "target=https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.15rc12.tar.gz" >> "$GITHUB_OUTPUT"
           else
             echo "target=netbox-proxbox" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -359,7 +359,7 @@ jobs:
           set -eux
           docker network create proxbox-e2e || true
           SECRET_KEY='proxbox-e2e-secret-key-proxbox-e2e-secret-key-proxbox-e2e-secret-key'
-          NETBOX_PROXBOX_TARGET='https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.15rc11.tar.gz'
+          NETBOX_PROXBOX_TARGET='https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.15rc12.tar.gz'
           DEV_OVERRIDES='git+https://github.com/emersonfelipesp/netbox-sdk.git@main git+https://github.com/emersonfelipesp/proxmox-sdk.git@main'
 
           docker rm -f netbox-e2e-postgres netbox-e2e-redis netbox-e2e-http proxmox-e2e-mock proxbox-e2e 2>/dev/null || true
@@ -630,7 +630,7 @@ jobs:
           set -eux
           docker network create proxbox-e2e || true
           SECRET_KEY='proxbox-e2e-secret-key-proxbox-e2e-secret-key-proxbox-e2e-secret-key'
-          NETBOX_PROXBOX_TARGET='https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.15rc11.tar.gz'
+          NETBOX_PROXBOX_TARGET='https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.15rc12.tar.gz'
 
           docker rm -f netbox-e2e-postgres netbox-e2e-redis netbox-e2e-http proxmox-e2e-mock proxbox-e2e 2>/dev/null || true
 

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -359,7 +359,7 @@ jobs:
           set -eux
           docker network create proxbox-e2e || true
           SECRET_KEY='proxbox-e2e-secret-key-proxbox-e2e-secret-key-proxbox-e2e-secret-key'
-          NETBOX_PROXBOX_TARGET='https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.15rc12.tar.gz'
+          NETBOX_PROXBOX_TARGET='https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.15.tar.gz'
           DEV_OVERRIDES='git+https://github.com/emersonfelipesp/netbox-sdk.git@main git+https://github.com/emersonfelipesp/proxmox-sdk.git@main'
 
           docker rm -f netbox-e2e-postgres netbox-e2e-redis netbox-e2e-http proxmox-e2e-mock proxbox-e2e 2>/dev/null || true
@@ -630,7 +630,7 @@ jobs:
           set -eux
           docker network create proxbox-e2e || true
           SECRET_KEY='proxbox-e2e-secret-key-proxbox-e2e-secret-key-proxbox-e2e-secret-key'
-          NETBOX_PROXBOX_TARGET='https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.15rc12.tar.gz'
+          NETBOX_PROXBOX_TARGET='https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.15.tar.gz'
 
           docker rm -f netbox-e2e-postgres netbox-e2e-redis netbox-e2e-http proxmox-e2e-mock proxbox-e2e 2>/dev/null || true
 

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -407,7 +407,7 @@ jobs:
             -e ALLOWED_HOSTS="* localhost 127.0.0.1 ::1 netbox-e2e-http" \
             -e LOGIN_REQUIRED=False \
             --entrypoint /bin/bash \
-            "${NETBOX_IMAGE}" -ec "uv pip install --no-cache-dir '${NETBOX_PROXBOX_TARGET}' && mkdir -p /etc/netbox/config && printf 'PLUGINS = [\"netbox_proxbox\"]\\n' > /etc/netbox/config/plugins.py && /opt/netbox/docker-entrypoint.sh /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py runserver 0.0.0.0:8000 --insecure"
+            "${NETBOX_IMAGE}" -ec "uv pip install --no-cache-dir '${NETBOX_PROXBOX_TARGET}' && mkdir -p /etc/netbox/config && printf 'PLUGINS = [\"netbox_proxbox\"]\\n' > /etc/netbox/config/plugins.py && i=0 && until /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py migrate --no-input; do i=\$((i+1)); if [ \$i -ge 120 ]; then echo 'migrate exhausted retries'; exit 1; fi; sleep 2; done && /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py runserver 0.0.0.0:8000 --insecure"
 
           docker build --target raw \
             --build-arg "DEV_OVERRIDES=${DEV_OVERRIDES}" \
@@ -677,7 +677,7 @@ jobs:
             -e ALLOWED_HOSTS="* localhost 127.0.0.1 ::1 netbox-e2e-http" \
             -e LOGIN_REQUIRED=False \
             --entrypoint /bin/bash \
-            "${NETBOX_IMAGE}" -ec "uv pip install --no-cache-dir '${NETBOX_PROXBOX_TARGET}' && mkdir -p /etc/netbox/config && printf 'PLUGINS = [\"netbox_proxbox\"]\\n' > /etc/netbox/config/plugins.py && /opt/netbox/docker-entrypoint.sh /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py runserver 0.0.0.0:8000 --insecure"
+            "${NETBOX_IMAGE}" -ec "uv pip install --no-cache-dir '${NETBOX_PROXBOX_TARGET}' && mkdir -p /etc/netbox/config && printf 'PLUGINS = [\"netbox_proxbox\"]\\n' > /etc/netbox/config/plugins.py && i=0 && until /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py migrate --no-input; do i=\$((i+1)); if [ \$i -ge 120 ]; then echo 'migrate exhausted retries'; exit 1; fi; sleep 2; done && /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py runserver 0.0.0.0:8000 --insecure"
 
           docker pull "${PROXBOX_API_IMAGE}:${RELEASE_VERSION}"
           docker run -d --name proxbox-e2e --network proxbox-e2e -p 18081:8000 \

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -359,7 +359,7 @@ jobs:
           set -eux
           docker network create proxbox-e2e || true
           SECRET_KEY='proxbox-e2e-secret-key-proxbox-e2e-secret-key-proxbox-e2e-secret-key'
-          NETBOX_PROXBOX_TARGET='https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.15rc4.tar.gz'
+          NETBOX_PROXBOX_TARGET='https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.15rc11.tar.gz'
           DEV_OVERRIDES='git+https://github.com/emersonfelipesp/netbox-sdk.git@main git+https://github.com/emersonfelipesp/proxmox-sdk.git@main'
 
           docker rm -f netbox-e2e-postgres netbox-e2e-redis netbox-e2e-http proxmox-e2e-mock proxbox-e2e 2>/dev/null || true
@@ -630,7 +630,7 @@ jobs:
           set -eux
           docker network create proxbox-e2e || true
           SECRET_KEY='proxbox-e2e-secret-key-proxbox-e2e-secret-key-proxbox-e2e-secret-key'
-          NETBOX_PROXBOX_TARGET='https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.15rc4.tar.gz'
+          NETBOX_PROXBOX_TARGET='https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.15rc11.tar.gz'
 
           docker rm -f netbox-e2e-postgres netbox-e2e-redis netbox-e2e-http proxmox-e2e-mock proxbox-e2e 2>/dev/null || true
 

--- a/proxbox_api/routes/proxmox/runtime_generated.py
+++ b/proxbox_api/routes/proxmox/runtime_generated.py
@@ -721,5 +721,4 @@ def clear_generated_proxmox_route_cache() -> None:
     """Remove the persisted runtime-generated Proxmox route cache artifact."""
 
     cache_path = _generated_route_cache_path()
-    if cache_path.exists():
-        cache_path.unlink()
+    cache_path.unlink(missing_ok=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ proxbox_api = ["static/*", "static/**/*", "generated/**/*.json", "generated/**/*
 
 [project]
 name = "proxbox_api"
-version = "0.0.11rc7"
+version = "0.0.11rc8"
 description = "Proxbox API service made using FastAPI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ proxbox_api = ["static/*", "static/**/*", "generated/**/*.json", "generated/**/*
 
 [project]
 name = "proxbox_api"
-version = "0.0.11rc5"
+version = "0.0.11rc6"
 description = "Proxbox API service made using FastAPI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ proxbox_api = ["static/*", "static/**/*", "generated/**/*.json", "generated/**/*
 
 [project]
 name = "proxbox_api"
-version = "0.0.11rc6"
+version = "0.0.11rc7"
 description = "Proxbox API service made using FastAPI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ proxbox_api = ["static/*", "static/**/*", "generated/**/*.json", "generated/**/*
 
 [project]
 name = "proxbox_api"
-version = "0.0.11rc8"
+version = "0.0.11"
 description = "Proxbox API service made using FastAPI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1703,7 +1703,7 @@ wheels = [
 
 [[package]]
 name = "proxbox-api"
-version = "0.0.11rc5"
+version = "0.0.11rc6"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/uv.lock
+++ b/uv.lock
@@ -1703,7 +1703,7 @@ wheels = [
 
 [[package]]
 name = "proxbox-api"
-version = "0.0.11rc6"
+version = "0.0.11rc7"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/uv.lock
+++ b/uv.lock
@@ -1703,7 +1703,7 @@ wheels = [
 
 [[package]]
 name = "proxbox-api"
-version = "0.0.11rc7"
+version = "0.0.11rc8"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/uv.lock
+++ b/uv.lock
@@ -1703,7 +1703,7 @@ wheels = [
 
 [[package]]
 name = "proxbox-api"
-version = "0.0.11rc8"
+version = "0.0.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Bump `proxbox-api` from `0.0.11rc8` to **`0.0.11`** (final).
- Repin netbox-proxbox dev E2E target from `v0.0.15rc12` to **`v0.0.15`** (final, released 2026-05-15) in `ci.yml` and `publish-testpypi.yml`; update `.github/CLAUDE.md` accordingly.
- Required compatibility floor: **`proxmox-sdk==0.0.4.post3`**, **`netbox-sdk==0.0.8.post1`**, **NetBox 4.5.8 / 4.5.9 / 4.6.0**.

## Pre-release verification (v0.0.11rc8 → v0.0.11 lane)

`publish-testpypi.yml` ran end-to-end on tag `v0.0.11rc8` (commit `e18bbaa`) and went fully green:

- prepare-release / validate-pypi-candidate (py3.11/3.12/3.13) — success
- E2E pre-publish (dev deps) [v4.5.8 / v4.5.9 / v4.6.0] — success
- publish to PyPI — success (`proxbox_api-0.0.11rc8` uploaded 2026-05-15T13:21:29Z)
- validate PyPI (py3.11/3.12/3.13) — success after rerun (initial py3.12/3.13 hit pypi CDN propagation lag; artifact verified present then `gh run rerun --failed` → green)
- publish Docker Hub — granian / nginx / raw — success
- E2E post-publish (published artifacts) [v4.5.8 / v4.5.9 / v4.6.0] — success

## Release plan after merge

1. Tag `v0.0.11` on `main`
2. Publish GitHub Release for `v0.0.11`
3. Release event fires `docker-hub-publish.yml` (final image tags) and `release-docker-verify.yml` (post-release smoke)

## Test plan

- [x] All RC publish-testpypi gates green for v0.0.11rc8
- [x] e2e-post-publish green against NetBox 4.5.8 / 4.5.9 / 4.6.0
- [ ] CI green on merge commit
- [ ] Tag `v0.0.11` triggers PyPI + Docker Hub publish lane
- [ ] release-docker-verify.yml green on all three published images