### PR TITLE
fix(cloud): validate image_url against SSRF protection before download

### DIFF
--- a/proxbox_api/routes/cloud/template_images.py
+++ b/proxbox_api/routes/cloud/template_images.py
@@ -17,6 +17,7 @@ from proxbox_api.schemas.cloud_provision import (
     CloudImageTemplateBuildResponse,
 )
 from proxbox_api.session.proxmox import ProxmoxSession
+from proxbox_api.ssrf import validate_endpoint_url
 from proxbox_api.utils.async_compat import maybe_await as _maybe_await
 
 router = APIRouter()
@@ -111,6 +112,14 @@ async def build_cloud_image_template(
 
     filename = _filename_from_request(req)
     image_volid = f"{req.image_storage}:import/{filename}"
+
+    safe, reason = validate_endpoint_url(req.image_url)
+    if not safe:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"image_url rejected by SSRF protection: {reason}",
+        )
+
     proxmox: ProxmoxSession | None = None
     try:
         proxmox = await _open_proxmox_session(gated)


### PR DESCRIPTION
## Summary

- `build_cloud_image_template` now calls `validate_endpoint_url(req.image_url)` from `proxbox_api.ssrf` before opening the Proxmox session.
- Submitting an RFC 1918 or otherwise blocked URL now returns HTTP 422 instead of forwarding the request to Proxmox for download.
- The preceding commit (`c3465b4`) already hardened `source_url` in the codegen route; this applies the same guard to the cloud template build route.

## Test plan
- [x] `proxbox_api/routes/cloud/template_images.py` lint clean (`ruff check`)
- [x] Compiles clean (`python3 -m compileall`)
- [ ] Submit a request with `image_url: "http://10.0.0.1/evil.img"` → expect HTTP 422