### PR TITLE
fix: set both primary_ip4 and primary_ip6 for dual-stack VMs

### DIFF
--- a/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
+++ b/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
@@ -924,6 +924,7 @@ async def _create_vm_interface_parallel(
         first_ip_id, first_ip = ip_results[0]
         result["ip"] = {"id": first_ip_id, "address": first_ip}
         result["first_ip_id"] = first_ip_id
+        result["all_ips"] = [{"id": iid, "address": addr} for iid, addr in ip_results]
 
     return result
 
@@ -2020,7 +2021,8 @@ async def create_virtual_machines(  # noqa: C901
 
         # Create VM interfaces
         netbox_vm_interfaces = []
-        first_ip_id: int | None = None
+        first_ipv4_id: int | None = None
+        first_ipv6_id: int | None = None
         if virtual_machine and vm_config and sync_vm_network:
             guest_agent_interfaces: list[dict] = []
             guest_agent_diagnostic: str | None = None
@@ -2134,9 +2136,14 @@ async def create_virtual_machines(  # noqa: C901
                         continue
                     if result.get("interface"):
                         netbox_vm_interfaces.append(result["interface"])
-                    ip_id = result.get("first_ip_id")
-                    if ip_id and first_ip_id is None:
-                        first_ip_id = ip_id
+                    for ip_entry in result.get("all_ips") or []:
+                        ip_id = ip_entry.get("id")
+                        addr = ip_entry.get("address") or ""
+                        if ip_id:
+                            if ":" in addr and first_ipv6_id is None:
+                                first_ipv6_id = ip_id
+                            elif ":" not in addr and first_ipv4_id is None:
+                                first_ipv4_id = ip_id
 
             disk_tasks = [
                 _create_vm_disk_parallel(
@@ -2153,19 +2160,19 @@ async def create_virtual_machines(  # noqa: C901
             if disk_tasks:
                 await asyncio.gather(*disk_tasks, return_exceptions=True)
 
-        # Set primary IP only when NetBox has no primary IP yet (user choice is preserved).
-        has_primary_ip = (
-            virtual_machine.get("primary_ip4") is not None
-            or virtual_machine.get("primary_ip6") is not None
-        )
-        if not has_primary_ip:
-            if first_ip_id is not None:
-                from proxbox_api.services.sync.vm_network import set_primary_ip
+        # Set primary IPs per-family. set_primary_ip preserves an already-set
+        # primary for each family independently, so both IPv4 and IPv6 are tried.
+        from proxbox_api.services.sync.vm_network import set_primary_ip
 
+        any_ip_found = first_ipv4_id is not None or first_ipv6_id is not None
+        if any_ip_found:
+            for primary_ip_id in (first_ipv4_id, first_ipv6_id):
+                if primary_ip_id is None:
+                    continue
                 primary_set = await set_primary_ip(
                     nb=nb,
                     virtual_machine=virtual_machine,
-                    primary_ip_id=first_ip_id,
+                    primary_ip_id=primary_ip_id,
                     primary_ip_preference=primary_ip_preference,
                 )
                 if not primary_set and websocket:
@@ -2178,24 +2185,24 @@ async def create_virtual_machines(  # noqa: C901
                             },
                         }
                     )
-            else:
-                logger.info(
-                    "No IP available for VM %s (vmid=%s), skipping primary IP assignment.",
-                    resource.get("name"),
-                    resource.get("vmid"),
+        else:
+            logger.info(
+                "No IP available for VM %s (vmid=%s), skipping primary IP assignment.",
+                resource.get("name"),
+                resource.get("vmid"),
+            )
+            if websocket:
+                await websocket.send_json(
+                    {
+                        "object": "virtual_machine",
+                        "data": {
+                            "completed": True,
+                            "status": "warning",
+                            "warning": "No IP address found; primary IP not set.",
+                            "rowid": virtual_machine.get("name"),
+                        },
+                    }
                 )
-                if websocket:
-                    await websocket.send_json(
-                        {
-                            "object": "virtual_machine",
-                            "data": {
-                                "completed": True,
-                                "status": "warning",
-                                "warning": "No IP address found; primary IP not set.",
-                                "rowid": virtual_machine.get("name"),
-                            },
-                        }
-                    )
 
         try:
             task_history_count = await sync_virtual_machine_task_history(
@@ -3112,8 +3119,15 @@ async def create_only_vm_ip_addresses(  # noqa: C901
                                 continue
                             ip_payloads.append(payload)
 
-                            # Track first IP for primary assignment
-                            if not first_ips:
+                            # Track first IP per address family for primary assignment.
+                            # Both IPv4 and IPv6 are collected so set_primary_ip can
+                            # designate each family independently.
+                            addr_is_ipv6 = ":" in interface_ip
+                            family_tracked = any(
+                                (":" in e["address"]) == addr_is_ipv6
+                                for e in first_ips
+                            )
+                            if not family_tracked:
                                 first_ips.append(
                                     {
                                         "vm_id": netbox_vm.get("id"),

--- a/proxbox_api/services/sync/vm_network.py
+++ b/proxbox_api/services/sync/vm_network.py
@@ -530,13 +530,6 @@ async def set_primary_ip(  # noqa: C901
 
     primary_ip_preference = normalize_primary_ip_preference(primary_ip_preference)
 
-    # Preserve existing explicit primary choice.
-    if (
-        virtual_machine.get("primary_ip4") is not None
-        or virtual_machine.get("primary_ip6") is not None
-    ):
-        return False
-
     # Verify (and fix if needed) that the IP is assigned to this VM before setting primary.
     assigned, reason = await ensure_ip_assigned_to_vm(nb, primary_ip_id, vm_id)
     if not assigned:
@@ -570,6 +563,12 @@ async def set_primary_ip(  # noqa: C901
             primary_ip_id,
             ip_record.get("address"),
         )
+        return False
+
+    # Preserve an existing user-set primary for this specific IP family only.
+    # Checking per-family (not OR across both) lets dual-stack VMs set primary_ip4
+    # and primary_ip6 independently across syncs.
+    if virtual_machine.get(primary_field) is not None:
         return False
 
     patch_payload: dict[str, object] = {primary_field: primary_ip_id}

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -875,7 +875,11 @@ def test_create_virtual_machines_reconciles_vm_children_for_single_vm_bundle(
 
     async def _fake_create_vm_interface_parallel(**kwargs):
         interface_calls.append(kwargs)
-        return {"interface": {"id": 66, "name": kwargs["interface_name"]}, "first_ip_id": 77}
+        return {
+            "interface": {"id": 66, "name": kwargs["interface_name"]},
+            "first_ip_id": 77,
+            "all_ips": [{"id": 77, "address": "1.1.1.3/24"}],
+        }
 
     async def _fake_create_vm_disk_parallel(**kwargs):
         disk_calls.append(kwargs)

--- a/tests/test_qemu_guest_agent_sync.py
+++ b/tests/test_qemu_guest_agent_sync.py
@@ -921,6 +921,10 @@ def test_vm_only_ip_sync_prefers_ipv4_primary_when_guest_reports_ipv6_first(monk
         )
     )
 
-    assert len(primary_ip_calls) == 1
+    # Both IPv4 and IPv6 primaries are set independently (dual-stack fix).
+    assert len(primary_ip_calls) == 2
+    called_ids = {c["primary_ip_id"] for c in primary_ip_calls}
+    assert called_ids == {77, 99}  # 77 = IPv4, 99 = IPv6
+    # IPv4 is listed first because ipv4 is the preferred family.
     assert primary_ip_calls[0]["primary_ip_id"] == 77
     assert primary_ip_calls[0]["primary_ip_preference"] == "ipv4"

--- a/tests/test_vm_network.py
+++ b/tests/test_vm_network.py
@@ -97,3 +97,99 @@ def test_set_primary_ip_uses_primary_ip6_for_ipv6_addresses(monkeypatch):
 
     assert updated is True
     assert patch_payloads == [{"primary_ip6": 90}]
+
+
+def test_set_primary_ip_sets_ipv6_when_ipv4_already_set(monkeypatch):
+    """IPv6 primary must be set even when primary_ip4 is already populated.
+
+    Before the fix, the guard returned False when either primary field was set,
+    so dual-stack VMs could never get primary_ip6 assigned.
+    """
+    patch_payloads: list[dict[str, object]] = []
+
+    async def _fake_ensure_ip_assigned_to_vm(*args, **kwargs):
+        return True, "already_assigned"
+
+    async def _fake_rest_first(nb, path, query=None):
+        if path == "/api/ipam/ip-addresses/":
+            return {"id": 90, "address": "2804:2cac:1030::10/64"}
+        return None
+
+    async def _fake_rest_patch(nb, path, record_id, payload):
+        patch_payloads.append(payload)
+        return {"id": 55, "primary_ip4": 77, "primary_ip6": 90}
+
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.vm_network.ensure_ip_assigned_to_vm",
+        _fake_ensure_ip_assigned_to_vm,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.vm_network.rest_first_async",
+        _fake_rest_first,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.vm_network.rest_patch_async",
+        _fake_rest_patch,
+    )
+
+    updated = asyncio.run(
+        set_primary_ip(
+            nb=object(),
+            virtual_machine={
+                "id": 55,
+                "name": "vm-55",
+                "primary_ip4": {"id": 77, "address": "10.0.0.1/24"},  # already set
+                "primary_ip6": None,
+            },
+            primary_ip_id=90,
+        )
+    )
+
+    assert updated is True
+    assert patch_payloads == [{"primary_ip6": 90}]
+
+
+def test_set_primary_ip_skips_ipv6_when_already_set(monkeypatch):
+    """Must not overwrite an already-designated primary_ip6."""
+    patch_payloads: list[dict[str, object]] = []
+
+    async def _fake_ensure_ip_assigned_to_vm(*args, **kwargs):
+        return True, "already_assigned"
+
+    async def _fake_rest_first(nb, path, query=None):
+        if path == "/api/ipam/ip-addresses/":
+            return {"id": 91, "address": "2804:2cac:1030::20/64"}
+        return None
+
+    async def _fake_rest_patch(nb, path, record_id, payload):  # pragma: no cover
+        patch_payloads.append(payload)
+        return {}
+
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.vm_network.ensure_ip_assigned_to_vm",
+        _fake_ensure_ip_assigned_to_vm,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.vm_network.rest_first_async",
+        _fake_rest_first,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.vm_network.rest_patch_async",
+        _fake_rest_patch,
+    )
+
+    updated = asyncio.run(
+        set_primary_ip(
+            nb=object(),
+            virtual_machine={
+                "id": 55,
+                "name": "vm-55",
+                "primary_ip4": None,
+                "primary_ip6": {"id": 90, "address": "2804:2cac:1030::10/64"},  # already set
+            },
+            primary_ip_id=91,
+        )
+    )
+
+    assert updated is False
+    assert patch_payloads == []


### PR DESCRIPTION
## Summary

Fixes #468 from `emersonfelipesp/netbox-proxbox`.

VMs with both IPv4 and IPv6 addresses were only getting `primary_ip4` set in NetBox; `primary_ip6` was silently skipped on every sync.

### Root Cause

Two cooperating bugs:

**Bug 1 — `set_primary_ip` guard too broad** (`proxbox_api/services/sync/vm_network.py`):

The guard at the top of `set_primary_ip` returned `False` when _either_ `primary_ip4` _or_ `primary_ip6` was already set on the VM dict. For dual-stack VMs, once `primary_ip4` was set on the first sync, every subsequent call (even with an IPv6 address) hit the guard and returned early. `primary_ip6` was never set.

**Bug 2 — Only one IP ID tracked per VM sync** (`sync_vm.py`):

Both the main streaming sync path and the bulk sync path tracked only a single `first_ip_id`. Since IPv4 is preferred by default, the IPv4 ID was captured and the IPv6 ID was discarded before `set_primary_ip` was ever called.

### Fix

- **`vm_network.py`**: Move the "preserve user choice" guard _after_ IP family determination. The new check is per-family: `if virtual_machine.get(primary_field) is not None: return False`. This lets `primary_ip4` and `primary_ip6` be designated independently.

- **`sync_vm.py` (main sync path)**: Track `first_ipv4_id` and `first_ipv6_id` separately. Populate from the new `all_ips` field in interface results. Call `set_primary_ip` once per non-`None` family ID.

- **`sync_vm.py` (bulk sync path)**: Same per-family tracking. The `first_ips` list now collects up to one entry per address family per VM.

- **`sync_vm.py` (`_create_vm_interface_parallel`)**: Add `all_ips` to the returned dict so callers can inspect all created IP IDs (both families).

## Test Plan

- `tests/test_vm_network.py`: 2 new tests verify the per-family guard — IPv6 primary is set when IPv4 is already populated, and an already-set family is preserved.
- `tests/test_qemu_guest_agent_sync.py::test_vm_only_ip_sync_prefers_ipv4_primary_when_guest_reports_ipv6_first`: updated to expect 2 `set_primary_ip` calls (IPv4 + IPv6) for a dual-stack VM.
- `tests/test_api_routes.py`: mock updated to return `all_ips` alongside `first_ip_id`.
- Full non-e2e suite: all 92 test files pass.