### PR TITLE
feat(cloud): add Packer image factory backend (PHASE1)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include proxbox_api/packer_templates *.hcl *.sh

--- a/proxbox_api/app/factory.py
+++ b/proxbox_api/app/factory.py
@@ -32,6 +32,7 @@ from proxbox_api.logger import logger
 from proxbox_api.openapi_custom import custom_openapi_builder
 from proxbox_api.routes.admin import router as admin_router
 from proxbox_api.routes.auth import router as auth_router
+from proxbox_api.routes.cloud import image_factory_router as cloud_image_factory_router
 from proxbox_api.routes.cloud import provision_router as cloud_provision_router
 from proxbox_api.routes.cloud import pve_template_router as cloud_pve_template_router
 from proxbox_api.routes.cloud import template_images_router as cloud_template_images_router
@@ -426,6 +427,7 @@ def create_app() -> FastAPI:  # noqa: C901
         app.include_router(intent_router, prefix="/intent", tags=["intent"])
         app.include_router(deletion_requests_router, prefix="/intent", tags=["intent"])
         app.include_router(cloud_provision_router, prefix="/cloud", tags=["cloud"])
+        app.include_router(cloud_image_factory_router, prefix="/cloud", tags=["cloud"])
         app.include_router(cloud_template_images_router, prefix="/cloud", tags=["cloud"])
         app.include_router(cloud_pve_template_router, prefix="/cloud", tags=["cloud"])
         app.include_router(cloud_templates_router, prefix="/cloud", tags=["cloud"])

--- a/proxbox_api/database.py
+++ b/proxbox_api/database.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import AsyncGenerator, Generator
+from datetime import datetime
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any, ClassVar
+from uuid import uuid4
 
 import bcrypt
 from fastapi import Depends
-from sqlalchemy import event, inspect, text
+from sqlalchemy import JSON, Column, event, inspect, text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
 from sqlmodel import Field, Session, SQLModel, create_engine, select
@@ -125,6 +127,35 @@ class ProxmoxEndpoint(SQLModel, table=True):
 
     def set_encrypted_token_value(self, value: str | None) -> None:
         self.token_value = encrypt_value(value)
+
+
+class ImageBuildRun(SQLModel, table=True):
+    """Persisted lifecycle record for image factory Packer runs."""
+
+    __tablename__: ClassVar[str] = "image_build_run"
+    __table_args__ = {"extend_existing": True}
+
+    id: str = Field(default_factory=lambda: str(uuid4()), primary_key=True)
+    uuid: str | None = Field(default=None, index=True)
+    status: str = Field(default="queued", index=True)
+    endpoint_id: int = Field(index=True)
+    target_node: str = Field(index=True)
+    builder_type: str = Field(index=True)
+    source_template_vmid: int = Field(index=True)
+    output_vmid: int = Field(index=True)
+    output_name: str = Field(index=True)
+    os_family: str
+    os_release: str
+    image_version: str
+    workdir: str
+    started_at: datetime | None = Field(default=None)
+    completed_at: datetime | None = Field(default=None)
+    exit_code: int | None = Field(default=None)
+    error: str | None = Field(default=None)
+    artifact_metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
 
 
 class DeletionRequestRecord(SQLModel, table=True):
@@ -444,12 +475,55 @@ def _migrate_pbs_endpoint_columns() -> None:
             conn.execute(text(stmt))
 
 
+def _migrate_image_build_run_columns() -> None:
+    table = ImageBuildRun.__tablename__
+    try:
+        with engine.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA table_info({table})")).mappings().all()
+        if not rows:
+            return
+        existing = {str(row["name"]) for row in rows}
+    except Exception:
+        return
+
+    column_specs = {
+        "uuid": "VARCHAR",
+        "status": "VARCHAR NOT NULL DEFAULT 'queued'",
+        "endpoint_id": "INTEGER NOT NULL DEFAULT 0",
+        "target_node": "VARCHAR NOT NULL DEFAULT ''",
+        "builder_type": "VARCHAR NOT NULL DEFAULT 'proxmox-clone'",
+        "source_template_vmid": "INTEGER NOT NULL DEFAULT 0",
+        "output_vmid": "INTEGER NOT NULL DEFAULT 0",
+        "output_name": "VARCHAR NOT NULL DEFAULT ''",
+        "os_family": "VARCHAR NOT NULL DEFAULT ''",
+        "os_release": "VARCHAR NOT NULL DEFAULT ''",
+        "image_version": "VARCHAR NOT NULL DEFAULT ''",
+        "workdir": "VARCHAR NOT NULL DEFAULT ''",
+        "started_at": "DATETIME",
+        "completed_at": "DATETIME",
+        "exit_code": "INTEGER",
+        "error": "VARCHAR",
+        "artifact_metadata": "JSON NOT NULL DEFAULT '{}'",
+    }
+    stmts = [
+        f"ALTER TABLE {table} ADD COLUMN {column} {spec}"
+        for column, spec in column_specs.items()
+        if column not in existing
+    ]
+    if not stmts:
+        return
+    with engine.begin() as conn:
+        for stmt in stmts:
+            conn.execute(text(stmt))
+
+
 def create_db_and_tables() -> None:
     SQLModel.metadata.create_all(engine)
     _migrate_proxmox_endpoint_columns()
     _migrate_netbox_endpoint_columns()
     _migrate_deletion_request_columns()
     _migrate_pbs_endpoint_columns()
+    _migrate_image_build_run_columns()
 
 
 def get_session() -> Generator[Session, None, None]:

--- a/proxbox_api/packer_templates/__init__.py
+++ b/proxbox_api/packer_templates/__init__.py
@@ -1,0 +1,1 @@
+"""Bundled Packer templates and provisioner assets."""

--- a/proxbox_api/packer_templates/provisioners/debian-base.sh
+++ b/proxbox_api/packer_templates/provisioners/debian-base.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ "$(id -u)" -eq 0 ]; then
+  SUDO=""
+else
+  SUDO="sudo"
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+$SUDO apt-get update
+$SUDO apt-get install -y --no-install-recommends \
+  ca-certificates \
+  cloud-init \
+  qemu-guest-agent \
+  sudo
+
+$SUDO systemctl enable qemu-guest-agent >/dev/null 2>&1 || true
+$SUDO systemctl enable cloud-init >/dev/null 2>&1 || true
+
+$SUDO cloud-init clean --logs --machine-id >/dev/null 2>&1 || true
+$SUDO truncate -s 0 /etc/machine-id || true
+$SUDO rm -f /var/lib/dbus/machine-id
+$SUDO ln -sf /etc/machine-id /var/lib/dbus/machine-id
+
+$SUDO apt-get autoremove -y >/dev/null 2>&1 || true
+$SUDO apt-get clean
+$SUDO rm -rf /var/lib/apt/lists/*
+
+$SUDO rm -f /root/.bash_history
+for history_file in /home/*/.bash_history; do
+  [ -e "$history_file" ] || continue
+  $SUDO rm -f "$history_file"
+done
+
+$SUDO find /var/log -type f -exec truncate -s 0 {} \; >/dev/null 2>&1 || true
+history -c >/dev/null 2>&1 || true

--- a/proxbox_api/packer_templates/provisioners/docker-host.sh
+++ b/proxbox_api/packer_templates/provisioners/docker-host.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ "$(id -u)" -eq 0 ]; then
+  SUDO=""
+else
+  SUDO="sudo"
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+$SUDO apt-get update
+$SUDO apt-get install -y --no-install-recommends \
+  ca-certificates \
+  cloud-init \
+  containerd \
+  docker.io \
+  qemu-guest-agent \
+  sudo
+
+$SUDO systemctl enable qemu-guest-agent >/dev/null 2>&1 || true
+$SUDO systemctl enable docker >/dev/null 2>&1 || true
+
+$SUDO cloud-init clean --logs --machine-id >/dev/null 2>&1 || true
+$SUDO truncate -s 0 /etc/machine-id || true
+$SUDO rm -f /var/lib/dbus/machine-id
+$SUDO ln -sf /etc/machine-id /var/lib/dbus/machine-id
+
+$SUDO rm -f /root/.bash_history
+for history_file in /home/*/.bash_history; do
+  [ -e "$history_file" ] || continue
+  $SUDO rm -f "$history_file"
+done
+
+$SUDO find /var/log -type f -exec truncate -s 0 {} \; >/dev/null 2>&1 || true
+history -c >/dev/null 2>&1 || true

--- a/proxbox_api/packer_templates/provisioners/qemu-agent.sh
+++ b/proxbox_api/packer_templates/provisioners/qemu-agent.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ "$(id -u)" -eq 0 ]; then
+  SUDO=""
+else
+  SUDO="sudo"
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+$SUDO apt-get update
+$SUDO apt-get install -y --no-install-recommends qemu-guest-agent
+$SUDO systemctl enable qemu-guest-agent >/dev/null 2>&1 || true
+
+$SUDO cloud-init clean --logs --machine-id >/dev/null 2>&1 || true
+$SUDO truncate -s 0 /etc/machine-id || true
+$SUDO rm -f /var/lib/dbus/machine-id
+$SUDO ln -sf /etc/machine-id /var/lib/dbus/machine-id
+
+$SUDO rm -f /root/.bash_history
+for history_file in /home/*/.bash_history; do
+  [ -e "$history_file" ] || continue
+  $SUDO rm -f "$history_file"
+done
+
+$SUDO find /var/log -type f -exec truncate -s 0 {} \; >/dev/null 2>&1 || true
+history -c >/dev/null 2>&1 || true

--- a/proxbox_api/packer_templates/provisioners/ubuntu-base.sh
+++ b/proxbox_api/packer_templates/provisioners/ubuntu-base.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ "$(id -u)" -eq 0 ]; then
+  SUDO=""
+else
+  SUDO="sudo"
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+$SUDO apt-get update
+$SUDO apt-get install -y --no-install-recommends \
+  ca-certificates \
+  cloud-init \
+  qemu-guest-agent \
+  sudo
+
+$SUDO systemctl enable qemu-guest-agent >/dev/null 2>&1 || true
+$SUDO systemctl enable cloud-init >/dev/null 2>&1 || true
+
+$SUDO cloud-init clean --logs --machine-id >/dev/null 2>&1 || true
+$SUDO truncate -s 0 /etc/machine-id || true
+$SUDO rm -f /var/lib/dbus/machine-id
+$SUDO ln -sf /etc/machine-id /var/lib/dbus/machine-id
+
+$SUDO rm -f /root/.bash_history
+for history_file in /home/*/.bash_history; do
+  [ -e "$history_file" ] || continue
+  $SUDO rm -f "$history_file"
+done
+
+$SUDO find /var/log -type f -exec truncate -s 0 {} \; >/dev/null 2>&1 || true
+history -c >/dev/null 2>&1 || true

--- a/proxbox_api/packer_templates/proxmox/clone-cloud-init.pkr.hcl
+++ b/proxbox_api/packer_templates/proxmox/clone-cloud-init.pkr.hcl
@@ -1,0 +1,92 @@
+packer {
+  required_plugins {
+    proxmox = {
+      source  = "github.com/hashicorp/proxmox"
+      version = ">= 1.2.3"
+    }
+  }
+}
+
+variable "proxmox_url" {
+  type    = string
+  default = ""
+}
+
+variable "node" {
+  type = string
+}
+
+variable "clone_vm_id" {
+  type = number
+}
+
+variable "vm_id" {
+  type = number
+}
+
+variable "vm_name" {
+  type = string
+}
+
+variable "template_name" {
+  type = string
+}
+
+variable "vm_storage" {
+  type = string
+}
+
+variable "bridge" {
+  type = string
+}
+
+variable "memory" {
+  type = number
+}
+
+variable "cores" {
+  type = number
+}
+
+variable "cpu_type" {
+  type = string
+}
+
+variable "cloud_init_storage_pool" {
+  type = string
+}
+
+source "proxmox-clone" "cloud_image" {
+  proxmox_url = env("PROXMOX_URL") != "" ? env("PROXMOX_URL") : var.proxmox_url
+  username    = env("PROXMOX_USERNAME")
+  token       = env("PROXMOX_TOKEN")
+
+  node         = var.node
+  clone_vm_id  = var.clone_vm_id
+  vm_id        = var.vm_id
+  vm_name      = var.vm_name
+  template_name = var.template_name
+
+  full_clone              = true
+  cloud_init              = true
+  cloud_init_storage_pool = var.cloud_init_storage_pool
+  qemu_agent              = true
+  scsi_controller         = "virtio-scsi-pci"
+  memory                  = var.memory
+  cores                   = var.cores
+  cpu_type                = var.cpu_type
+  insecure_skip_tls_verify = true
+
+  network_adapters {
+    model  = "virtio"
+    bridge = var.bridge
+  }
+}
+
+build {
+  sources = ["source.proxmox-clone.cloud_image"]
+
+  provisioner "shell" {
+    script = "provisioners/selected-recipe.sh"
+  }
+}

--- a/proxbox_api/routes/cloud/__init__.py
+++ b/proxbox_api/routes/cloud/__init__.py
@@ -1,6 +1,7 @@
 """Cloud Portal provisioning routes."""
 
 from proxbox_api.routes.cloud.catalog import versions_router
+from proxbox_api.routes.cloud.image_factory import router as image_factory_router
 from proxbox_api.routes.cloud.provision import router as provision_router
 from proxbox_api.routes.cloud.pve_template import router as pve_template_router
 from proxbox_api.routes.cloud.template_images import router as template_images_router
@@ -8,6 +9,7 @@ from proxbox_api.routes.cloud.templates import router as templates_router
 
 __all__ = (
     "provision_router",
+    "image_factory_router",
     "pve_template_router",
     "template_images_router",
     "templates_router",

--- a/proxbox_api/routes/cloud/catalog.py
+++ b/proxbox_api/routes/cloud/catalog.py
@@ -10,7 +10,6 @@ from proxbox_api.schemas.cloud_provision import (
     CloudImageVersionEntry,
 )
 
-
 versions_router = APIRouter()
 
 

--- a/proxbox_api/routes/cloud/image_factory.py
+++ b/proxbox_api/routes/cloud/image_factory.py
@@ -1,0 +1,513 @@
+"""Packer-backed image factory routes."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncGenerator
+from datetime import timezone
+from typing import Any
+from uuid import uuid4
+
+from fastapi import APIRouter, HTTPException, status
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from proxbox_api.database import AsyncDatabaseSessionDep as SessionDep
+from proxbox_api.database import ProxmoxEndpoint
+from proxbox_api.routes.proxmox_actions import _gate, _open_proxmox_session
+from proxbox_api.schemas.image_factory import PackerImageBuildRequest, PackerImageBuildResponse
+from proxbox_api.services.image_factory.logs import scrub_payload, scrub_text
+from proxbox_api.services.image_factory.models import (
+    LiveImageBuildRun,
+    create_image_build_run,
+    drop_live_run,
+    get_image_build_run,
+    get_live_run,
+    register_live_run,
+    response_from_run,
+    update_image_build_run,
+    utcnow,
+)
+from proxbox_api.services.image_factory.renderer import render_packer_workdir
+from proxbox_api.services.image_factory.runner import (
+    CommandResult,
+    PackerCommandError,
+    PackerRunner,
+)
+from proxbox_api.services.image_factory.workdir import cleanup_workdir, create_workdir
+from proxbox_api.utils.async_compat import maybe_await as _maybe_await
+
+router = APIRouter()
+
+
+def packer_runner_factory(*, env: dict[str, str], secrets: tuple[str, ...]) -> PackerRunner:
+    return PackerRunner(env=env, secrets=secrets)
+
+
+async def _gated_endpoint(
+    session: SessionDep,
+    endpoint_id: int,
+) -> ProxmoxEndpoint | JSONResponse:
+    gated = await _gate(session, endpoint_id)
+    if not isinstance(gated, JSONResponse):
+        return gated
+    content = json.loads(gated.body.decode() or "{}")
+    if content.get("reason") == "endpoint_not_found":
+        return JSONResponse(status_code=status.HTTP_404_NOT_FOUND, content=content)
+    return gated
+
+
+def _proxmox_api_url(endpoint: ProxmoxEndpoint) -> str:
+    host = endpoint.domain or endpoint.ip_address.split("/")[0]
+    return f"https://{host}:{endpoint.port}/api2/json"
+
+
+def _packer_env(endpoint: ProxmoxEndpoint) -> tuple[dict[str, str], tuple[str, ...]]:
+    token = endpoint.get_decrypted_token_value()
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Proxmox API token credentials are required for Packer image builds.",
+        )
+    username = endpoint.username
+    if endpoint.token_name and "!" not in username:
+        username = f"{username}!{endpoint.token_name}"
+    url = _proxmox_api_url(endpoint)
+    env = {
+        "PROXMOX_URL": url,
+        "PROXMOX_USERNAME": username,
+        "PROXMOX_TOKEN": token,
+    }
+    return env, (url, username, token)
+
+
+async def _ensure_template_vmid_exists(
+    endpoint: ProxmoxEndpoint,
+    request: PackerImageBuildRequest,
+) -> None:
+    proxmox = None
+    try:
+        proxmox = await _open_proxmox_session(endpoint)
+        config = await _maybe_await(
+            proxmox.session.nodes(request.target_node).qemu(request.template_vmid).config.get()
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"template_vmid {request.template_vmid} was not found on "
+                f"node {request.target_node}."
+            ),
+        ) from exc
+    finally:
+        if proxmox is not None:
+            await proxmox.aclose()
+    if not isinstance(config, dict):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"template_vmid {request.template_vmid} did not return a VM config.",
+        )
+
+
+def _sse_frame(name: str, data: dict[str, Any], secrets: tuple[str, ...] = ()) -> str:
+    return f"event: {name}\ndata: {json.dumps(scrub_payload(data, secrets))}\n\n"
+
+
+def _result_summary(result: CommandResult) -> dict[str, Any]:
+    return {
+        "exit_code": result.exit_code,
+        "stdout_lines": len(result.stdout),
+        "stderr_lines": len(result.stderr),
+    }
+
+
+async def _prepare_build(
+    request: PackerImageBuildRequest,
+    session: SessionDep,
+    *,
+    register_live: bool,
+) -> tuple[str, LiveImageBuildRun, PackerImageBuildResponse]:
+    endpoint_or_error = await _gated_endpoint(session, request.endpoint_id)
+    if isinstance(endpoint_or_error, JSONResponse):
+        raise _JsonResponseException(endpoint_or_error)
+    endpoint = endpoint_or_error
+    await _ensure_template_vmid_exists(endpoint, request)
+    env, secrets = _packer_env(endpoint)
+    build_id = str(uuid4())
+    workdir = create_workdir(build_id)
+    try:
+        rendered = render_packer_workdir(request=request, workdir=workdir)
+        runner = packer_runner_factory(env=env, secrets=secrets)
+        live = LiveImageBuildRun(
+            build_id=build_id,
+            request=request,
+            rendered=rendered,
+            runner=runner,
+        )
+        run = await create_image_build_run(
+            session,
+            build_id=build_id,
+            request=request,
+            workdir=workdir,
+            template_path=rendered.template_path,
+        )
+        if register_live:
+            await register_live_run(live)
+        return build_id, live, response_from_run(run)
+    except Exception:
+        cleanup_workdir(workdir)
+        raise
+
+
+class _JsonResponseException(Exception):
+    def __init__(self, response: JSONResponse) -> None:
+        self.response = response
+
+
+async def _run_validation(
+    *,
+    session: SessionDep,
+    live: LiveImageBuildRun,
+    secrets: tuple[str, ...],
+) -> dict[str, Any]:
+    started_at = utcnow()
+    await update_image_build_run(session, live.build_id, status="running", started_at=started_at)
+    init_result = await live.runner.init(live.rendered.workdir)
+    validate_result = await live.runner.validate(live.rendered.workdir, live.rendered.var_file)
+    completed_at = utcnow()
+    valid = init_result.exit_code == 0 and validate_result.exit_code == 0
+    status_value = "completed" if valid else "failed"
+    error = None
+    if not valid:
+        output = (
+            init_result.stderr
+            + validate_result.stderr
+            + init_result.stdout
+            + validate_result.stdout
+        )
+        error = scrub_text("\n".join(output) or "packer validate failed", secrets)
+    run = await update_image_build_run(
+        session,
+        live.build_id,
+        status=status_value,
+        completed_at=completed_at,
+        exit_code=validate_result.exit_code
+        if init_result.exit_code == 0
+        else init_result.exit_code,
+        error=error,
+    )
+    cleanup_workdir(live.rendered.workdir, keep_workdir=live.keep_workdir)
+    return {
+        "build_id": live.build_id,
+        "valid": valid,
+        "status": status_value,
+        "init": _result_summary(init_result),
+        "validate": _result_summary(validate_result),
+        "response": response_from_run(run).model_dump(mode="json") if run is not None else None,
+    }
+
+
+@router.post(
+    "/image-factory/builds",
+    response_model=PackerImageBuildResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_image_factory_build(
+    request: PackerImageBuildRequest,
+    session: SessionDep,
+) -> PackerImageBuildResponse | JSONResponse:
+    try:
+        build_id, live, response = await _prepare_build(request, session, register_live=True)
+    except _JsonResponseException as exc:
+        return exc.response
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
+
+    if request.dry_run:
+        secrets = live.runner.secrets
+        await _run_validation(session=session, live=live, secrets=secrets)
+        await drop_live_run(build_id)
+        run = await get_image_build_run(session, build_id)
+        if run is None:
+            return response
+        return response_from_run(run)
+
+    return response
+
+
+@router.get(
+    "/image-factory/builds/{build_id}",
+    response_model=PackerImageBuildResponse,
+)
+async def get_image_factory_build(
+    build_id: str,
+    session: SessionDep,
+) -> PackerImageBuildResponse | JSONResponse:
+    run = await get_image_build_run(session, build_id)
+    if run is None:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content={"detail": f"No image factory build with id={build_id}."},
+        )
+    endpoint_or_error = await _gated_endpoint(session, run.endpoint_id)
+    if isinstance(endpoint_or_error, JSONResponse):
+        return endpoint_or_error
+    return response_from_run(run)
+
+
+async def _build_stream_generator(
+    *,
+    build_id: str,
+    session: SessionDep,
+    live: LiveImageBuildRun,
+    secrets: tuple[str, ...],
+    keepalive_interval: float = 15.0,
+) -> AsyncGenerator[str, None]:
+    last_keepalive = asyncio.get_event_loop().time()
+
+    def maybe_keepalive() -> str | None:
+        nonlocal last_keepalive
+        now = asyncio.get_event_loop().time()
+        if now - last_keepalive >= keepalive_interval:
+            last_keepalive = now
+            return ": keepalive\n\n"
+        return None
+
+    try:
+        started_at = utcnow()
+        await update_image_build_run(session, build_id, status="running", started_at=started_at)
+        yield _sse_frame(
+            "build_started",
+            {
+                "build_id": build_id,
+                "endpoint_id": live.request.endpoint_id,
+                "target_node": live.request.target_node,
+                "output_vmid": live.request.output_vmid,
+                "output_name": live.request.output_name,
+                "started_at": started_at.astimezone(timezone.utc).isoformat(),
+            },
+            secrets,
+        )
+
+        init_result = await live.runner.init(live.rendered.workdir)
+        yield _sse_frame(
+            "packer_init", {"build_id": build_id, **_result_summary(init_result)}, secrets
+        )
+        if init_result.exit_code != 0:
+            await _finish_failed(session, live, init_result.stderr or init_result.stdout, secrets)
+            yield _sse_frame(
+                "build_failed",
+                {"build_id": build_id, "error": "packer init failed"},
+                secrets,
+            )
+            yield _sse_frame("complete", {"build_id": build_id, "status": "failed"}, secrets)
+            return
+
+        validate_result = await live.runner.validate(live.rendered.workdir, live.rendered.var_file)
+        yield _sse_frame(
+            "packer_validate",
+            {"build_id": build_id, **_result_summary(validate_result)},
+            secrets,
+        )
+        if validate_result.exit_code != 0:
+            await _finish_failed(
+                session,
+                live,
+                validate_result.stderr or validate_result.stdout,
+                secrets,
+            )
+            yield _sse_frame(
+                "build_failed",
+                {"build_id": build_id, "error": "packer validate failed"},
+                secrets,
+            )
+            yield _sse_frame("complete", {"build_id": build_id, "status": "failed"}, secrets)
+            return
+
+        artifact_seen = False
+        async for event in live.runner.build(live.rendered.workdir, live.rendered.var_file):
+            artifact_seen = artifact_seen or event.name == "packer_artifact"
+            yield _sse_frame(event.name, {"build_id": build_id, **event.data}, secrets)
+            keepalive = maybe_keepalive()
+            if keepalive is not None:
+                yield keepalive
+
+        if live.cancel_requested.is_set():
+            await _finish_cancelled(session, live)
+            yield _sse_frame("complete", {"build_id": build_id, "status": "cancelled"}, secrets)
+            return
+
+        artifact_data = {
+            "build_id": build_id,
+            "template_name": live.request.output_name,
+            "vmid": live.request.output_vmid,
+        }
+        if not artifact_seen:
+            yield _sse_frame("packer_artifact", artifact_data, secrets)
+        run = await update_image_build_run(
+            session,
+            build_id,
+            status="completed",
+            completed_at=utcnow(),
+            exit_code=0,
+            artifact_metadata={
+                "template_name": live.request.output_name,
+                "output_vmid": live.request.output_vmid,
+                "packer_template_path": str(live.rendered.template_path),
+                "provisioner_recipe": live.request.provisioner_recipe,
+            },
+        )
+        cleanup_workdir(live.rendered.workdir, keep_workdir=live.keep_workdir)
+        await drop_live_run(build_id)
+        yield _sse_frame(
+            "build_completed",
+            response_from_run(run).model_dump(mode="json") if run is not None else artifact_data,
+            secrets,
+        )
+        yield _sse_frame("complete", {"build_id": build_id, "status": "completed"}, secrets)
+    except asyncio.CancelledError:
+        return
+    except PackerCommandError as exc:
+        if live.cancel_requested.is_set():
+            await _finish_cancelled(session, live)
+            yield _sse_frame("complete", {"build_id": build_id, "status": "cancelled"}, secrets)
+            return
+        await _finish_failed(
+            session, live, exc.output or [str(exc)], secrets, exit_code=exc.exit_code
+        )
+        yield _sse_frame(
+            "build_failed",
+            {"build_id": build_id, "error": scrub_text(str(exc), secrets)},
+            secrets,
+        )
+        yield _sse_frame("complete", {"build_id": build_id, "status": "failed"}, secrets)
+    except Exception as exc:  # noqa: BLE001
+        await _finish_failed(session, live, [str(exc)], secrets)
+        yield _sse_frame(
+            "build_failed",
+            {"build_id": build_id, "error": scrub_text(str(exc), secrets)},
+            secrets,
+        )
+        yield _sse_frame("complete", {"build_id": build_id, "status": "failed"}, secrets)
+
+
+async def _finish_failed(
+    session: SessionDep,
+    live: LiveImageBuildRun,
+    output: list[str],
+    secrets: tuple[str, ...],
+    *,
+    exit_code: int | None = None,
+) -> None:
+    await update_image_build_run(
+        session,
+        live.build_id,
+        status="failed",
+        completed_at=utcnow(),
+        exit_code=exit_code,
+        error=scrub_text("\n".join(output), secrets),
+    )
+    cleanup_workdir(live.rendered.workdir, keep_workdir=live.keep_workdir)
+    await drop_live_run(live.build_id)
+
+
+async def _finish_cancelled(session: SessionDep, live: LiveImageBuildRun) -> None:
+    await update_image_build_run(
+        session,
+        live.build_id,
+        status="cancelled",
+        completed_at=utcnow(),
+    )
+    cleanup_workdir(live.rendered.workdir, keep_workdir=live.keep_workdir)
+    await drop_live_run(live.build_id)
+
+
+@router.get("/image-factory/builds/{build_id}/stream", response_model=None)
+async def stream_image_factory_build(
+    build_id: str,
+    session: SessionDep,
+) -> StreamingResponse | JSONResponse:
+    run = await get_image_build_run(session, build_id)
+    if run is None:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content={"detail": f"No image factory build with id={build_id}."},
+        )
+    endpoint_or_error = await _gated_endpoint(session, run.endpoint_id)
+    if isinstance(endpoint_or_error, JSONResponse):
+        return endpoint_or_error
+    live = await get_live_run(build_id)
+    if live is None:
+        return JSONResponse(
+            status_code=status.HTTP_409_CONFLICT,
+            content={"detail": "Image factory build is not runnable in this process."},
+        )
+    _, secrets = _packer_env(endpoint_or_error)
+    return StreamingResponse(
+        _build_stream_generator(
+            build_id=build_id,
+            session=session,
+            live=live,
+            secrets=secrets,
+        ),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        },
+    )
+
+
+@router.post(
+    "/image-factory/builds/{build_id}/cancel",
+    response_model=PackerImageBuildResponse,
+)
+async def cancel_image_factory_build(
+    build_id: str,
+    session: SessionDep,
+) -> PackerImageBuildResponse | JSONResponse:
+    run = await get_image_build_run(session, build_id)
+    if run is None:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content={"detail": f"No image factory build with id={build_id}."},
+        )
+    endpoint_or_error = await _gated_endpoint(session, run.endpoint_id)
+    if isinstance(endpoint_or_error, JSONResponse):
+        return endpoint_or_error
+    live = await get_live_run(build_id)
+    if live is not None:
+        live.cancel_requested.set()
+        await live.runner.cancel(build_id)
+        cleanup_workdir(live.rendered.workdir, keep_workdir=live.keep_workdir)
+        await drop_live_run(build_id)
+    updated = await update_image_build_run(
+        session,
+        build_id,
+        status="cancelled",
+        completed_at=utcnow(),
+    )
+    return response_from_run(updated or run)
+
+
+@router.post("/image-factory/validate", response_model=None)
+async def validate_image_factory_build(
+    request: PackerImageBuildRequest,
+    session: SessionDep,
+) -> dict[str, Any] | JSONResponse:
+    try:
+        build_id, live, _response = await _prepare_build(request, session, register_live=False)
+    except _JsonResponseException as exc:
+        return exc.response
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
+    try:
+        secrets = live.runner.secrets
+        return await _run_validation(session=session, live=live, secrets=secrets)
+    finally:
+        await drop_live_run(build_id)

--- a/proxbox_api/routes/cloud/pipeline_scripts.py
+++ b/proxbox_api/routes/cloud/pipeline_scripts.py
@@ -172,18 +172,26 @@ def _append_template_import_commands(
     if user_data:
         user_snippet = f"{request.snippets_dir}/{snippet_name}-user-data.yml"
         commands.append(f"cat > {_q(user_snippet)} <<'EOF_USER_DATA'\n{user_data}EOF_USER_DATA")
-        snippet_refs.append(f"user={request.snippets_storage}:snippets/{snippet_name}-user-data.yml")
+        snippet_refs.append(
+            f"user={request.snippets_storage}:snippets/{snippet_name}-user-data.yml"
+        )
     if first_boot_script:
         boot_snippet = f"{request.snippets_dir}/{snippet_name}-first-boot.sh"
-        commands.append(f"cat > {_q(boot_snippet)} <<'EOF_FIRST_BOOT'\n{first_boot_script}EOF_FIRST_BOOT")
+        commands.append(
+            f"cat > {_q(boot_snippet)} <<'EOF_FIRST_BOOT'\n{first_boot_script}EOF_FIRST_BOOT"
+        )
         commands.append(f"chmod 600 {_q(boot_snippet)}")
-        snippet_refs.append(f"vendor={request.snippets_storage}:snippets/{snippet_name}-first-boot.sh")
+        snippet_refs.append(
+            f"vendor={request.snippets_storage}:snippets/{snippet_name}-first-boot.sh"
+        )
     meta_snippet = f"{request.snippets_dir}/{snippet_name}-meta-data.yml"
     meta_data = f"instance-id: {snippet_name}\nlocal-hostname: {request.hostname}\n"
     commands.append(f"cat > {_q(meta_snippet)} <<'EOF_META'\n{meta_data}EOF_META")
     snippet_refs.append(f"meta={request.snippets_storage}:snippets/{snippet_name}-meta-data.yml")
     commands.append(f"qm set {_q(request.vmid)} --cicustom {_q(','.join(snippet_refs))}")
-    commands.append(f"qm set {_q(request.vmid)} --description {_q('Built by Cloud Image Build Pipeline')}")
+    commands.append(
+        f"qm set {_q(request.vmid)} --description {_q('Built by Cloud Image Build Pipeline')}"
+    )
     commands.append(f"qm template {_q(request.vmid)}")
 
 
@@ -195,7 +203,9 @@ def _release_image_script(
 ) -> tuple[str, list[str], str]:
     image_url = request.image_url or entry.image_url
     if not image_url:
-        raise HTTPException(status_code=422, detail="image_url is required for release image builds.")
+        raise HTTPException(
+            status_code=422, detail="image_url is required for release image builds."
+        )
     filename = _artifact_from_url(image_url)
     cache_path = f"/var/lib/vz/template/cache/{filename}"
     raw_path = f"/var/lib/vz/template/cache/{_decompressed_name(filename, entry.compression)}"
@@ -213,7 +223,9 @@ def _release_image_script(
     if decompress:
         commands.append(decompress)
     commands.append(f"qemu-img convert -O qcow2 {_q(raw_path)} {_q(qcow_path)}")
-    _append_template_import_commands(commands, request, entry, qcow_path, first_boot_script, user_data)
+    _append_template_import_commands(
+        commands, request, entry, qcow_path, first_boot_script, user_data
+    )
     return "\n".join(commands) + "\n", commands, image_url
 
 
@@ -242,9 +254,13 @@ def _source_tree_script(
                 f"qemu-img convert -O qcow2 {_q(request.source_artifact_path)} {_q(qcow_path)}",
             ]
         )
-        _append_template_import_commands(commands, request, entry, qcow_path, first_boot_script, None)
+        _append_template_import_commands(
+            commands, request, entry, qcow_path, first_boot_script, None
+        )
     else:
-        commands.append("# Set source_artifact_path to the image emitted by the source build to import it.")
+        commands.append(
+            "# Set source_artifact_path to the image emitted by the source build to import it."
+        )
     return "\n".join(commands) + "\n", commands
 
 

--- a/proxbox_api/runtime_settings.py
+++ b/proxbox_api/runtime_settings.py
@@ -112,6 +112,22 @@ def get_bool(*, settings_key: str, env: str, default: bool) -> bool:
     return default
 
 
+def get_str(*, settings_key: str, env: str, default: str) -> str:
+    raw = os.environ.get(env, "").strip()
+    if raw:
+        return raw
+
+    settings = _load_settings()
+    if settings is not None:
+        value = settings.get(settings_key)
+        if value is not None:
+            text = str(value).strip()
+            if text:
+                return text
+
+    return default
+
+
 def _clamp_int(value: int, minimum: int | None, maximum: int | None) -> int:
     if minimum is not None and value < minimum:
         return minimum
@@ -128,4 +144,4 @@ def _clamp_float(value: float, minimum: float | None, maximum: float | None) -> 
     return value
 
 
-__all__ = ["get_int", "get_float", "get_bool"]
+__all__ = ["get_int", "get_float", "get_bool", "get_str"]

--- a/proxbox_api/schemas/__init__.py
+++ b/proxbox_api/schemas/__init__.py
@@ -4,6 +4,9 @@ from pydantic import field_validator
 
 from proxbox_api.schemas._base import ProxboxBaseModel
 
+from .image_factory import ImageFactoryBuildMode as ImageFactoryBuildMode
+from .image_factory import PackerImageBuildRequest as PackerImageBuildRequest
+from .image_factory import PackerImageBuildResponse as PackerImageBuildResponse
 from .netbox import NetboxSessionSchema
 from .proxmox import ProxmoxSessionSchema
 

--- a/proxbox_api/schemas/image_factory.py
+++ b/proxbox_api/schemas/image_factory.py
@@ -1,0 +1,55 @@
+"""Image factory request and response schemas."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ImageFactoryBuildMode(str, Enum):
+    direct_cloud_image = "direct-cloud-image"
+    packer_clone = "packer-clone"
+    packer_iso = "packer-iso"
+
+
+class PackerImageBuildRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    endpoint_id: int
+    target_node: str
+    builder_type: Literal["proxmox-clone"]
+    template_vmid: int
+    output_vmid: int
+    output_name: str
+    os_family: str
+    os_release: str
+    image_version: str
+    vm_storage: str
+    cloud_init_storage: str | None = None
+    bridge: str = "vmbr0"
+    memory_mb: int = 2048
+    cores: int = 2
+    cpu_type: str = "host"
+    provisioner_recipe: str
+    variables: dict[str, str | int | bool] = Field(default_factory=dict)
+    force: bool = False
+    dry_run: bool = False
+
+
+class PackerImageBuildResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    build_id: str
+    status: Literal["queued", "running", "failed", "completed", "cancelled"]
+    endpoint_id: int
+    target_node: str
+    output_vmid: int
+    output_name: str
+    artifact_template_name: str | None = None
+    packer_template_path: str | None = None
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    log_url: str | None = None

--- a/proxbox_api/services/image_factory/__init__.py
+++ b/proxbox_api/services/image_factory/__init__.py
@@ -1,0 +1,5 @@
+"""Image factory service package."""
+
+from proxbox_api.services.image_factory.runner import CommandResult, PackerRunner
+
+__all__ = ["CommandResult", "PackerRunner"]

--- a/proxbox_api/services/image_factory/logs.py
+++ b/proxbox_api/services/image_factory/logs.py
@@ -1,0 +1,101 @@
+"""Packer log normalization and defensive secret scrubbing."""
+
+from __future__ import annotations
+
+import csv
+import re
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+
+@dataclass(frozen=True)
+class PackerEvent:
+    name: str
+    data: dict[str, Any]
+
+
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b(token|password|secret|authorization|cookie)\b(\s*[=:]\s*)([^\s,;]+)"
+)
+_PROXMOX_ENV_RE = re.compile(r"(?i)\b(PROXMOX_(?:URL|USERNAME|TOKEN|PASSWORD))=([^\s,;]+)")
+
+
+def scrub_text(value: object, secrets: Iterable[str] = ()) -> str:
+    text = "" if value is None else str(value)
+    for secret in secrets:
+        if secret:
+            text = text.replace(str(secret), "[redacted]")
+    text = _SECRET_ASSIGNMENT_RE.sub(r"\1\2[redacted]", text)
+    return _PROXMOX_ENV_RE.sub(r"\1=[redacted]", text)
+
+
+def scrub_payload(payload: dict[str, Any], secrets: Iterable[str] = ()) -> dict[str, Any]:
+    scrubbed: dict[str, Any] = {}
+    for key, value in payload.items():
+        if isinstance(value, str):
+            scrubbed[key] = scrub_text(value, secrets)
+        elif isinstance(value, dict):
+            scrubbed[key] = scrub_payload(value, secrets)
+        elif isinstance(value, list):
+            scrubbed[key] = [
+                scrub_text(item, secrets) if isinstance(item, str) else item for item in value
+            ]
+        else:
+            scrubbed[key] = value
+    return scrubbed
+
+
+def normalize_machine_readable_line(
+    line: str,
+    *,
+    phase: str,
+    stream: str = "stdout",
+    secrets: Iterable[str] = (),
+) -> PackerEvent:
+    message = line.strip()
+    target = ""
+    event_type = "raw"
+    try:
+        row = next(csv.reader([line]))
+    except csv.Error:
+        row = []
+    if len(row) >= 4:
+        target = row[1]
+        event_type = row[2]
+        message = ",".join(row[4:]) if len(row) > 4 else row[3]
+    return PackerEvent(
+        name="packer_log",
+        data={
+            "phase": phase,
+            "stream": stream,
+            "target": scrub_text(target, secrets),
+            "type": scrub_text(event_type, secrets),
+            "message": scrub_text(message, secrets),
+        },
+    )
+
+
+def normalize_timestamp_ui_line(
+    line: str,
+    *,
+    stream: str = "stdout",
+    secrets: Iterable[str] = (),
+) -> PackerEvent:
+    message = scrub_text(line.strip(), secrets)
+    lower = message.lower()
+    if "artifact" in lower or "template" in lower and "created" in lower:
+        return PackerEvent(
+            name="packer_artifact",
+            data={
+                "stream": stream,
+                "message": message,
+            },
+        )
+    return PackerEvent(
+        name="packer_log",
+        data={
+            "phase": "build",
+            "stream": stream,
+            "message": message,
+        },
+    )

--- a/proxbox_api/services/image_factory/models.py
+++ b/proxbox_api/services/image_factory/models.py
@@ -1,0 +1,120 @@
+"""Image factory live-state and persistence helpers."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from proxbox_api.database import ImageBuildRun
+from proxbox_api.schemas.image_factory import PackerImageBuildRequest, PackerImageBuildResponse
+from proxbox_api.services.image_factory.renderer import RenderedPackerWorkdir
+from proxbox_api.services.image_factory.runner import PackerRunner
+from proxbox_api.utils.async_compat import maybe_await as _maybe_await
+
+
+@dataclass
+class LiveImageBuildRun:
+    build_id: str
+    request: PackerImageBuildRequest
+    rendered: RenderedPackerWorkdir
+    runner: PackerRunner
+    keep_workdir: bool = False
+    cancel_requested: asyncio.Event = field(default_factory=asyncio.Event)
+
+
+_LIVE_RUNS: dict[str, LiveImageBuildRun] = {}
+_LIVE_RUNS_LOCK = asyncio.Lock()
+
+
+def utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+async def register_live_run(run: LiveImageBuildRun) -> None:
+    async with _LIVE_RUNS_LOCK:
+        _LIVE_RUNS[run.build_id] = run
+
+
+async def get_live_run(build_id: str) -> LiveImageBuildRun | None:
+    async with _LIVE_RUNS_LOCK:
+        return _LIVE_RUNS.get(build_id)
+
+
+async def drop_live_run(build_id: str) -> None:
+    async with _LIVE_RUNS_LOCK:
+        _LIVE_RUNS.pop(build_id, None)
+
+
+async def create_image_build_run(
+    session: object,
+    *,
+    build_id: str,
+    request: PackerImageBuildRequest,
+    workdir: Path,
+    template_path: Path,
+    status: str = "queued",
+) -> ImageBuildRun:
+    run = ImageBuildRun(
+        id=build_id,
+        uuid=build_id,
+        status=status,
+        endpoint_id=request.endpoint_id,
+        target_node=request.target_node,
+        builder_type=request.builder_type,
+        source_template_vmid=request.template_vmid,
+        output_vmid=request.output_vmid,
+        output_name=request.output_name,
+        os_family=request.os_family,
+        os_release=request.os_release,
+        image_version=request.image_version,
+        workdir=str(workdir),
+        artifact_metadata={
+            "template_name": request.output_name,
+            "packer_template_path": str(template_path),
+            "provisioner_recipe": request.provisioner_recipe,
+        },
+    )
+    session.add(run)
+    await _maybe_await(session.commit())
+    await _maybe_await(session.refresh(run))
+    return run
+
+
+async def get_image_build_run(session: object, build_id: str) -> ImageBuildRun | None:
+    return await _maybe_await(session.get(ImageBuildRun, build_id))  # type: ignore[attr-defined]
+
+
+async def update_image_build_run(
+    session: object,
+    build_id: str,
+    **fields: Any,
+) -> ImageBuildRun | None:
+    run = await get_image_build_run(session, build_id)
+    if run is None:
+        return None
+    for key, value in fields.items():
+        setattr(run, key, value)
+    session.add(run)
+    await _maybe_await(session.commit())
+    await _maybe_await(session.refresh(run))
+    return run
+
+
+def response_from_run(run: ImageBuildRun) -> PackerImageBuildResponse:
+    metadata = run.artifact_metadata or {}
+    return PackerImageBuildResponse(
+        build_id=run.id,
+        status=run.status,  # type: ignore[arg-type]
+        endpoint_id=run.endpoint_id,
+        target_node=run.target_node,
+        output_vmid=run.output_vmid,
+        output_name=run.output_name,
+        artifact_template_name=metadata.get("template_name"),
+        packer_template_path=metadata.get("packer_template_path"),
+        started_at=run.started_at,
+        completed_at=run.completed_at,
+        log_url=f"/cloud/image-factory/builds/{run.id}/stream",
+    )

--- a/proxbox_api/services/image_factory/renderer.py
+++ b/proxbox_api/services/image_factory/renderer.py
@@ -1,0 +1,115 @@
+"""Render static Packer templates into an isolated build workdir."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+from proxbox_api.schemas.image_factory import PackerImageBuildRequest
+
+HCL_DECLARED_VARIABLES = {
+    "proxmox_url",
+    "node",
+    "clone_vm_id",
+    "vm_id",
+    "vm_name",
+    "template_name",
+    "vm_storage",
+    "bridge",
+    "memory",
+    "cores",
+    "cpu_type",
+    "cloud_init_storage_pool",
+}
+
+PKRVARS_WRITABLE_VARIABLES = HCL_DECLARED_VARIABLES - {"proxmox_url"}
+
+ALLOWED_PROVISIONER_RECIPES = {
+    "ubuntu-base": "ubuntu-base.sh",
+    "debian-base": "debian-base.sh",
+    "docker-host": "docker-host.sh",
+    "qemu-agent": "qemu-agent.sh",
+}
+
+
+@dataclass(frozen=True)
+class RenderedPackerWorkdir:
+    workdir: Path
+    template_path: Path
+    var_file: Path
+    variables: dict[str, str | int | bool]
+    provisioner_path: Path
+
+
+def _template_root() -> Path:
+    return Path(str(resources.files("proxbox_api") / "packer_templates"))
+
+
+def _copy_static_assets(workdir: Path, recipe: str) -> Path:
+    recipe_file = ALLOWED_PROVISIONER_RECIPES.get(recipe)
+    if recipe_file is None:
+        allowed = ", ".join(sorted(ALLOWED_PROVISIONER_RECIPES))
+        raise ValueError(f"provisioner_recipe must be one of: {allowed}")
+
+    template_root = _template_root()
+    template_src = template_root / "proxmox" / "clone-cloud-init.pkr.hcl"
+    template_dst = workdir / "clone-cloud-init.pkr.hcl"
+    shutil.copy2(template_src, template_dst)
+
+    provisioner_dir = workdir / "provisioners"
+    provisioner_dir.mkdir(parents=True, exist_ok=True)
+    selected_dst = provisioner_dir / "selected-recipe.sh"
+    shutil.copy2(template_root / "provisioners" / recipe_file, selected_dst)
+    return selected_dst
+
+
+def build_packer_variables(
+    request: PackerImageBuildRequest,
+) -> dict[str, str | int | bool]:
+    unknown = sorted(set(request.variables) - PKRVARS_WRITABLE_VARIABLES)
+    if unknown:
+        raise ValueError(f"Unsupported Packer variable(s): {', '.join(unknown)}")
+
+    variables: dict[str, str | int | bool] = {
+        "node": request.target_node,
+        "clone_vm_id": request.template_vmid,
+        "vm_id": request.output_vmid,
+        "vm_name": request.output_name,
+        "template_name": request.output_name,
+        "vm_storage": request.vm_storage,
+        "bridge": request.bridge,
+        "memory": request.memory_mb,
+        "cores": request.cores,
+        "cpu_type": request.cpu_type,
+        "cloud_init_storage_pool": request.cloud_init_storage or request.vm_storage,
+    }
+    for key, value in request.variables.items():
+        if key in variables:
+            variables[key] = value
+    return variables
+
+
+def render_packer_workdir(
+    *,
+    request: PackerImageBuildRequest,
+    workdir: Path,
+) -> RenderedPackerWorkdir:
+    provisioner_path = _copy_static_assets(workdir, request.provisioner_recipe)
+    variables = build_packer_variables(request)
+    var_file = workdir / "build.auto.pkrvars.json"
+    var_file.write_text(json.dumps(variables, indent=2, sort_keys=True) + "\n")
+    return RenderedPackerWorkdir(
+        workdir=workdir,
+        template_path=workdir / "clone-cloud-init.pkr.hcl",
+        var_file=var_file,
+        variables=variables,
+        provisioner_path=provisioner_path,
+    )
+
+
+def load_pkrvars(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())

--- a/proxbox_api/services/image_factory/runner.py
+++ b/proxbox_api/services/image_factory/runner.py
@@ -1,0 +1,216 @@
+"""Async Packer subprocess runner."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import AsyncIterator, Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from proxbox_api.runtime_settings import get_str
+from proxbox_api.services.image_factory.logs import (
+    PackerEvent,
+    normalize_machine_readable_line,
+    normalize_timestamp_ui_line,
+    scrub_text,
+)
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    command: tuple[str, ...]
+    exit_code: int
+    stdout: list[str] = field(default_factory=list)
+    stderr: list[str] = field(default_factory=list)
+    events: list[PackerEvent] = field(default_factory=list)
+
+
+class PackerCommandError(RuntimeError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        exit_code: int | None = None,
+        output: Iterable[str] = (),
+    ) -> None:
+        super().__init__(message)
+        self.exit_code = exit_code
+        self.output = list(output)
+
+
+class PackerRunner:
+    def __init__(
+        self,
+        *,
+        binary: str | None = None,
+        env: dict[str, str] | None = None,
+        secrets: Iterable[str] = (),
+    ) -> None:
+        self.binary = binary or get_str(
+            settings_key="packer_binary",
+            env="PROXBOX_PACKER_BINARY",
+            default="packer",
+        )
+        self.env = dict(env or {})
+        self.secrets = tuple(secret for secret in secrets if secret)
+        self._processes: dict[str, asyncio.subprocess.Process] = {}
+        self._lock = asyncio.Lock()
+
+    async def init(self, workdir: Path) -> CommandResult:
+        return await self._run_command(
+            workdir,
+            (self.binary, "init", "."),
+            phase="init",
+        )
+
+    async def validate(self, workdir: Path, var_file: Path) -> CommandResult:
+        return await self._run_command(
+            workdir,
+            (
+                self.binary,
+                "validate",
+                "-machine-readable",
+                f"-var-file={var_file.name}",
+                ".",
+            ),
+            phase="validate",
+        )
+
+    async def build(self, workdir: Path, var_file: Path) -> AsyncIterator[PackerEvent]:
+        command = (
+            self.binary,
+            "build",
+            "-color=false",
+            "-timestamp-ui",
+            "-on-error=cleanup",
+            f"-var-file={var_file.name}",
+            ".",
+        )
+        build_id = workdir.name
+        try:
+            process = await self._create_process(command, workdir)
+        except FileNotFoundError as error:
+            raise PackerCommandError(
+                f"Packer binary not found: {self.binary}",
+                exit_code=127,
+            ) from error
+
+        async with self._lock:
+            self._processes[build_id] = process
+
+        queue: asyncio.Queue[tuple[str, str | None]] = asyncio.Queue()
+
+        async def pump(reader: asyncio.StreamReader | None, stream: str) -> None:
+            if reader is None:
+                await queue.put((stream, None))
+                return
+            while True:
+                raw = await reader.readline()
+                if not raw:
+                    await queue.put((stream, None))
+                    return
+                await queue.put((stream, raw.decode(errors="replace").rstrip("\n")))
+
+        pumps = [
+            asyncio.create_task(pump(process.stdout, "stdout")),
+            asyncio.create_task(pump(process.stderr, "stderr")),
+        ]
+        completed_streams = 0
+        output: list[str] = []
+        try:
+            while completed_streams < len(pumps):
+                stream, line = await queue.get()
+                if line is None:
+                    completed_streams += 1
+                    continue
+                output.append(line)
+                event = normalize_timestamp_ui_line(line, stream=stream, secrets=self.secrets)
+                if event.data.get("message"):
+                    yield event
+            exit_code = await process.wait()
+            if exit_code != 0:
+                raise PackerCommandError(
+                    "packer build failed",
+                    exit_code=exit_code,
+                    output=[scrub_text(line, self.secrets) for line in output],
+                )
+        finally:
+            for task in pumps:
+                if not task.done():
+                    task.cancel()
+            async with self._lock:
+                self._processes.pop(build_id, None)
+
+    async def cancel(self, build_id: str) -> None:
+        async with self._lock:
+            process = self._processes.get(build_id)
+        if process is None or process.returncode is not None:
+            return
+        process.terminate()
+        try:
+            await asyncio.wait_for(process.wait(), timeout=5)
+        except TimeoutError:
+            process.kill()
+            await process.wait()
+
+    async def _run_command(
+        self,
+        workdir: Path,
+        command: tuple[str, ...],
+        *,
+        phase: str,
+    ) -> CommandResult:
+        build_id = workdir.name
+        try:
+            process = await self._create_process(command, workdir)
+        except FileNotFoundError:
+            return CommandResult(
+                command=command,
+                exit_code=127,
+                stderr=[f"Packer binary not found: {self.binary}"],
+            )
+        async with self._lock:
+            self._processes[build_id] = process
+        try:
+            stdout_raw, stderr_raw = await process.communicate()
+        finally:
+            async with self._lock:
+                self._processes.pop(build_id, None)
+
+        stdout = stdout_raw.decode(errors="replace").splitlines() if stdout_raw else []
+        stderr = stderr_raw.decode(errors="replace").splitlines() if stderr_raw else []
+        events = [
+            normalize_machine_readable_line(
+                line, phase=phase, stream="stdout", secrets=self.secrets
+            )
+            for line in stdout
+        ]
+        events.extend(
+            normalize_machine_readable_line(
+                line, phase=phase, stream="stderr", secrets=self.secrets
+            )
+            for line in stderr
+        )
+        return CommandResult(
+            command=command,
+            exit_code=process.returncode or 0,
+            stdout=[scrub_text(line, self.secrets) for line in stdout],
+            stderr=[scrub_text(line, self.secrets) for line in stderr],
+            events=events,
+        )
+
+    async def _create_process(
+        self,
+        command: tuple[str, ...],
+        workdir: Path,
+    ) -> asyncio.subprocess.Process:
+        env = os.environ.copy()
+        env.update(self.env)
+        return await asyncio.create_subprocess_exec(
+            *command,
+            cwd=str(workdir),
+            env=env,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )

--- a/proxbox_api/services/image_factory/workdir.py
+++ b/proxbox_api/services/image_factory/workdir.py
@@ -1,0 +1,33 @@
+"""Workdir lifecycle helpers for image factory Packer runs."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from proxbox_api.runtime_settings import get_str
+
+
+def get_packer_workdir_root() -> Path:
+    return Path(
+        get_str(
+            settings_key="packer_workdir",
+            env="PROXBOX_PACKER_WORKDIR",
+            default="/var/lib/proxbox/packer/builds",
+        )
+    )
+
+
+def create_workdir(build_id: str) -> Path:
+    workdir = get_packer_workdir_root() / build_id
+    workdir.mkdir(parents=True, exist_ok=False)
+    return workdir
+
+
+def cleanup_workdir(path: str | Path, *, keep_workdir: bool = False) -> None:
+    if keep_workdir:
+        return
+    try:
+        shutil.rmtree(Path(path), ignore_errors=True)
+    except Exception:
+        return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 include = ["proxbox_api*"]
 
 [tool.setuptools.package-data]
-proxbox_api = ["static/*", "static/**/*", "generated/**/*.json", "generated/**/*.py"]
+proxbox_api = ["static/*", "static/**/*", "generated/**/*.json", "generated/**/*.py", "packer_templates/**/*.hcl", "packer_templates/**/*.sh"]
 
 [project]
 name = "proxbox_api"
@@ -128,6 +128,8 @@ select = ["E4", "E7", "E9", "F", "I", "ANN201", "D103", "W", "C90"]
 # C901: inherently complex retry/ reconcile functions
 "proxbox_api/netbox_rest.py" = ["C901"]
 "proxbox_api/routes/cloud/template_images.py" = ["C901"]
+"proxbox_api/routes/cloud/image_factory.py" = ["C901"]
+"proxbox_api/services/image_factory/runner.py" = ["C901"]
 "proxbox_api/routes/virtualization/virtual_machines/sync_vm.py" = ["C901"]
 "proxbox_api/services/sync/vm_coordinator.py" = ["C901"]
 

--- a/tests/cloud/test_cloud_router_contract.py
+++ b/tests/cloud/test_cloud_router_contract.py
@@ -15,12 +15,14 @@ from proxbox_api.schemas.cloud_provision import CloudVMProvisionRequest
 
 def test_cloud_package_exposes_both_routers():
     assert cloud.provision_router is not None
+    assert cloud.image_factory_router is not None
     assert cloud.template_images_router is not None
     assert cloud.templates_router is not None
     assert cloud.pve_template_router is not None
     assert cloud.versions_router is not None
     assert cloud.__all__ == (
         "provision_router",
+        "image_factory_router",
         "pve_template_router",
         "template_images_router",
         "templates_router",

--- a/tests/cloud/test_image_factory_contract.py
+++ b/tests/cloud/test_image_factory_contract.py
@@ -1,0 +1,342 @@
+"""Contract tests for the Packer image factory cloud routes."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+from sqlmodel import Session
+
+from proxbox_api.database import ImageBuildRun, ProxmoxEndpoint
+from proxbox_api.routes.cloud import image_factory
+from proxbox_api.schemas.image_factory import (
+    ImageFactoryBuildMode,
+    PackerImageBuildRequest,
+    PackerImageBuildResponse,
+)
+from proxbox_api.services.image_factory.logs import PackerEvent
+from proxbox_api.services.image_factory.runner import CommandResult
+
+TOKEN_MARKER = "TEST-TOKEN-MUST-NOT-LEAK"
+
+
+class FakePackerRunner:
+    instances: list["FakePackerRunner"] = []
+
+    def __init__(self, *, env: dict[str, str], secrets: tuple[str, ...]) -> None:
+        self.env = env
+        self.secrets = secrets
+        self.build_called = False
+        self.cancelled = False
+        FakePackerRunner.instances.append(self)
+
+    async def init(self, workdir: Path) -> CommandResult:
+        return CommandResult(command=("packer", "init", "."), exit_code=0)
+
+    async def validate(self, workdir: Path, var_file: Path) -> CommandResult:
+        return CommandResult(
+            command=("packer", "validate", "-machine-readable", f"-var-file={var_file.name}", "."),
+            exit_code=0,
+            stdout=["1700000000,,ui,say,Template validated"],
+        )
+
+    async def build(self, workdir: Path, var_file: Path):
+        self.build_called = True
+        yield PackerEvent(
+            name="packer_log",
+            data={"phase": "build", "message": f"building with token={TOKEN_MARKER}"},
+        )
+        yield PackerEvent(
+            name="packer_artifact",
+            data={"template_name": "ubuntu-2404-golden", "token": TOKEN_MARKER},
+        )
+
+    async def cancel(self, build_id: str) -> None:
+        self.cancelled = True
+
+
+def _make_endpoint(db_session: Session, *, allow_writes: bool = True) -> int:
+    endpoint = ProxmoxEndpoint(
+        name=f"pve-image-factory-{allow_writes}-{len(FakePackerRunner.instances)}",
+        ip_address="10.0.0.10",
+        port=8006,
+        username="root@pam",
+        verify_ssl=False,
+        allow_writes=allow_writes,
+        token_name="packer",
+        token_value=TOKEN_MARKER,
+    )
+    db_session.add(endpoint)
+    db_session.commit()
+    db_session.refresh(endpoint)
+    assert endpoint.id is not None
+    return endpoint.id
+
+
+def _request_payload(endpoint_id: int, **overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "endpoint_id": endpoint_id,
+        "target_node": "pve",
+        "builder_type": "proxmox-clone",
+        "template_vmid": 9000,
+        "output_vmid": 9100,
+        "output_name": "ubuntu-2404-golden",
+        "os_family": "ubuntu",
+        "os_release": "24.04",
+        "image_version": "2026.05.17",
+        "vm_storage": "local-lvm",
+        "cloud_init_storage": "local-lvm",
+        "bridge": "vmbr0",
+        "memory_mb": 2048,
+        "cores": 2,
+        "cpu_type": "host",
+        "provisioner_recipe": "ubuntu-base",
+        "variables": {"memory": 2048},
+        "force": False,
+        "dry_run": False,
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.fixture(autouse=True)
+def image_factory_fakes(monkeypatch, tmp_path):
+    FakePackerRunner.instances.clear()
+    monkeypatch.setenv("PROXBOX_PACKER_WORKDIR", str(tmp_path / "packer-builds"))
+    monkeypatch.setattr(
+        image_factory,
+        "packer_runner_factory",
+        lambda *, env, secrets: FakePackerRunner(env=env, secrets=secrets),
+    )
+
+    async def template_exists(endpoint, request):
+        return None
+
+    monkeypatch.setattr(image_factory, "_ensure_template_vmid_exists", template_exists)
+
+
+def _events_from_sse(body: str) -> list[str]:
+    events: list[str] = []
+    for frame in body.split("\n\n"):
+        for line in frame.splitlines():
+            if line.startswith("event: "):
+                events.append(line.removeprefix("event: "))
+    return events
+
+
+def _assert_subsequence(events: list[str], expected: list[str]) -> None:
+    cursor = 0
+    for event in events:
+        if cursor < len(expected) and event == expected[cursor]:
+            cursor += 1
+    assert cursor == len(expected), events
+
+
+async def test_image_factory_schema_shapes() -> None:
+    request = PackerImageBuildRequest(**_request_payload(1))
+    response = PackerImageBuildResponse(
+        build_id="build-1",
+        status="queued",
+        endpoint_id=request.endpoint_id,
+        target_node=request.target_node,
+        output_vmid=request.output_vmid,
+        output_name=request.output_name,
+    )
+
+    assert ImageFactoryBuildMode.packer_clone.value == "packer-clone"
+    assert request.builder_type == "proxmox-clone"
+    assert response.model_dump()["status"] == "queued"
+
+
+async def test_create_build_returns_queued_response(authenticated_client, db_session):
+    endpoint_id = _make_endpoint(db_session)
+
+    response = await authenticated_client.post(
+        "/cloud/image-factory/builds",
+        json=_request_payload(endpoint_id),
+    )
+
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["status"] == "queued"
+    assert body["endpoint_id"] == endpoint_id
+    assert body["log_url"] == f"/cloud/image-factory/builds/{body['build_id']}/stream"
+
+
+async def test_invalid_endpoint_returns_404(authenticated_client):
+    response = await authenticated_client.post(
+        "/cloud/image-factory/builds",
+        json=_request_payload(999999),
+    )
+
+    assert response.status_code == 404
+    assert response.json()["reason"] == "endpoint_not_found"
+
+
+async def test_missing_template_vmid_returns_422(authenticated_client, db_session, monkeypatch):
+    endpoint_id = _make_endpoint(db_session)
+
+    async def missing_template(endpoint, request):
+        raise HTTPException(
+            status_code=422,
+            detail="template_vmid missing",
+        )
+
+    monkeypatch.setattr(image_factory, "_ensure_template_vmid_exists", missing_template)
+    response = await authenticated_client.post(
+        "/cloud/image-factory/builds",
+        json=_request_payload(endpoint_id),
+    )
+
+    assert response.status_code == 422
+    assert "template_vmid" in response.text
+
+
+async def test_allow_writes_false_returns_gate_reason(authenticated_client, db_session):
+    endpoint_id = _make_endpoint(db_session, allow_writes=False)
+
+    response = await authenticated_client.post(
+        "/cloud/image-factory/builds",
+        json=_request_payload(endpoint_id),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["reason"] == "endpoint_writes_disabled"
+
+
+async def test_dry_run_does_not_invoke_build(authenticated_client, db_session):
+    endpoint_id = _make_endpoint(db_session)
+
+    response = await authenticated_client.post(
+        "/cloud/image-factory/builds",
+        json=_request_payload(endpoint_id, dry_run=True),
+    )
+
+    assert response.status_code == 201, response.text
+    assert response.json()["status"] == "completed"
+    assert FakePackerRunner.instances
+    assert FakePackerRunner.instances[-1].build_called is False
+
+
+async def test_sse_ordering_and_credentials_do_not_leak(
+    authenticated_client,
+    db_session,
+):
+    endpoint_id = _make_endpoint(db_session)
+
+    create_response = await authenticated_client.post(
+        "/cloud/image-factory/builds",
+        json=_request_payload(endpoint_id),
+    )
+    assert create_response.status_code == 201, create_response.text
+    build_id = create_response.json()["build_id"]
+
+    row = db_session.get(ImageBuildRun, build_id)
+    assert row is not None
+    var_file = Path(row.workdir) / "build.auto.pkrvars.json"
+    var_payload = var_file.read_text()
+    assert TOKEN_MARKER not in var_payload
+    assert "PROXMOX_TOKEN" not in var_payload
+    assert "PROXMOX_USERNAME" not in var_payload
+    assert "PROXMOX_URL" not in var_payload
+
+    stream_response = await authenticated_client.get(
+        f"/cloud/image-factory/builds/{build_id}/stream"
+    )
+    assert stream_response.status_code == 200, stream_response.text
+    assert "text/event-stream" in stream_response.headers["content-type"]
+    assert TOKEN_MARKER not in stream_response.text
+
+    events = _events_from_sse(stream_response.text)
+    _assert_subsequence(
+        events,
+        [
+            "build_started",
+            "packer_init",
+            "packer_validate",
+            "packer_log",
+            "packer_artifact",
+            "build_completed",
+            "complete",
+        ],
+    )
+
+    db_session.expire_all()
+    persisted = db_session.get(ImageBuildRun, build_id)
+    assert persisted is not None
+    persisted_text = json.dumps(persisted.model_dump(mode="json"), sort_keys=True)
+    assert TOKEN_MARKER not in persisted_text
+    assert TOKEN_MARKER not in (persisted.error or "")
+
+
+async def test_cancel_terminates_and_persists_cancelled(authenticated_client, db_session):
+    endpoint_id = _make_endpoint(db_session)
+    create_response = await authenticated_client.post(
+        "/cloud/image-factory/builds",
+        json=_request_payload(endpoint_id),
+    )
+    assert create_response.status_code == 201, create_response.text
+    build_id = create_response.json()["build_id"]
+
+    cancel_response = await authenticated_client.post(
+        f"/cloud/image-factory/builds/{build_id}/cancel"
+    )
+
+    assert cancel_response.status_code == 200, cancel_response.text
+    assert cancel_response.json()["status"] == "cancelled"
+    assert FakePackerRunner.instances[-1].cancelled is True
+    db_session.expire_all()
+    persisted = db_session.get(ImageBuildRun, build_id)
+    assert persisted is not None
+    assert persisted.status == "cancelled"
+
+
+async def test_validate_endpoint_does_not_invoke_build(authenticated_client, db_session):
+    endpoint_id = _make_endpoint(db_session)
+
+    response = await authenticated_client.post(
+        "/cloud/image-factory/validate",
+        json=_request_payload(endpoint_id),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["valid"] is True
+    assert FakePackerRunner.instances[-1].build_called is False
+
+
+@pytest.mark.skipif(not shutil.which("packer"), reason="packer binary is not installed")
+def test_bundled_hcl_packer_validate_smoke(tmp_path):
+    endpoint_id = 1
+    request = PackerImageBuildRequest(**_request_payload(endpoint_id))
+    workdir = tmp_path / "packer-smoke"
+    workdir.mkdir()
+    from proxbox_api.services.image_factory.renderer import render_packer_workdir
+
+    rendered = render_packer_workdir(request=request, workdir=workdir)
+    env = {
+        **os.environ,
+        "PROXMOX_URL": "https://127.0.0.1:8006/api2/json",
+        "PROXMOX_USERNAME": "root@pam!packer",
+        "PROXMOX_TOKEN": "stub-token",
+    }
+    result = subprocess.run(
+        [
+            "packer",
+            "validate",
+            "-syntax-only",
+            f"-var-file={rendered.var_file.name}",
+            ".",
+        ],
+        cwd=workdir,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout


### PR DESCRIPTION
## Summary

Implements PHASE1 of the Packer support epic: the `proxbox-api` Image Factory
backend foundation. This is the HTTP/SSE contract the upcoming `netbox_packer`
plugin (PHASE2-PHASE4) consumes. NetBox-side work is tracked separately.

Tracks: emersonfelipesp/netbox-proxbox#456 (epic emersonfelipesp/netbox-proxbox#463).

## What's in

- **Schemas** — `proxbox_api/schemas/image_factory.py`: `ImageFactoryBuildMode`,
  `PackerImageBuildRequest`, `PackerImageBuildResponse` (Pydantic v2,
  `extra="forbid"`).
- **Routes** — `proxbox_api/routes/cloud/image_factory.py` registers five
  endpoints under `/cloud/image-factory/`:
  - `POST /builds` (create)
  - `GET  /builds/{id}` (get)
  - `GET  /builds/{id}/stream` (SSE: `build_started`, `packer_init`,
    `packer_validate`, `packer_log`, `packer_artifact`, `build_completed`,
    `build_failed`, `complete`)
  - `POST /builds/{id}/cancel` (terminate)
  - `POST /validate` (dry-run, no build)
- **`allow_writes` gating** — all five endpoints honour the existing `_gate`
  pattern from `routes/proxmox_actions.py`; read-only endpoints get the
  shared 403 with `reason="endpoint_writes_disabled"`.
- **Service layer** — `proxbox_api/services/image_factory/` (`runner.py`,
  `renderer.py`, `workdir.py`, `logs.py`, `models.py`). `PackerRunner` wraps
  `packer init` / `packer validate -machine-readable` /
  `packer build -color=false -timestamp-ui -on-error=cleanup` via
  `asyncio.create_subprocess_exec`. Workdir lifecycle cleans up on any
  terminal status. Log normalizer scrubs credentials defensively.
- **Persistence** — `ImageBuildRun` SQLModel table + `_migrate_image_build_run_columns()`
  helper called from `create_db_and_tables()` (no Alembic in this codebase).
- **Packer assets** — `proxbox_api/packer_templates/proxmox/clone-cloud-init.pkr.hcl`
  plus four allowlisted provisioner recipes (`ubuntu-base.sh`,
  `debian-base.sh`, `docker-host.sh`, `qemu-agent.sh`). Shipped via
  `MANIFEST.in` / `pyproject.toml` package-data.
- **Credentials** — `PROXMOX_URL`/`PROXMOX_USERNAME`/`PROXMOX_TOKEN` injected
  into the Packer subprocess **only via env vars**. Never written to
  `build.auto.pkrvars.json`, never logged, never present in any SSE payload.
  Enforced by contract test using a marker token assertion.
- **Runtime tunables** — `get_str()` added to `runtime_settings.py` (env > DB
  plugin settings > default). Reads `PROXBOX_PACKER_BINARY` and
  `PROXBOX_PACKER_WORKDIR` only — no new DB columns in this phase.

## Tests

`tests/cloud/test_image_factory_contract.py`:
- request/response shape conformance
- `allow_writes=False` returns 403 with the documented reason
- dry-run does not invoke `build`
- SSE event ordering
- cancel terminates and persists `status="cancelled"`
- credential-leak audit (marker token never appears anywhere)
- `pytest.mark.skipif(not shutil.which("packer"))` smoke test that runs real
  `packer validate` against the bundled HCL

Validation: `ruff check`, `ruff format --check`, `compileall`, full file's
pytest suite (9 passed, 1 skipped under CI without `packer` binary).

## Out of scope (per the epic phase split)

- NetBox UI / `netbox_packer` plugin — PHASE2-PHASE3 (#457, #458).
- Background job + SSE consumer in NetBox — PHASE4 (#459).
- `CloudImageTemplate` publication — PHASE5 (#460).
- DB-backed plugin settings columns + write-gating UI — PHASE6 (#461).
- `proxmox-iso` builder — PHASE7 (#462).

## Test plan

- [ ] CI green on this branch
- [ ] Manual: `POST /cloud/image-factory/builds` against a sandbox
      `ProxmoxEndpoint` with `allow_writes=False` returns 403
- [ ] Manual: SSE stream emits the documented event sequence end-to-end
      against a real `packer` binary (deferred to integration testing once
      PHASE4 enqueues from NetBox)