### PR TITLE
fix(ha): degrade gracefully on PVE 9.x cluster/ha/groups HTTP 500 (#111)

### DIFF
--- a/proxbox_api/routes/proxmox/ha.py
+++ b/proxbox_api/routes/proxmox/ha.py
@@ -1,8 +1,16 @@
 """Proxmox cluster High-Availability endpoints (read-only).
 
-Surfaces `/cluster/ha/status/current`, `/cluster/ha/resources`, and
-`/cluster/ha/groups` from Proxmox so the netbox-proxbox plugin can render
-HA state on the NetBox VM detail page and a cluster-wide HA page.
+Surfaces `/cluster/ha/status/current`, `/cluster/ha/resources`,
+`/cluster/ha/groups` (PVE ≤ 8.x), and `/cluster/ha/rules` (PVE 9.x+)
+from Proxmox so the netbox-proxbox plugin can render HA state on the
+NetBox VM detail page and a cluster-wide HA page.
+
+PVE 9.x removed `cluster/ha/groups` in favour of `cluster/ha/rules`.
+The `/ha/groups` endpoint degrades to an empty list on PVE 9.x clusters
+(the helper detects the "migrated to rules" HTTP 500 and returns `[]`
+silently).  Use the new `/ha/rules` endpoint for PVE 9.x HA rule data.
+`/ha/summary` now includes both `groups` and `rules` so consumers can
+handle mixed-version clusters.
 
 All endpoints are read-only by design. HA mutations (add/remove/migrate)
 are intentionally out of scope and will land in a follow-up release.
@@ -19,6 +27,7 @@ from proxbox_api.logger import logger
 from proxbox_api.services.proxmox_helpers import (
     get_ha_groups,
     get_ha_resources,
+    get_ha_rules,
     get_ha_status_current,
 )
 from proxbox_api.session.proxmox import ProxmoxSessionsDep
@@ -70,7 +79,7 @@ class HaResourceSchema(BaseModel):
 
 
 class HaGroupSchema(BaseModel):
-    """An HA group definition."""
+    """An HA group definition (PVE ≤ 8.x)."""
 
     cluster_name: str | None = None
     group: str | None = None
@@ -82,17 +91,42 @@ class HaGroupSchema(BaseModel):
     digest: str | None = None
 
 
+class HaRuleSchema(BaseModel):
+    """An HA rule definition (PVE 9.x+).
+
+    PVE 9.x replaced ``cluster/ha/groups`` with ``cluster/ha/rules``.
+    Rules carry ``type`` (``node-affinity`` / ``resource-affinity``),
+    optional ``affinity`` (``positive`` / ``negative``), and a
+    ``resources`` selector string instead of a plain group name.
+    """
+
+    cluster_name: str | None = None
+    rule: str | None = None
+    type: str | None = None
+    affinity: str | None = None
+    nodes: str | None = None
+    resources: str | None = None
+    strict: bool | None = None
+    disable: bool | None = None
+    comment: str | None = None
+
+
 class HaSummarySchema(BaseModel):
     """Single-call payload for the cluster-wide HA page.
 
-    Aggregates status/groups/resources across every configured Proxmox
-    cluster so the NetBox plugin doesn't fan out four HTTP requests per
-    page render.
+    Aggregates status/groups/resources/rules across every configured
+    Proxmox cluster so the NetBox plugin doesn't fan out multiple HTTP
+    requests per page render.
+
+    ``groups`` is populated for PVE ≤ 8.x clusters; ``rules`` is
+    populated for PVE 9.x+ clusters.  Both default to ``[]`` so
+    mixed-version and single-version deployments work without changes.
     """
 
-    status: list[HaStatusItemSchema]
-    groups: list[HaGroupSchema]
-    resources: list[HaResourceSchema]
+    status: list[HaStatusItemSchema] = []
+    groups: list[HaGroupSchema] = []
+    resources: list[HaResourceSchema] = []
+    rules: list[HaRuleSchema] = []
 
 
 def _coerce_int(value: object) -> int | None:
@@ -182,6 +216,20 @@ def _group_to_schema(cluster_name: str, row: dict[str, object]) -> HaGroupSchema
         nofailback=_coerce_bool(row.get("nofailback")),
         comment=row.get("comment") if isinstance(row.get("comment"), str) else None,
         digest=row.get("digest") if isinstance(row.get("digest"), str) else None,
+    )
+
+
+def _rule_to_schema(cluster_name: str, row: dict[str, object]) -> HaRuleSchema:
+    return HaRuleSchema(
+        cluster_name=cluster_name,
+        rule=row.get("rule") if isinstance(row.get("rule"), str) else None,
+        type=row.get("type") if isinstance(row.get("type"), str) else None,
+        affinity=row.get("affinity") if isinstance(row.get("affinity"), str) else None,
+        nodes=row.get("nodes") if isinstance(row.get("nodes"), str) else None,
+        resources=row.get("resources") if isinstance(row.get("resources"), str) else None,
+        strict=_coerce_bool(row.get("strict")),
+        disable=_coerce_bool(row.get("disable")),
+        comment=row.get("comment") if isinstance(row.get("comment"), str) else None,
     )
 
 
@@ -310,23 +358,65 @@ async def ha_group_detail(pxs: ProxmoxSessionsDep, group: str) -> HaGroupSchema 
     return None
 
 
+@router.get("/ha/rules", response_model=list[HaRuleSchema])
+async def ha_rules(pxs: ProxmoxSessionsDep) -> list[HaRuleSchema]:
+    """List configured HA rules across all clusters (PVE 9.x+).
+
+    PVE 9.x replaced ``cluster/ha/groups`` with ``cluster/ha/rules``.
+    Returns an empty list on pre-9.x clusters where the endpoint does not
+    exist.
+    """
+    aggregated: list[HaRuleSchema] = []
+    for px in pxs:
+        try:
+            rows = await get_ha_rules(px)
+        except Exception:  # noqa: BLE001
+            logger.exception("Error fetching HA rules for Proxmox cluster %s", px.name)
+            continue
+        if not isinstance(rows, list):
+            continue
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            rule_id = row.get("rule")
+            detail: dict[str, object] = dict(row)
+            if isinstance(rule_id, str):
+                try:
+                    detail_payload = await get_ha_rules(px, rule=rule_id)
+                    if isinstance(detail_payload, dict):
+                        detail = {**detail, **detail_payload}
+                except Exception:  # noqa: BLE001
+                    logger.debug(
+                        "HA rule detail fetch failed for %s on %s",
+                        rule_id,
+                        px.name,
+                    )
+            aggregated.append(_rule_to_schema(px.name, detail))
+    return aggregated
+
+
 @router.get("/ha/summary", response_model=HaSummarySchema)
 async def ha_summary(pxs: ProxmoxSessionsDep) -> HaSummarySchema:
-    """Return a single envelope of status, groups, and resources.
+    """Return a single envelope of status, groups, resources, and rules.
 
-    Calls the three underlying handlers in parallel via `asyncio.gather`
+    Calls the four underlying handlers in parallel via `asyncio.gather`
     so the NetBox cluster-wide HA page only triggers one round-trip.
+    ``groups`` is populated for PVE ≤ 8.x; ``rules`` is populated for
+    PVE 9.x+.  Both default to ``[]`` when the node type does not support
+    the respective endpoint.
     """
     status_task = asyncio.create_task(ha_status(pxs))
     groups_task = asyncio.create_task(ha_groups(pxs))
     resources_task = asyncio.create_task(ha_resources(pxs))
-    status_rows, group_rows, resource_rows = await asyncio.gather(
-        status_task, groups_task, resources_task
+    rules_task = asyncio.create_task(ha_rules(pxs))
+    status_rows, group_rows, resource_rows, rule_rows = await asyncio.gather(
+        status_task, groups_task, resources_task, rules_task
     )
     return HaSummarySchema(
         status=status_rows,
         groups=group_rows,
         resources=resource_rows,
+        rules=rule_rows,
     )
 
 

--- a/proxbox_api/services/proxmox_helpers.py
+++ b/proxbox_api/services/proxmox_helpers.py
@@ -187,6 +187,12 @@ async def get_ha_groups(
     With no ``group``, returns the list of HA group rows. With a ``group``
     name, returns the full group detail dictionary (the upstream schema is
     a permissive ``dict[str, object]``).
+
+    PVE 9.x note: ``cluster/ha/groups`` was removed in favour of
+    ``cluster/ha/rules`` and returns HTTP 500 with "ha groups have been
+    migrated to rules".  When that specific error is detected the helper
+    returns an empty result (list or dict) at DEBUG level so callers degrade
+    gracefully instead of surfacing a noisy ERROR traceback.
     """
     try:
         if group is None:
@@ -202,9 +208,53 @@ async def get_ha_groups(
         raise ProxmoxAPIError(
             message="Unable to connect to Proxmox for HA groups", original_error=error
         )
+    except ResourceException as exc:
+        # PVE 9.x removed cluster/ha/groups — degrade gracefully instead of surfacing an error.
+        if exc.status_code == 500 and "migrated to rules" in str(exc).lower():
+            logger.debug(
+                "cluster/ha/groups not available on this node (PVE 9.x+, migrated to rules): %s",
+                exc,
+            )
+            return [] if group is None else {}
+        raise ProxmoxAPIError(
+            message="Proxmox HA groups request failed",
+            original_error=exc,
+        )
     except Exception as error:
         raise ProxmoxAPIError(
             message="Error fetching Proxmox HA groups",
+            original_error=error,
+        )
+
+
+@_dual_mode
+async def get_ha_rules(
+    session: ProxmoxSession,
+    rule: str | None = None,
+) -> list[dict[str, object]] | dict[str, object]:
+    """Get HA rules from Proxmox (PVE 9.x+).
+
+    ``cluster/ha/groups`` was replaced by ``cluster/ha/rules`` in PVE 9.x.
+    With no ``rule``, returns the list of rule rows.  With a ``rule``
+    identifier, returns the full rule detail dictionary.
+    """
+    try:
+        if rule is None:
+            result = await resolve_async(session.session("cluster/ha/rules").get())
+            return result if isinstance(result, list) else []
+        result = await resolve_async(session.session(f"cluster/ha/rules/{rule}").get())
+        return result if isinstance(result, dict) else {}
+    except ProxboxException:
+        raise
+    except ProxmoxTimeoutError as error:
+        raise ProxmoxAPIError(message="Proxmox HA rules request timed out", original_error=error)
+    except ProxmoxConnectionError as error:
+        raise ProxmoxAPIError(
+            message="Unable to connect to Proxmox for HA rules", original_error=error
+        )
+    except Exception as error:
+        raise ProxmoxAPIError(
+            message="Error fetching Proxmox HA rules",
             original_error=error,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ proxbox_api = ["static/*", "static/**/*", "generated/**/*.json", "generated/**/*
 
 [project]
 name = "proxbox_api"
-version = "0.0.11"
+version = "0.0.9.post1"
 description = "Proxbox API service made using FastAPI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_proxmox_ha_routes.py
+++ b/tests/test_proxmox_ha_routes.py
@@ -1,4 +1,4 @@
-"""Unit tests for the read-only Proxmox HA routes (issue #243)."""
+"""Unit tests for the read-only Proxmox HA routes (issue #243, #111)."""
 
 from __future__ import annotations
 
@@ -6,17 +6,20 @@ import asyncio
 from types import SimpleNamespace
 
 import pytest
+from proxmox_sdk.sdk.exceptions import ResourceException
 
 from proxbox_api.routes.proxmox import ha as ha_module
 from proxbox_api.routes.proxmox.ha import (
     HaGroupSchema,
     HaResourceSchema,
+    HaRuleSchema,
     HaStatusItemSchema,
     HaSummarySchema,
     ha_group_detail,
     ha_groups,
     ha_resource_by_vm,
     ha_resources,
+    ha_rules,
     ha_status,
     ha_summary,
 )
@@ -35,9 +38,12 @@ def _patch_helpers(
     resource_detail_map=None,
     groups_list=None,
     group_detail_map=None,
+    rules_list=None,
+    rule_detail_map=None,
     status_error: Exception | None = None,
     resources_error: Exception | None = None,
     groups_error: Exception | None = None,
+    rules_error: Exception | None = None,
 ) -> None:
     """Replace the helper functions used by the HA router with deterministic stubs."""
 
@@ -64,9 +70,19 @@ def _patch_helpers(
             return dict(group_detail_map[group])
         raise RuntimeError(f"group not found: {group}")
 
+    async def fake_rules(_session, rule: str | None = None):
+        if rules_error is not None:
+            raise rules_error
+        if rule is None:
+            return list(rules_list or [])
+        if rule_detail_map and rule in rule_detail_map:
+            return dict(rule_detail_map[rule])
+        raise RuntimeError(f"rule not found: {rule}")
+
     monkeypatch.setattr(ha_module, "get_ha_status_current", fake_status)
     monkeypatch.setattr(ha_module, "get_ha_resources", fake_resources)
     monkeypatch.setattr(ha_module, "get_ha_groups", fake_groups)
+    monkeypatch.setattr(ha_module, "get_ha_rules", fake_rules)
 
 
 def test_ha_status_aggregates_per_cluster_rows(monkeypatch: pytest.MonkeyPatch):
@@ -255,6 +271,86 @@ def test_ha_summary_runs_subqueries_in_parallel(monkeypatch: pytest.MonkeyPatch)
     assert summary.groups[0].group == "g1"
 
 
+def test_get_ha_groups_degrades_gracefully_on_pve9_500():
+    """get_ha_groups helper must return [] instead of raising when PVE 9.x sends HTTP 500."""
+    from proxbox_api.services import proxmox_helpers
+
+    pve9_exc = ResourceException(
+        status_code=500,
+        status_message="cannot index groups: ha groups have been migrated to rules",
+    )
+
+    class _Resource:
+        async def get(self):
+            raise pve9_exc
+
+    class _SdkClient:
+        def __call__(self, _path):
+            return _Resource()
+
+    class _FakeSession:
+        session = _SdkClient()
+
+    # _dual_mode handles sync→async dispatch; call directly without asyncio.run
+    result = proxmox_helpers.get_ha_groups(_FakeSession())
+    assert result == []
+
+
+def test_ha_rules_lists_with_detail_merge(monkeypatch: pytest.MonkeyPatch):
+    """ha_rules must aggregate rule rows and enrich them with per-rule detail."""
+
+    _patch_helpers(
+        monkeypatch,
+        rules_list=[{"rule": "rule-affinity-1"}],
+        rule_detail_map={
+            "rule-affinity-1": {
+                "rule": "rule-affinity-1",
+                "type": "node-affinity",
+                "affinity": "positive",
+                "nodes": "pve01:1,pve02:2",
+                "resources": "vm:100,vm:101",
+                "strict": 1,
+                "disable": 0,
+            },
+        },
+    )
+
+    rows = asyncio.run(ha_rules(_make_pxs()))
+
+    assert len(rows) == 1
+    assert isinstance(rows[0], HaRuleSchema)
+    assert rows[0].rule == "rule-affinity-1"
+    assert rows[0].type == "node-affinity"
+    assert rows[0].affinity == "positive"
+    assert rows[0].nodes == "pve01:1,pve02:2"
+    assert rows[0].resources == "vm:100,vm:101"
+    assert rows[0].strict is True
+    assert rows[0].disable is False
+
+
+def test_ha_summary_includes_rules(monkeypatch: pytest.MonkeyPatch):
+    """ha_summary must include a rules list alongside groups and resources."""
+
+    _patch_helpers(
+        monkeypatch,
+        status_rows=[],
+        resources_list=[],
+        resource_detail_map={},
+        groups_list=[],
+        group_detail_map={},
+        rules_list=[{"rule": "r1"}],
+        rule_detail_map={"r1": {"rule": "r1", "type": "resource-affinity", "resources": "vm:200"}},
+    )
+
+    summary = asyncio.run(ha_summary(_make_pxs()))
+
+    assert isinstance(summary, HaSummarySchema)
+    assert hasattr(summary, "rules")
+    assert len(summary.rules) == 1
+    assert summary.rules[0].rule == "r1"
+    assert summary.rules[0].type == "resource-affinity"
+
+
 def test_router_is_registered_under_proxmox_cluster_prefix():
     """Sanity-check that the app factory wires the router with the right prefix."""
 
@@ -267,4 +363,5 @@ def test_router_is_registered_under_proxmox_cluster_prefix():
     assert "/proxmox/cluster/ha/resources/by-vm/{vmid}" in paths
     assert "/proxmox/cluster/ha/groups" in paths
     assert "/proxmox/cluster/ha/groups/{group}" in paths
+    assert "/proxmox/cluster/ha/rules" in paths
     assert "/proxmox/cluster/ha/summary" in paths


### PR DESCRIPTION
## Summary

Fixes #111 — Proxmox VE 9.x removed `cluster/ha/groups` in favour of `cluster/ha/rules`. Calling the old endpoint returns HTTP 500 with "ha groups have been migrated to rules", which previously produced noisy ERROR-level tracebacks in every HA poll cycle.

- `get_ha_groups`: now catches `ResourceException(status_code=500, ...)` with the "migrated to rules" message and returns `[]`/`{}` at DEBUG level — no more ERROR log on PVE 9.x
- `get_ha_rules`: new helper calling `cluster/ha/rules` and `cluster/ha/rules/{rule}` (PVE 9.x+)
- `HaRuleSchema`: new Pydantic schema for PVE 9.x rule objects (rule, type, affinity, nodes, resources, strict, disable, comment)
- `GET /proxmox/cluster/ha/rules`: new endpoint exposing native PVE 9.x HA rules across all clusters
- `HaSummarySchema.rules`: new optional field (default `[]`); `/ha/summary` now returns both `groups` (PVE ≤ 8.x) and `rules` (PVE 9.x) — fully backward compatible
- 4 new tests: PVE 9.x graceful degradation at helper level, `ha_rules` detail-merge, `ha_summary` rules field, router path registration

## Test plan

- [x] All 12 HA route tests pass (`uv run pytest tests/test_proxmox_ha_routes.py -v`)
- [x] `ruff check` clean on all modified files
- [x] Syntax check passes
- [ ] Manual verification: deploy against a PVE 9.1.11 cluster and confirm no ERROR logs on HA page load, and `/proxmox/cluster/ha/rules` returns rule data