### PR TITLE
fix: stop merging existing custom_fields into stamp PATCH payload

### DIFF
--- a/proxbox_api/services/sync/vm_helpers.py
+++ b/proxbox_api/services/sync/vm_helpers.py
@@ -369,10 +369,11 @@ async def stamp_vm_last_run_id(
     """Stamp `custom_fields.proxbox_last_run_id` on a NetBox VM after reconcile.
 
     Idempotent: if the record already carries the same run_id, no PATCH is issued.
-    Operator-set custom_fields keys are preserved by merging on top of the
-    current custom_fields dict. This runs as a separate narrow PATCH so the
-    stamp is written regardless of the operator's `overwrite_vm_custom_fields`
-    gate (which controls whether the main reconciler diffs `custom_fields` at all).
+    NetBox merges custom_field keys server-side on PATCH, so we only send the
+    target key. Spreading the existing custom_fields dict into the payload would
+    cause a serialization failure if any value is not JSON-serializable.
+    This runs as a separate narrow PATCH so the stamp is written regardless of
+    the operator's `overwrite_vm_custom_fields` gate.
     """
     if not run_id or not vm_record:
         return
@@ -394,13 +395,12 @@ async def stamp_vm_last_run_id(
 
     from proxbox_api.netbox_rest import rest_patch_async
 
-    merged_cf = {**current_cf, LAST_RUN_ID_CUSTOM_FIELD: run_id}
     try:
         await rest_patch_async(
             nb,
             "/api/virtualization/virtual-machines/",
             record_id,
-            {"custom_fields": merged_cf},
+            {"custom_fields": {LAST_RUN_ID_CUSTOM_FIELD: run_id}},
         )
     except Exception as error:  # noqa: BLE001
         logger.warning(

--- a/tests/test_proxbox_last_run_id_stamp.py
+++ b/tests/test_proxbox_last_run_id_stamp.py
@@ -66,9 +66,7 @@ async def test_stamp_writes_run_id_on_fresh_vm(patch_recorder: _PatchRecorder) -
     call = patch_recorder.calls[0]
     assert call["path"] == "/api/virtualization/virtual-machines/"
     assert call["record_id"] == 42
-    assert call["payload"] == {
-        "custom_fields": {LAST_RUN_ID_CUSTOM_FIELD: "run-uuid-1"}
-    }
+    assert call["payload"] == {"custom_fields": {LAST_RUN_ID_CUSTOM_FIELD: "run-uuid-1"}}
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxbox_last_run_id_stamp.py
+++ b/tests/test_proxbox_last_run_id_stamp.py
@@ -67,18 +67,15 @@ async def test_stamp_writes_run_id_on_fresh_vm(patch_recorder: _PatchRecorder) -
     assert call["path"] == "/api/virtualization/virtual-machines/"
     assert call["record_id"] == 42
     assert call["payload"] == {
-        "custom_fields": {
-            "team": "platform",
-            LAST_RUN_ID_CUSTOM_FIELD: "run-uuid-1",
-        }
+        "custom_fields": {LAST_RUN_ID_CUSTOM_FIELD: "run-uuid-1"}
     }
 
 
 @pytest.mark.asyncio
-async def test_stamp_preserves_operator_set_custom_field_keys(
+async def test_stamp_sends_only_run_id_key_not_existing_fields(
     patch_recorder: _PatchRecorder,
 ) -> None:
-    """Non-managed CF keys set by the operator survive the merge."""
+    """The PATCH payload contains only the run_id key; NetBox merges existing keys server-side."""
     vm_record = {
         "id": 7,
         "custom_fields": {
@@ -91,10 +88,10 @@ async def test_stamp_preserves_operator_set_custom_field_keys(
     await stamp_vm_last_run_id(nb=object(), vm_record=vm_record, run_id="run-uuid-2")
 
     assert len(patch_recorder.calls) == 1
-    merged_cf = patch_recorder.calls[0]["payload"]["custom_fields"]
-    assert merged_cf["team"] == "platform"
-    assert merged_cf["cost_center"] == "infra-42"
-    assert merged_cf[LAST_RUN_ID_CUSTOM_FIELD] == "run-uuid-2"
+    payload_cf = patch_recorder.calls[0]["payload"]["custom_fields"]
+    assert payload_cf == {LAST_RUN_ID_CUSTOM_FIELD: "run-uuid-2"}
+    assert "team" not in payload_cf
+    assert "cost_center" not in payload_cf
 
 
 @pytest.mark.asyncio
@@ -285,6 +282,37 @@ async def test_stamp_skips_when_dict_call_raises(
     await stamp_vm_last_run_id(nb=object(), vm_record=_BrokenPynetboxVM(), run_id="run-uuid-13")
 
     assert patch_recorder.calls == []
+
+
+@pytest.mark.asyncio
+async def test_stamp_survives_unserializable_existing_custom_field(
+    patch_recorder: _PatchRecorder,
+) -> None:
+    """Non-JSON-serializable values in existing custom_fields must not block the stamp.
+
+    Reproduces GitHub issue #120: spreading current_cf into the PATCH payload
+    causes aiohttp to fail with TypeError when any existing custom field value is
+    not JSON-serializable (e.g. a Query object that leaked into the record).
+    The fix is to only send the target key, relying on NetBox's server-side merge.
+    """
+
+    class _NonSerializable:
+        """Simulates a Query or similar non-JSON-serializable object."""
+
+    vm_record = {
+        "id": 77,
+        "name": "vm-77",
+        "custom_fields": {
+            "some_object_field": _NonSerializable(),
+        },
+    }
+
+    await stamp_vm_last_run_id(nb=object(), vm_record=vm_record, run_id="run-uuid-bug120")
+
+    assert len(patch_recorder.calls) == 1
+    payload_cf = patch_recorder.calls[0]["payload"]["custom_fields"]
+    assert LAST_RUN_ID_CUSTOM_FIELD in payload_cf
+    assert "some_object_field" not in payload_cf
 
 
 def test_module_exports_helpers() -> None:


### PR DESCRIPTION
## Summary

Closes #120

`stamp_vm_last_run_id` was spreading the **full** existing `custom_fields` dict from the cached VM record into the PATCH body:

```python
# Before (buggy)
merged_cf = {**current_cf, LAST_RUN_ID_CUSTOM_FIELD: run_id}
await rest_patch_async(nb, ..., {"custom_fields": merged_cf})
```

If any value in `current_cf` is not JSON-serializable (e.g. a FastAPI/SQLAlchemy `Query` object that leaked into the record), aiohttp raises `TypeError: Object of type Query is not JSON serializable`, which NetBox surfaces as a 400 Bad Request — exactly the error in the issue.

The client-side merge is also **redundant**: NetBox's `CustomFieldsDataField.to_internal_value` already merges incoming keys with the existing `custom_field_data` server-side on PATCH (see `extras/api/customfields.py:113-114`). Sending only the target key is both correct and sufficient.

```python
# After (fixed)
await rest_patch_async(nb, ..., {"custom_fields": {LAST_RUN_ID_CUSTOM_FIELD: run_id}})
```

## Changes

- `proxbox_api/services/sync/vm_helpers.py` — remove the `{**current_cf, ...}` spread; send only `{LAST_RUN_ID_CUSTOM_FIELD: run_id}`; update docstring
- `tests/test_proxbox_last_run_id_stamp.py`:
  - Add `test_stamp_survives_unserializable_existing_custom_field` — reproduces the bug; fails before the fix, passes after
  - Update `test_stamp_writes_run_id_on_fresh_vm` — payload now only contains the stamp key
  - Rename and update `test_stamp_preserves_operator_set_custom_field_keys` → `test_stamp_sends_only_run_id_key_not_existing_fields` to assert the new correct behaviour

## Test plan

- [ ] `uv run pytest tests/test_proxbox_last_run_id_stamp.py` — all 17 tests pass
- [ ] `uv run ruff check proxbox_api/services/sync/vm_helpers.py tests/test_proxbox_last_run_id_stamp.py` — no issues
- [ ] CI green on this PR