### PR TITLE
feat(cloud): /cloud/templates/pve — build PVE-installer cloud-init templates

### DIFF
--- a/proxbox_api/app/factory.py
+++ b/proxbox_api/app/factory.py
@@ -33,6 +33,7 @@ from proxbox_api.openapi_custom import custom_openapi_builder
 from proxbox_api.routes.admin import router as admin_router
 from proxbox_api.routes.auth import router as auth_router
 from proxbox_api.routes.cloud import provision_router as cloud_provision_router
+from proxbox_api.routes.cloud import pve_template_router as cloud_pve_template_router
 from proxbox_api.routes.cloud import template_images_router as cloud_template_images_router
 from proxbox_api.routes.cloud import templates_router as cloud_templates_router
 from proxbox_api.routes.dcim import router as dcim_router
@@ -425,6 +426,7 @@ def create_app() -> FastAPI:  # noqa: C901
         app.include_router(deletion_requests_router, prefix="/intent", tags=["intent"])
         app.include_router(cloud_provision_router, prefix="/cloud", tags=["cloud"])
         app.include_router(cloud_template_images_router, prefix="/cloud", tags=["cloud"])
+        app.include_router(cloud_pve_template_router, prefix="/cloud", tags=["cloud"])
         app.include_router(cloud_templates_router, prefix="/cloud", tags=["cloud"])
         app.include_router(
             sync_individual_router, prefix="/sync/individual", tags=["sync / individual"]

--- a/proxbox_api/routes/cloud/__init__.py
+++ b/proxbox_api/routes/cloud/__init__.py
@@ -1,7 +1,13 @@
 """Cloud Portal provisioning routes."""
 
 from proxbox_api.routes.cloud.provision import router as provision_router
+from proxbox_api.routes.cloud.pve_template import router as pve_template_router
 from proxbox_api.routes.cloud.template_images import router as template_images_router
 from proxbox_api.routes.cloud.templates import router as templates_router
 
-__all__ = ("provision_router", "template_images_router", "templates_router")
+__all__ = (
+    "provision_router",
+    "pve_template_router",
+    "template_images_router",
+    "templates_router",
+)

--- a/proxbox_api/routes/cloud/pve_cloudinit_payload.py
+++ b/proxbox_api/routes/cloud/pve_cloudinit_payload.py
@@ -1,0 +1,233 @@
+"""Render PVE-installer cloud-init payloads.
+
+This module produces three cloud-init artifacts that, when written into
+Proxmox's snippet storage and wired through ``--cicustom``, drive an
+unattended Proxmox VE install on top of a Debian 12 (Bookworm) base image:
+
+* ``user-data`` — APT pin + repo + runcmd that installs ``proxmox-ve``.
+* ``network-config`` — Netplan v2 that creates the ``vmbr0`` bridge.
+* ``meta-data`` — declares the cloud-init ``instance-id``; a fresh value
+  here is what forces cloud-init to re-run on a clone.
+
+Source-of-truth for the static template lives in the ``nms`` repository
+under ``cloud-init/pve-install/``. This module embeds the same content as
+Python multi-line strings so ``proxbox-api`` does not need an out-of-tree
+file at runtime.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from textwrap import dedent
+
+DEFAULT_PVE_VERSION_PIN = "9.1.11"
+DEFAULT_DEBIAN_RELEASE = "bookworm"
+DEFAULT_NIC_NAME = "ens18"
+DEFAULT_BRIDGE_NAME = "vmbr0"
+DEFAULT_HOSTNAME = "pve-node-01"
+DEFAULT_DOMAIN = "nmulti.local"
+DEFAULT_NODE_CIDR = "10.0.30.50/24"
+DEFAULT_GATEWAY = "10.0.30.1"
+DEFAULT_NAMESERVERS = ("1.1.1.1", "8.8.8.8")
+
+
+@dataclass(frozen=True)
+class PVECloudInitPayloads:
+    user_data: str
+    network_config: str
+    meta_data: str
+
+
+def _format_ssh_keys(keys: list[str] | tuple[str, ...]) -> str:
+    if not keys:
+        return '      - "ssh-ed25519 AAAA... replace-with-operator-key"'
+    lines = []
+    for key in keys:
+        key_clean = key.strip().replace('"', '\\"')
+        lines.append(f'      - "{key_clean}"')
+    return "\n".join(lines)
+
+
+def render_user_data(
+    *,
+    hostname: str = DEFAULT_HOSTNAME,
+    domain: str = DEFAULT_DOMAIN,
+    nic_name: str = DEFAULT_NIC_NAME,
+    pve_version_pin: str = DEFAULT_PVE_VERSION_PIN,
+    debian_release: str = DEFAULT_DEBIAN_RELEASE,
+    ssh_authorized_keys: list[str] | tuple[str, ...] = (),
+) -> str:
+    """Render the PVE-installer cloud-init ``user-data`` payload.
+
+    The result is a ``#cloud-config`` document that, once cloud-init runs
+    against a freshly-booted Debian 12 cloud image, will:
+
+    1. Insert an FQDN/IP entry in ``/etc/hosts`` (required by pve-manager's
+       postinstall — it calls ``hostname --fqdn`` during ``dpkg configure``).
+    2. Add the Proxmox no-subscription APT repo and pin ``pve-manager`` /
+       ``proxmox-ve`` / ``pve-kernel-6.8`` at the requested version.
+    3. Install ``proxmox-ve``, ``postfix``, ``open-iscsi``, ``chrony``.
+    4. Remove the stock Debian kernel and ``os-prober`` (hypervisor hygiene).
+    5. Run ``update-grub`` so the PVE kernel becomes the default entry.
+    6. Reboot into the PVE kernel.
+    """
+    fqdn = f"{hostname}.{domain}"
+    ssh_block = _format_ssh_keys(ssh_authorized_keys)
+
+    return dedent(
+        f"""\
+        #cloud-config
+        # Unattended Proxmox VE {pve_version_pin} installation on top of Debian 12 ({debian_release}).
+        hostname: {hostname}
+        fqdn: {fqdn}
+        manage_etc_hosts: false
+
+        bootcmd:
+          - |
+            NODE_IP=$(ip -4 addr show {nic_name} | grep -oP '(?<=inet )\\d+\\.\\d+\\.\\d+\\.\\d+' | head -1)
+            if [ -n "$NODE_IP" ] && ! grep -q "{fqdn}" /etc/hosts; then
+              echo "${{NODE_IP}}  {fqdn}  {hostname}" >> /etc/hosts
+            fi
+
+        package_update: true
+        package_upgrade: false
+
+        packages:
+          - curl
+          - gnupg
+          - ca-certificates
+
+        write_files:
+          - path: /etc/apt/sources.list.d/pve-no-subscription.list
+            permissions: '0644'
+            content: |
+              deb http://download.proxmox.com/debian/pve {debian_release} pve-no-subscription
+
+          - path: /etc/apt/preferences.d/pve-pin
+            permissions: '0644'
+            content: |
+              Package: pve-manager
+              Pin: version {pve_version_pin}*
+              Pin-Priority: 1001
+
+              Package: proxmox-ve
+              Pin: version {pve_version_pin}*
+              Pin-Priority: 1001
+
+              Package: pve-kernel-6.8
+              Pin: version *
+              Pin-Priority: 1001
+
+        users:
+          - name: root
+            ssh_authorized_keys:
+{ssh_block}
+
+        runcmd:
+          - curl -fsSL https://enterprise.proxmox.com/debian/proxmox-release-{debian_release}.gpg -o /etc/apt/trusted.gpg.d/proxmox-release-{debian_release}.gpg
+          - rm -f /etc/apt/sources.list.d/pve-enterprise.list
+          - DEBIAN_FRONTEND=noninteractive apt-get update -y
+          - DEBIAN_FRONTEND=noninteractive apt-get install -y proxmox-ve postfix open-iscsi chrony
+          - DEBIAN_FRONTEND=noninteractive apt-get remove -y linux-image-amd64 os-prober
+          - update-grub
+
+        power_state:
+          mode: reboot
+          message: "PVE {pve_version_pin} installation complete — rebooting into PVE kernel"
+          timeout: 30
+          condition: true
+        """
+    )
+
+
+def render_network_config(
+    *,
+    nic_name: str = DEFAULT_NIC_NAME,
+    bridge_name: str = DEFAULT_BRIDGE_NAME,
+    node_cidr: str = DEFAULT_NODE_CIDR,
+    gateway: str = DEFAULT_GATEWAY,
+    nameservers: tuple[str, ...] = DEFAULT_NAMESERVERS,
+    search_domain: str = DEFAULT_DOMAIN,
+) -> str:
+    """Render the cloud-init Netplan v2 ``network-config`` payload."""
+    ns_addrs = ", ".join(nameservers)
+    return dedent(
+        f"""\
+        version: 2
+        ethernets:
+          {nic_name}:
+            dhcp4: false
+
+        bridges:
+          {bridge_name}:
+            interfaces: [{nic_name}]
+            addresses: [{node_cidr}]
+            gateway4: {gateway}
+            nameservers:
+              addresses: [{ns_addrs}]
+              search: [{search_domain}]
+            parameters:
+              stp: false
+              forward-delay: 0
+        """
+    )
+
+
+def render_meta_data(
+    *,
+    instance_id: str,
+    hostname: str = DEFAULT_HOSTNAME,
+) -> str:
+    """Render the cloud-init ``meta-data`` payload.
+
+    ``instance_id`` is the load-bearing field: cloud-init silently skips
+    re-running if a clone inherits the same value, so callers must pass a
+    fresh identifier (e.g. ``f"{hostname}-{int(time.time())}"``) when
+    rendering meta-data for a new clone.
+    """
+    return dedent(
+        f"""\
+        instance-id: {instance_id}
+        local-hostname: {hostname}
+        """
+    )
+
+
+def render_all(
+    *,
+    hostname: str = DEFAULT_HOSTNAME,
+    domain: str = DEFAULT_DOMAIN,
+    nic_name: str = DEFAULT_NIC_NAME,
+    bridge_name: str = DEFAULT_BRIDGE_NAME,
+    pve_version_pin: str = DEFAULT_PVE_VERSION_PIN,
+    debian_release: str = DEFAULT_DEBIAN_RELEASE,
+    node_cidr: str = DEFAULT_NODE_CIDR,
+    gateway: str = DEFAULT_GATEWAY,
+    nameservers: tuple[str, ...] = DEFAULT_NAMESERVERS,
+    instance_id: str | None = None,
+    ssh_authorized_keys: list[str] | tuple[str, ...] = (),
+) -> PVECloudInitPayloads:
+    """Convenience: render all three payloads in one call."""
+    resolved_iid = instance_id or hostname
+    return PVECloudInitPayloads(
+        user_data=render_user_data(
+            hostname=hostname,
+            domain=domain,
+            nic_name=nic_name,
+            pve_version_pin=pve_version_pin,
+            debian_release=debian_release,
+            ssh_authorized_keys=ssh_authorized_keys,
+        ),
+        network_config=render_network_config(
+            nic_name=nic_name,
+            bridge_name=bridge_name,
+            node_cidr=node_cidr,
+            gateway=gateway,
+            nameservers=nameservers,
+            search_domain=domain,
+        ),
+        meta_data=render_meta_data(
+            instance_id=resolved_iid,
+            hostname=hostname,
+        ),
+    )

--- a/proxbox_api/routes/cloud/pve_template.py
+++ b/proxbox_api/routes/cloud/pve_template.py
@@ -279,9 +279,7 @@ async def build_pve_template(
         create_result = await _maybe_await(
             proxmox.session.nodes(req.target_node).qemu.post(**create_kwargs)
         )
-        create_upid = await _wait_for_task(
-            proxmox, node=req.target_node, response=create_result
-        )
+        create_upid = await _wait_for_task(proxmox, node=req.target_node, response=create_result)
 
         return PVETemplateBuildResponse(
             endpoint_id=req.endpoint_id,

--- a/proxbox_api/routes/cloud/pve_template.py
+++ b/proxbox_api/routes/cloud/pve_template.py
@@ -1,0 +1,306 @@
+"""PVE-installer cloud-init template build route.
+
+Sibling of ``template_images.py``. Where that endpoint builds a generic
+Ubuntu/Debian cloud-init template, this one builds a template whose first
+boot installs Proxmox VE itself, using the cloud-init payload rendered by
+``pve_cloudinit_payload.py``.
+
+The endpoint does the parts that the Proxmox HTTP API supports natively
+(image download via ``storage/{name}/download-url`` and VM create with
+``--cicustom`` wiring) and returns the rendered snippet content plus
+operator-side instructions so the snippets can be deposited into
+``/var/lib/vz/snippets/`` on the host. Multipart snippet upload via the
+Proxmox storage upload action is intentionally out of scope here — that
+is a follow-up once ``proxmox-sdk`` grows native multipart support.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import PurePosixPath
+from typing import Any
+from urllib.parse import urlsplit
+
+from fastapi import APIRouter, HTTPException, status
+from fastapi.responses import JSONResponse
+
+from proxbox_api.database import AsyncDatabaseSessionDep as SessionDep
+from proxbox_api.routes.cloud.provision import _extract_task_id, _wait_for_upid
+from proxbox_api.routes.cloud.pve_cloudinit_payload import render_all
+from proxbox_api.routes.proxmox_actions import _gate, _open_proxmox_session
+from proxbox_api.schemas.cloud_provision import (
+    PVETemplateBuildRequest,
+    PVETemplateBuildResponse,
+)
+from proxbox_api.session.proxmox import ProxmoxSession
+from proxbox_api.ssrf import validate_endpoint_url
+from proxbox_api.utils.async_compat import maybe_await as _maybe_await
+
+router = APIRouter()
+
+_IMAGE_EXTENSIONS = {".qcow2", ".raw", ".vmdk", ".vma"}
+
+
+def _filename_from_request(req: PVETemplateBuildRequest) -> str:
+    raw = (req.image_filename or "").strip()
+    if not raw:
+        raw = PurePosixPath(urlsplit(req.debian_image_url).path).name
+    if not raw:
+        raise HTTPException(status_code=422, detail="image_filename could not be derived.")
+    path = PurePosixPath(raw)
+    suffix = path.suffix.lower()
+    if suffix == ".img":
+        return f"{path.stem}.qcow2"
+    if suffix not in _IMAGE_EXTENSIONS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"image_filename must end with one of {sorted(_IMAGE_EXTENSIONS)}.",
+        )
+    return path.name
+
+
+def _snippet_paths(req: PVETemplateBuildRequest) -> tuple[str, str, str, str]:
+    """Compute snippet ``volid`` strings and the ``--cicustom`` argument.
+
+    Returned tuple is ``(user_data, network_config, meta_data, cicustom)``.
+    """
+    prefix = f"pve-{req.vmid}"
+    user_path = f"{req.snippets_storage}:snippets/{prefix}-user-data"
+    network_path = f"{req.snippets_storage}:snippets/{prefix}-network-config.yaml"
+    meta_path = f"{req.snippets_storage}:snippets/{prefix}-meta-data"
+    cicustom = f"user={user_path},network={network_path},meta={meta_path}"
+    return user_path, network_path, meta_path, cicustom
+
+
+def _operator_instructions(
+    *,
+    target_node: str,
+    snippet_user: str,
+    snippet_network: str,
+    snippet_meta: str,
+) -> str:
+    """Build the ssh + tee block the operator runs on the PVE host."""
+    return (
+        "# On the Proxmox VE host, drop the rendered snippets into the\n"
+        "# snippets storage (default '/var/lib/vz/snippets/'). The API\n"
+        "# returns the file contents inline; persist them with e.g.:\n"
+        f"#   ssh root@{target_node}\n"
+        f"#   cat > /var/lib/vz/snippets/{PurePosixPath(snippet_user.split(':snippets/', 1)[1]).name} <<'CIEOF'\n"
+        "#   <paste user_data here>\n"
+        "#   CIEOF\n"
+        f"#   cat > /var/lib/vz/snippets/{PurePosixPath(snippet_network.split(':snippets/', 1)[1]).name} <<'CIEOF'\n"
+        "#   <paste network_config here>\n"
+        "#   CIEOF\n"
+        f"#   cat > /var/lib/vz/snippets/{PurePosixPath(snippet_meta.split(':snippets/', 1)[1]).name} <<'CIEOF'\n"
+        "#   <paste meta_data here>\n"
+        "#   CIEOF\n"
+    )
+
+
+async def _vm_config_or_none(
+    proxmox: ProxmoxSession,
+    *,
+    node: str,
+    vmid: int,
+) -> dict[str, Any] | None:
+    try:
+        config = await _maybe_await(proxmox.session.nodes(node).qemu(vmid).config.get())
+    except Exception:  # noqa: BLE001
+        return None
+    return config if isinstance(config, dict) else {}
+
+
+async def _image_exists(
+    proxmox: ProxmoxSession,
+    *,
+    node: str,
+    storage: str,
+    volid: str,
+) -> bool:
+    try:
+        content = await _maybe_await(
+            proxmox.session.nodes(node).storage(storage).content.get(content="import")
+        )
+    except Exception:  # noqa: BLE001
+        return False
+    rows = content if isinstance(content, list) else []
+    return any(isinstance(row, dict) and row.get("volid") == volid for row in rows)
+
+
+async def _wait_for_task(
+    proxmox: ProxmoxSession,
+    *,
+    node: str,
+    response: object,
+) -> str | None:
+    upid = _extract_task_id(response)
+    if upid and upid.startswith("UPID:"):
+        await _wait_for_upid(proxmox, node, upid)
+    return upid
+
+
+@router.post(
+    "/templates/pve",
+    response_model=PVETemplateBuildResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def build_pve_template(
+    req: PVETemplateBuildRequest,
+    session: SessionDep,
+) -> PVETemplateBuildResponse | JSONResponse:
+    """Render PVE-installer cloud-init payloads and (optionally) create the VM.
+
+    With ``create_vm=true`` (default) the endpoint will:
+
+    1. Validate ``debian_image_url`` against the SSRF allowlist.
+    2. Resolve the target ``ProxmoxEndpoint`` and gate it through the same
+       ``allow_writes`` check used by the VM verb routes.
+    3. Trigger a ``storage/{name}/download-url`` server-side fetch of the
+       Debian image into ``image_storage``.
+    4. Create the template VM with ``--cicustom`` pointing at the snippet
+       paths it expects the operator to populate (see
+       ``operator_instructions`` in the response).
+
+    With ``create_vm=false`` the endpoint returns the rendered payloads and
+    expected snippet paths without touching Proxmox — useful for a dry run
+    from the NMS UI before the operator commits.
+    """
+    instance_id = f"{req.hostname}-{int(time.time())}"
+    payloads = render_all(
+        hostname=req.hostname,
+        domain=req.domain,
+        nic_name=req.nic_name,
+        pve_version_pin=req.pve_version_pin,
+        debian_release=req.debian_release,
+        node_cidr=req.node_cidr,
+        gateway=req.gateway,
+        nameservers=tuple(req.nameservers),
+        instance_id=instance_id,
+        ssh_authorized_keys=req.ssh_authorized_keys,
+    )
+
+    user_path, network_path, meta_path, cicustom = _snippet_paths(req)
+    operator_instructions = _operator_instructions(
+        target_node=req.target_node,
+        snippet_user=user_path,
+        snippet_network=network_path,
+        snippet_meta=meta_path,
+    )
+
+    filename = _filename_from_request(req)
+    image_volid = f"{req.image_storage}:import/{filename}"
+
+    if not req.create_vm:
+        return PVETemplateBuildResponse(
+            endpoint_id=req.endpoint_id,
+            target_node=req.target_node,
+            vmid=req.vmid,
+            name=req.name,
+            status="rendered",
+            image_volid=image_volid,
+            snippet_user_data_path=user_path,
+            snippet_network_config_path=network_path,
+            snippet_meta_data_path=meta_path,
+            user_data=payloads.user_data,
+            network_config=payloads.network_config,
+            meta_data=payloads.meta_data,
+            qm_cicustom=cicustom,
+            operator_instructions=operator_instructions,
+        )
+
+    gated = await _gate(session, req.endpoint_id)
+    if isinstance(gated, JSONResponse):
+        return gated
+
+    safe, reason = validate_endpoint_url(req.debian_image_url)
+    if not safe:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"debian_image_url rejected by SSRF protection: {reason}",
+        )
+
+    proxmox: ProxmoxSession | None = None
+    try:
+        proxmox = await _open_proxmox_session(gated)
+        existing = await _vm_config_or_none(
+            proxmox,
+            node=req.target_node,
+            vmid=req.vmid,
+        )
+        if existing is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    f"VMID {req.vmid} already exists on node {req.target_node}. "
+                    "Choose a different VMID or delete the existing VM first."
+                ),
+            )
+
+        download_upid = None
+        if not await _image_exists(
+            proxmox,
+            node=req.target_node,
+            storage=req.image_storage,
+            volid=image_volid,
+        ):
+            download_result = await _maybe_await(
+                proxmox.session.nodes(req.target_node)
+                .storage(f"{req.image_storage}/download-url")
+                .post(
+                    content="import",
+                    filename=filename,
+                    url=req.debian_image_url,
+                    **{"verify-certificates": 1 if req.verify_image_certificates else 0},
+                )
+            )
+            download_upid = await _wait_for_task(
+                proxmox,
+                node=req.target_node,
+                response=download_result,
+            )
+
+        create_kwargs: dict[str, object] = {
+            "vmid": req.vmid,
+            "name": req.name,
+            "memory": req.memory_mb,
+            "cores": req.cores,
+            "sockets": 1,
+            "ostype": "l26",
+            "agent": "enabled=1",
+            "scsihw": "virtio-scsi-pci",
+            "scsi0": f"{req.vm_storage}:0,import-from={image_volid},discard=on",
+            "ide2": f"{req.vm_storage}:cloudinit",
+            "boot": "order=scsi0",
+            "serial0": "socket",
+            "vga": "serial0",
+            "net0": f"virtio,bridge={req.bridge}",
+            "cicustom": cicustom,
+        }
+        create_result = await _maybe_await(
+            proxmox.session.nodes(req.target_node).qemu.post(**create_kwargs)
+        )
+        create_upid = await _wait_for_task(
+            proxmox, node=req.target_node, response=create_result
+        )
+
+        return PVETemplateBuildResponse(
+            endpoint_id=req.endpoint_id,
+            target_node=req.target_node,
+            vmid=req.vmid,
+            name=req.name,
+            status="created",
+            image_volid=image_volid,
+            snippet_user_data_path=user_path,
+            snippet_network_config_path=network_path,
+            snippet_meta_data_path=meta_path,
+            user_data=payloads.user_data,
+            network_config=payloads.network_config,
+            meta_data=payloads.meta_data,
+            qm_cicustom=cicustom,
+            operator_instructions=operator_instructions,
+            download_upid=download_upid,
+            create_upid=create_upid,
+        )
+    finally:
+        if proxmox is not None:
+            await proxmox.aclose()

--- a/proxbox_api/schemas/cloud_provision.py
+++ b/proxbox_api/schemas/cloud_provision.py
@@ -100,3 +100,81 @@ class CloudImageTemplateBuildResponse(BaseModel):
     boot: Optional[str] = None
     scsi0: Optional[str] = None
     ide2: Optional[str] = None
+
+
+class PVETemplateBuildRequest(BaseModel):
+    """Build an unattended Proxmox VE installer template on a Proxmox host.
+
+    The resulting VM, once booted, runs cloud-init against a Debian 12 cloud
+    image and installs a pinned ``proxmox-ve`` release on top. The endpoint
+    handles the parts it can do through the Proxmox API directly (image
+    download + VM create with ``--cicustom``) and returns the rendered
+    cloud-init snippet content alongside the operator-side instructions
+    needed to drop the snippets into ``/var/lib/vz/snippets/`` on the host.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    endpoint_id: int = Field(..., description="ProxmoxEndpoint primary key")
+    vmid: int = Field(..., ge=100, description="Template VMID to create")
+    name: str = Field("debian12-pve-tmpl", min_length=1, max_length=128)
+    target_node: str = Field(..., min_length=1)
+    debian_image_url: str = Field(
+        "https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2",
+        min_length=1,
+        description="HTTP(S) URL for the Debian 12 generic cloud image",
+    )
+    image_filename: str | None = Field(
+        None,
+        description="Filename to store in Proxmox import storage; .img is normalized to .qcow2",
+    )
+    image_storage: str = Field("local", min_length=1)
+    vm_storage: str = Field("local-lvm", min_length=1)
+    snippets_storage: str = Field("local", min_length=1)
+    bridge: str = Field("vmbr0", min_length=1)
+    memory_mb: int = Field(4096, ge=512)
+    cores: int = Field(4, ge=1)
+    nic_name: str = Field("ens18", min_length=1)
+    hostname: str = Field("pve-node-01", min_length=1)
+    domain: str = Field("nmulti.local", min_length=1)
+    node_cidr: str = Field("10.0.30.50/24", min_length=1)
+    gateway: str = Field("10.0.30.1", min_length=1)
+    nameservers: list[str] = Field(default_factory=lambda: ["1.1.1.1", "8.8.8.8"])
+    pve_version_pin: str = Field("9.1.11", min_length=1)
+    debian_release: str = Field("bookworm", min_length=1)
+    ssh_authorized_keys: list[str] = Field(
+        default_factory=list,
+        description="Operator SSH public keys to inject as root authorized_keys",
+    )
+    verify_image_certificates: bool = True
+    create_vm: bool = Field(
+        True,
+        description="If false, only render cloud-init payloads and do not touch Proxmox.",
+    )
+
+
+class PVETemplateBuildResponse(BaseModel):
+    """Result of a PVE template build request.
+
+    The response always carries the rendered cloud-init payloads so callers
+    (UI or operator) can persist them into the host's snippets directory.
+    ``status`` summarizes whether the API created the VM, or just rendered
+    the payloads (``create_vm=false``), or detected an existing VMID.
+    """
+
+    endpoint_id: int
+    target_node: str
+    vmid: int
+    name: str
+    status: str
+    image_volid: str
+    snippet_user_data_path: str
+    snippet_network_config_path: str
+    snippet_meta_data_path: str
+    user_data: str
+    network_config: str
+    meta_data: str
+    qm_cicustom: str
+    operator_instructions: str
+    download_upid: Optional[str] = None
+    create_upid: Optional[str] = None

--- a/tests/cloud/test_cloud_router_contract.py
+++ b/tests/cloud/test_cloud_router_contract.py
@@ -17,7 +17,13 @@ def test_cloud_package_exposes_both_routers():
     assert cloud.provision_router is not None
     assert cloud.template_images_router is not None
     assert cloud.templates_router is not None
-    assert cloud.__all__ == ("provision_router", "template_images_router", "templates_router")
+    assert cloud.pve_template_router is not None
+    assert cloud.__all__ == (
+        "provision_router",
+        "pve_template_router",
+        "template_images_router",
+        "templates_router",
+    )
 
 
 def test_cloud_routes_are_registered_on_app(monkeypatch):

--- a/tests/cloud/test_pve_template_contract.py
+++ b/tests/cloud/test_pve_template_contract.py
@@ -1,0 +1,50 @@
+"""Static contracts for the PVE-installer cloud-init template build route."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from proxbox_api.routes.cloud.pve_cloudinit_payload import render_all
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_cloud_pve_template_build_route_registered() -> None:
+    factory = (ROOT / "proxbox_api/app/factory.py").read_text()
+    init = (ROOT / "proxbox_api/routes/cloud/__init__.py").read_text()
+    assert "pve_template_router" in init
+    assert "cloud_pve_template_router" in factory
+
+
+def test_cloud_pve_template_build_route_source_shape() -> None:
+    src = (ROOT / "proxbox_api/routes/cloud/pve_template.py").read_text()
+    for token in (
+        '"/templates/pve"',
+        "validate_endpoint_url",
+        "render_all",
+        "import-from=",
+        "cicustom",
+        "snippets/",
+        "_gate",
+    ):
+        assert token in src, f"missing token in pve_template.py: {token!r}"
+
+
+def test_pve_cloudinit_payload_renders_required_fields() -> None:
+    payloads = render_all(
+        hostname="pve-node-42",
+        node_cidr="10.0.30.42/24",
+        gateway="10.0.30.1",
+        pve_version_pin="9.1.11",
+        ssh_authorized_keys=["ssh-ed25519 AAAA testkey op@host"],
+    )
+    assert "#cloud-config" in payloads.user_data
+    assert "pve-node-42.nmulti.local" in payloads.user_data
+    assert "Pin: version 9.1.11*" in payloads.user_data
+    assert "proxmox-ve postfix open-iscsi chrony" in payloads.user_data
+    assert "ssh-ed25519 AAAA testkey op@host" in payloads.user_data
+    assert "vmbr0:" in payloads.network_config
+    assert "10.0.30.42/24" in payloads.network_config
+    assert "stp: false" in payloads.network_config
+    assert payloads.meta_data.startswith("instance-id: pve-node-42")
+    assert "local-hostname: pve-node-42" in payloads.meta_data


### PR DESCRIPTION
Closes #116.

## Summary

Adds a sibling of `POST /cloud/templates/images` that builds a Proxmox VE-installer cloud-init template against a registered ProxmoxEndpoint: `POST /cloud/templates/pve`.

The endpoint covers what the Proxmox HTTP API supports natively:

- SSRF-checked Debian image download via `storage/{name}/download-url`.
- VM create with `--cicustom` wiring against a deterministic `local:snippets/pve-<vmid>-{user-data,network-config,meta-data}` layout.
- `import-from=<image_volid>` + virtio-scsi-pci scsi0 + serial0 console.
- Endpoint gating (`allow_writes`) via the existing `_gate` helper.

The cloud-init payload itself is rendered in `pve_cloudinit_payload.py` from request inputs (hostname, domain, NIC name, node CIDR/gateway, PVE version pin, SSH keys) and returned inline alongside operator-side instructions for dropping the snippets into `/var/lib/vz/snippets/`. Multipart snippet upload via the Proxmox storage upload action is left as a follow-up.

With `create_vm=false` the route renders the payloads without touching Proxmox, which gives the NMS UI a safe dry-run path before commit.

## Files

- `proxbox_api/routes/cloud/pve_template.py` — new route module.
- `proxbox_api/routes/cloud/pve_cloudinit_payload.py` — `render_user_data` / `render_network_config` / `render_meta_data` / `render_all`.
- `proxbox_api/schemas/cloud_provision.py` — `PVETemplateBuildRequest` / `PVETemplateBuildResponse` schemas.
- `proxbox_api/routes/cloud/__init__.py` and `proxbox_api/app/factory.py` — router registration.
- `tests/cloud/test_pve_template_contract.py` — static contract test pinning the route + renderer output.

## Test plan

- [ ] `uv run pytest tests/cloud/test_pve_template_contract.py`
- [ ] `uv run python -m compileall proxbox_api tests`
- [ ] `uv run ruff check .`
- [ ] Smoke: `POST /cloud/templates/pve` against a dev Proxmox endpoint with `create_vm=false` and confirm the response contains the three rendered snippets with the requested PVE pin.