### PR TITLE
feat(cloud): build Proxmox template images

### DIFF
--- a/proxbox_api/app/factory.py
+++ b/proxbox_api/app/factory.py
@@ -33,6 +33,7 @@ from proxbox_api.openapi_custom import custom_openapi_builder
 from proxbox_api.routes.admin import router as admin_router
 from proxbox_api.routes.auth import router as auth_router
 from proxbox_api.routes.cloud import provision_router as cloud_provision_router
+from proxbox_api.routes.cloud import template_images_router as cloud_template_images_router
 from proxbox_api.routes.cloud import templates_router as cloud_templates_router
 from proxbox_api.routes.dcim import router as dcim_router
 from proxbox_api.routes.extras import router as extras_router
@@ -423,6 +424,7 @@ def create_app() -> FastAPI:  # noqa: C901
         app.include_router(intent_router, prefix="/intent", tags=["intent"])
         app.include_router(deletion_requests_router, prefix="/intent", tags=["intent"])
         app.include_router(cloud_provision_router, prefix="/cloud", tags=["cloud"])
+        app.include_router(cloud_template_images_router, prefix="/cloud", tags=["cloud"])
         app.include_router(cloud_templates_router, prefix="/cloud", tags=["cloud"])
         app.include_router(
             sync_individual_router, prefix="/sync/individual", tags=["sync / individual"]

--- a/proxbox_api/routes/cloud/__init__.py
+++ b/proxbox_api/routes/cloud/__init__.py
@@ -1,6 +1,7 @@
 """Cloud Portal provisioning routes."""
 
 from proxbox_api.routes.cloud.provision import router as provision_router
+from proxbox_api.routes.cloud.template_images import router as template_images_router
 from proxbox_api.routes.cloud.templates import router as templates_router
 
-__all__ = ("provision_router", "templates_router")
+__all__ = ("provision_router", "template_images_router", "templates_router")

--- a/proxbox_api/routes/cloud/template_images.py
+++ b/proxbox_api/routes/cloud/template_images.py
@@ -1,0 +1,221 @@
+"""Cloud image template build route."""
+
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+from typing import Any
+from urllib.parse import urlsplit
+
+from fastapi import APIRouter, HTTPException, status
+from fastapi.responses import JSONResponse
+
+from proxbox_api.database import AsyncDatabaseSessionDep as SessionDep
+from proxbox_api.routes.cloud.provision import _extract_task_id, _wait_for_upid
+from proxbox_api.routes.proxmox_actions import _gate, _open_proxmox_session
+from proxbox_api.schemas.cloud_provision import (
+    CloudImageTemplateBuildRequest,
+    CloudImageTemplateBuildResponse,
+)
+from proxbox_api.session.proxmox import ProxmoxSession
+from proxbox_api.utils.async_compat import maybe_await as _maybe_await
+
+router = APIRouter()
+
+_IMAGE_EXTENSIONS = {".qcow2", ".raw", ".vmdk", ".vma"}
+
+
+def _filename_from_request(req: CloudImageTemplateBuildRequest) -> str:
+    raw = (req.image_filename or "").strip()
+    if not raw:
+        raw = PurePosixPath(urlsplit(req.image_url).path).name
+    if not raw:
+        raise HTTPException(status_code=422, detail="image_filename could not be derived.")
+    path = PurePosixPath(raw)
+    suffix = path.suffix.lower()
+    if suffix == ".img":
+        return f"{path.stem}.qcow2"
+    if suffix not in _IMAGE_EXTENSIONS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"image_filename must end with one of {sorted(_IMAGE_EXTENSIONS)}.",
+        )
+    return path.name
+
+
+def _is_ready_template(config: object) -> bool:
+    if not isinstance(config, dict):
+        return False
+    return (
+        str(config.get("template")) in {"1", "True", "true"}
+        and "scsi0" in config
+        and "cloudinit" in str(config.get("ide2", "")).lower()
+        and "scsi0" in str(config.get("boot", ""))
+    )
+
+
+async def _vm_config_or_none(
+    proxmox: ProxmoxSession,
+    *,
+    node: str,
+    vmid: int,
+) -> dict[str, Any] | None:
+    try:
+        config = await _maybe_await(proxmox.session.nodes(node).qemu(vmid).config.get())
+    except Exception:  # noqa: BLE001
+        return None
+    return config if isinstance(config, dict) else {}
+
+
+async def _image_exists(
+    proxmox: ProxmoxSession,
+    *,
+    node: str,
+    storage: str,
+    volid: str,
+) -> bool:
+    try:
+        content = await _maybe_await(
+            proxmox.session.nodes(node).storage(storage).content.get(content="import")
+        )
+    except Exception:  # noqa: BLE001
+        return False
+    rows = content if isinstance(content, list) else []
+    return any(isinstance(row, dict) and row.get("volid") == volid for row in rows)
+
+
+async def _wait_for_task(
+    proxmox: ProxmoxSession,
+    *,
+    node: str,
+    response: object,
+) -> str | None:
+    upid = _extract_task_id(response)
+    if upid and upid.startswith("UPID:"):
+        await _wait_for_upid(proxmox, node, upid)
+    return upid
+
+
+@router.post(
+    "/templates/images",
+    response_model=CloudImageTemplateBuildResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def build_cloud_image_template(
+    req: CloudImageTemplateBuildRequest,
+    session: SessionDep,
+) -> CloudImageTemplateBuildResponse | JSONResponse:
+    """Create a bootable Proxmox template from a cloud image URL."""
+    gated = await _gate(session, req.endpoint_id)
+    if isinstance(gated, JSONResponse):
+        return gated
+
+    filename = _filename_from_request(req)
+    image_volid = f"{req.image_storage}:import/{filename}"
+    proxmox: ProxmoxSession | None = None
+    try:
+        proxmox = await _open_proxmox_session(gated)
+        existing = await _vm_config_or_none(
+            proxmox,
+            node=req.target_node,
+            vmid=req.vmid,
+        )
+        if existing is not None:
+            if _is_ready_template(existing):
+                return CloudImageTemplateBuildResponse(
+                    endpoint_id=req.endpoint_id,
+                    target_node=req.target_node,
+                    vmid=req.vmid,
+                    name=str(existing.get("name") or req.name),
+                    status="already_exists",
+                    image_volid=image_volid,
+                    boot=existing.get("boot"),
+                    scsi0=existing.get("scsi0"),
+                    ide2=existing.get("ide2"),
+                )
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"VMID {req.vmid} already exists and is not a ready cloud-init template.",
+            )
+
+        download_upid = None
+        if not await _image_exists(
+            proxmox,
+            node=req.target_node,
+            storage=req.image_storage,
+            volid=image_volid,
+        ):
+            download_result = await _maybe_await(
+                proxmox.session.nodes(req.target_node)
+                .storage(f"{req.image_storage}/download-url")
+                .post(
+                    content="import",
+                    filename=filename,
+                    url=req.image_url,
+                    **{"verify-certificates": 1 if req.verify_image_certificates else 0},
+                )
+            )
+            download_upid = await _wait_for_task(
+                proxmox,
+                node=req.target_node,
+                response=download_result,
+            )
+
+        create_kwargs: dict[str, object] = {
+            "vmid": req.vmid,
+            "name": req.name,
+            "memory": req.memory_mb,
+            "cores": req.cores,
+            "sockets": 1,
+            "ostype": req.os_type,
+            "agent": "enabled=1",
+            "scsihw": "virtio-scsi-pci",
+            "scsi0": f"{req.vm_storage}:0,import-from={image_volid},discard=on",
+            "ide2": f"{req.vm_storage}:cloudinit",
+            "boot": "order=scsi0",
+            "serial0": "socket",
+            "vga": "serial0",
+            "net0": f"virtio,bridge={req.bridge}",
+            "ciuser": req.ciuser,
+            "ipconfig0": "ip=dhcp",
+        }
+        if req.cpu:
+            create_kwargs["cpu"] = req.cpu
+        if req.description:
+            create_kwargs["description"] = req.description
+        create_result = await _maybe_await(
+            proxmox.session.nodes(req.target_node).qemu.post(**create_kwargs)
+        )
+        create_upid = await _wait_for_task(proxmox, node=req.target_node, response=create_result)
+
+        template_result = await _maybe_await(
+            proxmox.session.nodes(req.target_node).qemu(req.vmid).template.post(disk="scsi0")
+        )
+        template_upid = await _wait_for_task(
+            proxmox,
+            node=req.target_node,
+            response=template_result,
+        )
+        config = await _vm_config_or_none(proxmox, node=req.target_node, vmid=req.vmid)
+        if not _is_ready_template(config):
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Proxmox template was created but did not reach the expected config.",
+            )
+        config = config or {}
+        return CloudImageTemplateBuildResponse(
+            endpoint_id=req.endpoint_id,
+            target_node=req.target_node,
+            vmid=req.vmid,
+            name=str(config.get("name") or req.name),
+            status="created",
+            image_volid=image_volid,
+            download_upid=download_upid,
+            create_upid=create_upid,
+            template_upid=template_upid,
+            boot=config.get("boot"),
+            scsi0=config.get("scsi0"),
+            ide2=config.get("ide2"),
+        )
+    finally:
+        if proxmox is not None:
+            await proxmox.aclose()

--- a/proxbox_api/schemas/cloud_provision.py
+++ b/proxbox_api/schemas/cloud_provision.py
@@ -24,6 +24,7 @@ class CloudVMProvisionRequest(BaseModel):
         description="VM memory in MiB (Proxmox 'memory' convention; field name kept for API compatibility)",
     )
     cores: Optional[int] = Field(None, ge=1)
+    disk_gb: Optional[int] = Field(None, ge=1)
     full_clone: bool = True
 
 
@@ -31,6 +32,7 @@ class CloudVMProvisionResponse(BaseModel):
     new_vmid: int
     clone_upid: Optional[str] = None
     config_upid: Optional[str] = None
+    resize_upid: Optional[str] = None
     start_upid: Optional[str] = None
     status: str  # "started" | "stopped" (failures raise HTTPException)
     detail: Optional[str] = None
@@ -53,3 +55,48 @@ class CloudTemplateSummary(BaseModel):
 class CloudTemplateListResponse(BaseModel):
     count: int
     results: list[CloudTemplateSummary]
+
+
+class CloudImageTemplateBuildRequest(BaseModel):
+    """Create a Proxmox cloud-init VM template from a downloadable cloud image."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    endpoint_id: int = Field(..., description="ProxmoxEndpoint primary key")
+    vmid: int = Field(..., ge=100, description="Template VMID to create")
+    name: str = Field(..., min_length=1, max_length=128)
+    target_node: str = Field(..., min_length=1)
+    image_url: str = Field(
+        "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img",
+        min_length=1,
+        description="HTTP(S) URL for the source cloud image",
+    )
+    image_filename: str | None = Field(
+        None,
+        description="Filename to store in Proxmox import storage; .img is normalized to .qcow2",
+    )
+    image_storage: str = Field("local", min_length=1)
+    vm_storage: str = Field("local-zfs", min_length=1)
+    memory_mb: int = Field(512, ge=64)
+    cores: int = Field(1, ge=1)
+    bridge: str = Field("vmbr0", min_length=1)
+    ciuser: str = Field("ubuntu", min_length=1, max_length=64)
+    os_type: str = Field("l26", min_length=1)
+    cpu: str | None = Field("host")
+    verify_image_certificates: bool = True
+    description: str | None = Field(None, max_length=8192)
+
+
+class CloudImageTemplateBuildResponse(BaseModel):
+    endpoint_id: int
+    target_node: str
+    vmid: int
+    name: str
+    status: str
+    image_volid: str
+    download_upid: Optional[str] = None
+    create_upid: Optional[str] = None
+    template_upid: Optional[str] = None
+    boot: Optional[str] = None
+    scsi0: Optional[str] = None
+    ide2: Optional[str] = None

--- a/tests/cloud/test_cloud_router_contract.py
+++ b/tests/cloud/test_cloud_router_contract.py
@@ -15,8 +15,9 @@ from proxbox_api.schemas.cloud_provision import CloudVMProvisionRequest
 
 def test_cloud_package_exposes_both_routers():
     assert cloud.provision_router is not None
+    assert cloud.template_images_router is not None
     assert cloud.templates_router is not None
-    assert cloud.__all__ == ("provision_router", "templates_router")
+    assert cloud.__all__ == ("provision_router", "template_images_router", "templates_router")
 
 
 def test_cloud_routes_are_registered_on_app(monkeypatch):
@@ -30,6 +31,10 @@ def test_cloud_routes_are_registered_on_app(monkeypatch):
     )
     assert any(
         route.path == "/cloud/templates" and "GET" in (route.methods or set())
+        for route in test_app.routes
+    )
+    assert any(
+        route.path == "/cloud/templates/images" and "POST" in (route.methods or set())
         for route in test_app.routes
     )
 
@@ -68,3 +73,5 @@ def test_cloud_provision_route_reuses_required_helpers():
 
     assert "build_proxmox_ci_args" in source
     assert "_gate" in source
+    assert "await _wait_for_upid(proxmox, req.target_node, config_upid)" in source
+    assert "await _wait_for_upid(proxmox, req.target_node, start_upid)" in source

--- a/tests/cloud/test_template_images_contract.py
+++ b/tests/cloud/test_template_images_contract.py
@@ -1,0 +1,27 @@
+"""Static contracts for cloud image template build support."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_cloud_template_image_build_route_registered() -> None:
+    factory = (ROOT / "proxbox_api/app/factory.py").read_text()
+    init = (ROOT / "proxbox_api/routes/cloud/__init__.py").read_text()
+    assert "template_images_router" in init
+    assert "cloud_template_images_router" in factory
+
+
+def test_cloud_template_image_build_route_creates_bootable_cloudinit_template() -> None:
+    src = (ROOT / "proxbox_api/routes/cloud/template_images.py").read_text()
+    for token in (
+        '"/templates/images"',
+        "download-url",
+        "import-from",
+        '"boot": "order=scsi0"',
+        '"ide2": f"{req.vm_storage}:cloudinit"',
+        ".template.post(disk=\"scsi0\")",
+    ):
+        assert token in src


### PR DESCRIPTION
## Summary

- Add `POST /cloud/templates/images` to create or reuse Proxmox cloud-init template images.
- Normalize Ubuntu cloud image imports and configure QEMU cloud-init template settings.
- Register the router and add contract coverage for the new route.

## Validation

- `uv run ruff check proxbox_api/routes/cloud/template_images.py proxbox_api/schemas/cloud_provision.py proxbox_api/app/factory.py tests/cloud/test_template_images_contract.py`
- `uv run pytest tests/cloud/test_template_images_contract.py tests/cloud/test_cloud_router_contract.py`
- Live admin build endpoint returned `201` with VMID `9000` marked ready.
