### PR TITLE
fix: recover from concurrent tag creation race in ensure_tag_async (#121)

### DIFF
--- a/proxbox_api/netbox_rest.py
+++ b/proxbox_api/netbox_rest.py
@@ -2005,22 +2005,35 @@ async def ensure_tag_async(
     color: str,
     description: str,
 ) -> RestRecord:
-    return await rest_reconcile_async(
-        nb,
-        "/api/extras/tags/",
-        lookup={"slug": slug},
-        payload={
-            "name": name,
-            "slug": slug,
-            "color": color,
-            "description": description,
-        },
-        schema=TagSchema,
-        current_normalizer=lambda record: {
-            "name": record.get("name"),
-            "slug": record.get("slug"),
-            "color": record.get("color"),
-            "description": record.get("description"),
-        },
-        patchable_fields={"name", "color", "description"},
-    )
+    try:
+        return await rest_reconcile_async(
+            nb,
+            "/api/extras/tags/",
+            lookup={"slug": slug},
+            payload={
+                "name": name,
+                "slug": slug,
+                "color": color,
+                "description": description,
+            },
+            schema=TagSchema,
+            current_normalizer=lambda record: {
+                "name": record.get("name"),
+                "slug": record.get("slug"),
+                "color": record.get("color"),
+                "description": record.get("description"),
+            },
+            patchable_fields={"name", "color", "description"},
+        )
+    except ProxboxException as exc:
+        if not _is_duplicate_error(getattr(exc, "detail", str(exc))):
+            raise
+        # The reconciler saw a duplicate error but couldn't locate the record
+        # (race condition: another concurrent worker just created the same tag).
+        # Try two direct lookups that bypass any in-flight cache state.
+        record = await rest_first_async(nb, "/api/extras/tags/", query={"slug": slug})
+        if record is None:
+            record = await rest_first_async(nb, "/api/extras/tags/", query={"name": name})
+        if record is not None:
+            return record
+        raise

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -66,6 +66,7 @@ Unit, integration, and end-to-end tests for the `proxbox_api` backend package. A
 | `test_vm_sync_reconciliation_queue.py` | Reconciliation queue draining and retry semantics |
 | `test_auth_lockout.py` | bcrypt API-key check, failed-attempt counting, lockout duration, and async path |
 | `test_schema_cli.py` | `proxbox-schema` CLI subcommands (`list`, `status`, `generate`) via argparse |
+| `test_ensure_tag_duplicate_recovery.py` | `ensure_tag_async` concurrent-creation race recovery: slug/name fallback lookups, re-raise on miss, non-duplicate passthrough |
 | `e2e/conftest.py` | E2E fixtures: `proxmox_mock_http_published`, `proxmox_mock_backend`, `client_with_fake_netbox`, `auth_headers` |
 | `e2e/test_backups_sync.py` | Backup sync end-to-end against mock backend / HTTP mock |
 | `e2e/test_demo_auth.py` | Demo auth happy-path and failure modes |

--- a/tests/test_ensure_tag_duplicate_recovery.py
+++ b/tests/test_ensure_tag_duplicate_recovery.py
@@ -1,0 +1,132 @@
+"""Tests for ensure_tag_async duplicate-error recovery (issue #121).
+
+When multiple concurrent VM syncs share a Proxmox tag, one worker creates the
+tag and a second worker's POST receives "tag with this name already exists".
+The reconciler may still fail to locate the record (timing / slug mismatch).
+ensure_tag_async must catch that case, do two direct lookups, and return the
+existing record rather than propagating a noisy traceback.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from proxbox_api.exception import ProxboxException
+from proxbox_api.netbox_rest import ensure_tag_async
+
+
+_SLUG = "production"
+_NAME = "production"
+_COLOR = "4caf50"
+_DESC = "Synced by Proxbox"
+
+_FAKE_TAG: dict[str, Any] = {
+    "id": 42,
+    "name": _NAME,
+    "slug": _SLUG,
+    "color": _COLOR,
+    "description": _DESC,
+}
+
+_DUPLICATE_EXC = ProxboxException(
+    "NetBox returned an error",
+    detail={"name": ["tag with this name already exists."]},
+)
+
+
+@pytest.mark.asyncio
+async def test_ensure_tag_recovers_via_slug_lookup() -> None:
+    """Reconciler raises duplicate error; slug lookup finds the record."""
+    nb = object()
+    with (
+        patch(
+            "proxbox_api.netbox_rest.rest_reconcile_async",
+            new_callable=AsyncMock,
+            side_effect=_DUPLICATE_EXC,
+        ),
+        patch(
+            "proxbox_api.netbox_rest.rest_first_async",
+            new_callable=AsyncMock,
+            return_value=_FAKE_TAG,
+        ) as mock_first,
+    ):
+        result = await ensure_tag_async(nb, name=_NAME, slug=_SLUG, color=_COLOR, description=_DESC)
+
+    assert result == _FAKE_TAG
+    mock_first.assert_awaited_once_with(nb, "/api/extras/tags/", query={"slug": _SLUG})
+
+
+@pytest.mark.asyncio
+async def test_ensure_tag_recovers_via_name_lookup_when_slug_misses() -> None:
+    """Slug lookup misses; name lookup finds the record."""
+    nb = object()
+    call_count = 0
+
+    async def _first(nb_: object, path: str, *, query: dict[str, object]) -> dict[str, Any] | None:
+        nonlocal call_count
+        call_count += 1
+        if query.get("slug"):
+            return None
+        return _FAKE_TAG
+
+    with (
+        patch(
+            "proxbox_api.netbox_rest.rest_reconcile_async",
+            new_callable=AsyncMock,
+            side_effect=_DUPLICATE_EXC,
+        ),
+        patch("proxbox_api.netbox_rest.rest_first_async", side_effect=_first),
+    ):
+        result = await ensure_tag_async(nb, name=_NAME, slug=_SLUG, color=_COLOR, description=_DESC)
+
+    assert result == _FAKE_TAG
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_ensure_tag_reraises_when_fallback_lookups_both_miss() -> None:
+    """Both fallback lookups return None → original exception re-raised."""
+    nb = object()
+    with (
+        patch(
+            "proxbox_api.netbox_rest.rest_reconcile_async",
+            new_callable=AsyncMock,
+            side_effect=_DUPLICATE_EXC,
+        ),
+        patch(
+            "proxbox_api.netbox_rest.rest_first_async",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        with pytest.raises(ProxboxException) as exc_info:
+            await ensure_tag_async(nb, name=_NAME, slug=_SLUG, color=_COLOR, description=_DESC)
+
+    assert exc_info.value is _DUPLICATE_EXC
+
+
+@pytest.mark.asyncio
+async def test_ensure_tag_does_not_swallow_non_duplicate_exception() -> None:
+    """A ProxboxException that is NOT a duplicate error propagates immediately."""
+    nb = object()
+    non_dup_exc = ProxboxException("timeout talking to NetBox", detail="Request timeout")
+
+    with (
+        patch(
+            "proxbox_api.netbox_rest.rest_reconcile_async",
+            new_callable=AsyncMock,
+            side_effect=non_dup_exc,
+        ),
+        patch(
+            "proxbox_api.netbox_rest.rest_first_async",
+            new_callable=AsyncMock,
+        ) as mock_first,
+    ):
+        with pytest.raises(ProxboxException) as exc_info:
+            await ensure_tag_async(nb, name=_NAME, slug=_SLUG, color=_COLOR, description=_DESC)
+
+    assert exc_info.value is non_dup_exc
+    mock_first.assert_not_awaited()

--- a/tests/test_ensure_tag_duplicate_recovery.py
+++ b/tests/test_ensure_tag_duplicate_recovery.py
@@ -17,7 +17,6 @@ import pytest
 from proxbox_api.exception import ProxboxException
 from proxbox_api.netbox_rest import ensure_tag_async
 
-
 _SLUG = "production"
 _NAME = "production"
 _COLOR = "4caf50"


### PR DESCRIPTION
## Summary

Fixes the `netbox-exception: tag with this name already exists` traceback reported in #121.

**Root cause**: when multiple VMs share a Proxmox tag and are synced concurrently, two workers can both see the tag as absent and attempt a simultaneous POST. The second POST gets HTTP 400 "already exists". `_rest_reconcile_async_impl` clears the GET cache and retries the lookup — but timing or API filter quirks can still return `None`, causing a bare `raise` that propagates a noisy WARNING traceback. The tag is actually created successfully by the first worker; only the error reporting was wrong.

**Fix**: wrap the `rest_reconcile_async()` call in `ensure_tag_async` with a `try/except ProxboxException`. On a duplicate error, do two last-resort direct queries via `rest_first_async` (by slug, then by name), bypassing any in-flight cache state. Return the found record silently. Re-raise only when both fallback lookups also miss.

**Change scope**: 11 lines added to `ensure_tag_async` in `netbox_rest.py`. No changes to `_rest_reconcile_async_impl`, `rest_reconcile_async`, or `tag_resolver.py`.

## Test plan

- [x] `test_ensure_tag_recovers_via_slug_lookup` — duplicate error → slug lookup returns record → no exception
- [x] `test_ensure_tag_recovers_via_name_lookup_when_slug_misses` — slug lookup misses, name lookup finds record
- [x] `test_ensure_tag_reraises_when_fallback_lookups_both_miss` — both lookups miss → original exception re-raised
- [x] `test_ensure_tag_does_not_swallow_non_duplicate_exception` — non-duplicate ProxboxException propagates immediately without calling fallback
- [x] Full unit test suite passes (excluding e2e)

Closes #121