### PR TITLE
release: v0.0.11.post2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,13 @@ proxbox_api = ["static/*", "static/**/*", "generated/**/*.json", "generated/**/*
 
 [project]
 name = "proxbox_api"
-version = "0.0.11.post1"
+version = "0.0.11.post2"
 description = "Proxbox API service made using FastAPI"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "fastapi[standard]==0.136.1",
-    "proxmox-sdk==0.0.4.post3",
+    "proxmox-sdk==0.0.5.post1",
     "netbox-sdk==0.0.8.post1",
     "sqlmodel==0.0.38",
     "pydantic==2.13.3",

--- a/uv.lock
+++ b/uv.lock
@@ -1703,7 +1703,7 @@ wheels = [
 
 [[package]]
 name = "proxbox-api"
-version = "0.0.11.post1"
+version = "0.0.11.post2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -1765,7 +1765,7 @@ requires-dist = [
     { name = "netbox-sdk", specifier = "==0.0.8.post1" },
     { name = "playwright", marker = "extra == 'playwright'", specifier = ">=1.58.0" },
     { name = "playwright", marker = "extra == 'test'", specifier = ">=1.58.0" },
-    { name = "proxmox-sdk", specifier = "==0.0.4.post3" },
+    { name = "proxmox-sdk", specifier = "==0.0.5.post1" },
     { name = "pydantic", specifier = "==2.13.3" },
     { name = "pytest", marker = "extra == 'e2e'", specifier = ">=9.0.3" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3" },
@@ -1807,7 +1807,7 @@ dev = [{ name = "ruff", specifier = ">=0.15.8" }]
 
 [[package]]
 name = "proxmox-sdk"
-version = "0.0.4.post3"
+version = "0.0.5.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1816,9 +1816,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "slowapi" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/6d/845925bd37f3b6717728af6372834f91771c974386ba3e27f9d0fbe33c57/proxmox_sdk-0.0.4.post3.tar.gz", hash = "sha256:3a7fe066d60b7c78c47dad0b70c1940f04dc9601f5dd9727d6e605522d437929", size = 802445, upload-time = "2026-05-15T02:50:14.326Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/b0/7e4c1f56c42e5eeca7223759b44e4d4967d0ad9195bb88b51cc9c464f2de/proxmox_sdk-0.0.5.post1.tar.gz", hash = "sha256:51f946a94e7ba5e9c3d90ec3a1eeef2e9b6a2310cd5ca650005ccf3883d3b3f6", size = 826849, upload-time = "2026-05-16T21:59:34.635Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/d3/4df714a034705aab9ac37185117289f2635b71c6060097ea885d0bf51ff9/proxmox_sdk-0.0.4.post3-py3-none-any.whl", hash = "sha256:a43698d4fe1f996b8079bd5c660ab1ee3e5bda7915804c735aa74e93344a84d3", size = 867111, upload-time = "2026-05-15T02:50:12.9Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/d7/241e26495214d90c04c6504ff311722a376b0bb76c444bb374ed10f916ce/proxmox_sdk-0.0.5.post1-py3-none-any.whl", hash = "sha256:bfc7bf04be487e6b1de76ab7c9faddf4721b92410157a04a79da068ca169b7f4", size = 897924, upload-time = "2026-05-16T21:59:32.621Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `proxmox-sdk` pin from `0.0.4.post3` -> `0.0.5.post1` to pick up the new `proxmox_sdk.pdm` subpackage (full PDM SDK + CLI + TUI + mock server) shipped via emersonfelipesp/proxmox-sdk#17.
- Bumps `proxbox-api` version to `0.0.11.post2`.

## Why
First step toward Proxmox Datacenter Manager support tracked in emersonfelipesp/netbox-proxbox#449. The plan in that issue lands incrementally; this PR ships only the SDK pin bump so PDM-aware operators can pull `proxmox-sdk 0.0.5.post1` through `proxbox-api` immediately. The actual `proxbox_api/pdm/` subpackage and `PDMEndpoint` database model land in follow-up PRs.

## Public API surface check

Verified every `proxmox_sdk.*` import used by `proxbox-api` still resolves against the `0.0.5.post1` wheel:

- `from proxmox_sdk import ProxmoxSDK` — re-exported via lazy attribute table.
- `from proxmox_sdk.sdk.exceptions import ResourceException` (and `ProxmoxSDKError`).
- `from proxmox_sdk.sdk.api import ProxmoxSDK`.
- `from proxmox_sdk.sdk.resource import ProxmoxResource`.
- `from proxmox_sdk.pbs import PBSClient` (optional `[pbs]` extra).
- `from proxmox_sdk.ceph import CephClient` (optional `[ceph]` extra).
- `from proxmox_sdk.node.hardware import discover_node` — path is now a subpackage but `__init__.py` still re-exports `discover_node` from `proxmox_sdk.node.hardware.discover`.
- `from proxmox_sdk.ssh import RemoteSSHClient, CommandNotAllowed, HostKeyMismatch, OutputTooLarge, SshAuthFailed, SshTimeout` — all still listed in `__all__`.
- `from proxmox_sdk.mock.{schema_helpers,state} import schema_fingerprint, shared_mock_store`.
- `from proxmox_sdk.schema import load_proxmox_generated_openapi`.

## Test plan
- [ ] Existing `tests/` suite (`uv run pytest tests`) passes against the new SDK.
- [ ] `uv run python -c "import proxbox_api.main"` still imports clean.
- [ ] CI test matrix (`test (latest)` + pinned NetBox slots) passes.
- [ ] PyPI publish workflow fires on tag push (`v0.0.11.post2`).
- [ ] Docker Hub publish workflow fires on release publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)