### PR TITLE
fix: skip mkcert when custom certs are already present (closes #126)

### DIFF
--- a/docker/entrypoint-granian.sh
+++ b/docker/entrypoint-granian.sh
@@ -6,28 +6,52 @@ if [ "$#" -gt 0 ]; then
 fi
 
 CERT_DIR="${MKCERT_CERT_DIR:-/certs}"
-mkdir -p "$CERT_DIR"
 
-mkcert -install
+if [ -f "$CERT_DIR/cert.pem" ] && [ -f "$CERT_DIR/key.pem" ]; then
+  echo "Custom certificates detected in $CERT_DIR — skipping mkcert generation."
+  if [ -f "$CERT_DIR/key-pkcs8.pem" ]; then
+    KEY_PKCS8="$CERT_DIR/key-pkcs8.pem"
+  else
+    # granian requires PKCS#8; try to write alongside the custom certs, fall
+    # back to /tmp when the mount is read-only.
+    if openssl pkcs8 -topk8 -nocrypt \
+        -in "$CERT_DIR/key.pem" \
+        -out "$CERT_DIR/key-pkcs8.pem" 2>/dev/null; then
+      chmod 600 "$CERT_DIR/key-pkcs8.pem" 2>/dev/null || true
+      KEY_PKCS8="$CERT_DIR/key-pkcs8.pem"
+    else
+      openssl pkcs8 -topk8 -nocrypt \
+        -in "$CERT_DIR/key.pem" \
+        -out /tmp/key-pkcs8.pem
+      chmod 600 /tmp/key-pkcs8.pem
+      KEY_PKCS8="/tmp/key-pkcs8.pem"
+    fi
+  fi
+else
+  mkdir -p "$CERT_DIR"
 
-tmp=$(mktemp)
-trap 'rm -f "$tmp"' EXIT
-printf '%s\n' localhost 127.0.0.1 > "$tmp"
-if [ -n "${MKCERT_EXTRA_NAMES:-}" ]; then
-  echo "$MKCERT_EXTRA_NAMES" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' >> "$tmp"
-  echo "$MKCERT_EXTRA_NAMES" | tr ' ' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' >> "$tmp"
+  mkcert -install
+
+  tmp=$(mktemp)
+  trap 'rm -f "$tmp"' EXIT
+  printf '%s\n' localhost 127.0.0.1 > "$tmp"
+  if [ -n "${MKCERT_EXTRA_NAMES:-}" ]; then
+    echo "$MKCERT_EXTRA_NAMES" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' >> "$tmp"
+    echo "$MKCERT_EXTRA_NAMES" | tr ' ' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' >> "$tmp"
+  fi
+
+  list=$(sort -u "$tmp" | tr '\n' ' ')
+
+  # shellcheck disable=SC2086
+  mkcert -cert-file "$CERT_DIR/cert.pem" -key-file "$CERT_DIR/key.pem" $list
+
+  # granian requires PKCS#8 format; mkcert generates PKCS#1 (traditional) by default.
+  openssl pkcs8 -topk8 -nocrypt \
+    -in "$CERT_DIR/key.pem" \
+    -out "$CERT_DIR/key-pkcs8.pem"
+  chmod 600 "$CERT_DIR/key-pkcs8.pem"
+  KEY_PKCS8="$CERT_DIR/key-pkcs8.pem"
 fi
-
-list=$(sort -u "$tmp" | tr '\n' ' ')
-
-# shellcheck disable=SC2086
-mkcert -cert-file "$CERT_DIR/cert.pem" -key-file "$CERT_DIR/key.pem" $list
-
-# granian requires PKCS#8 format; mkcert generates PKCS#1 (traditional) by default.
-openssl pkcs8 -topk8 -nocrypt \
-  -in "$CERT_DIR/key.pem" \
-  -out "$CERT_DIR/key-pkcs8.pem"
-chmod 600 "$CERT_DIR/key-pkcs8.pem"
 
 PORT="${PORT:-8000}"
 
@@ -46,6 +70,6 @@ exec /app/.venv/bin/granian \
   --port "${PORT}" \
   --ws \
   --ssl-certificate "$CERT_DIR/cert.pem" \
-  --ssl-keyfile "$CERT_DIR/key-pkcs8.pem" \
+  --ssl-keyfile "$KEY_PKCS8" \
   --ssl-protocol-min tls1.2 \
   proxbox_api.main:app

--- a/docker/entrypoint-nginx.sh
+++ b/docker/entrypoint-nginx.sh
@@ -6,26 +6,31 @@ if [ "$#" -gt 0 ]; then
 fi
 
 CERT_DIR="${MKCERT_CERT_DIR:-/certs}"
-mkdir -p "$CERT_DIR"
 
-mkcert -install
+if [ -f "$CERT_DIR/cert.pem" ] && [ -f "$CERT_DIR/key.pem" ]; then
+  echo "Custom certificates detected in $CERT_DIR — skipping mkcert generation."
+else
+  mkdir -p "$CERT_DIR"
 
-tmp=$(mktemp)
-trap 'rm -f "$tmp"' EXIT
-printf '%s\n' localhost 127.0.0.1 > "$tmp"
-if [ -n "${MKCERT_EXTRA_NAMES:-}" ]; then
-  echo "$MKCERT_EXTRA_NAMES" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' >> "$tmp"
-  echo "$MKCERT_EXTRA_NAMES" | tr ' ' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' >> "$tmp"
+  mkcert -install
+
+  tmp=$(mktemp)
+  trap 'rm -f "$tmp"' EXIT
+  printf '%s\n' localhost 127.0.0.1 > "$tmp"
+  if [ -n "${MKCERT_EXTRA_NAMES:-}" ]; then
+    echo "$MKCERT_EXTRA_NAMES" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' >> "$tmp"
+    echo "$MKCERT_EXTRA_NAMES" | tr ' ' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' >> "$tmp"
+  fi
+
+  list=$(sort -u "$tmp" | tr '\n' ' ')
+
+  # shellcheck disable=SC2086
+  mkcert -cert-file "$CERT_DIR/cert.pem" -key-file "$CERT_DIR/key.pem" $list
+
+  chmod 644 "$CERT_DIR/cert.pem" 2>/dev/null || true
+  chgrp nginx "$CERT_DIR/key.pem" 2>/dev/null || true
+  chmod 640 "$CERT_DIR/key.pem" 2>/dev/null || true
 fi
-
-list=$(sort -u "$tmp" | tr '\n' ' ')
-
-# shellcheck disable=SC2086
-mkcert -cert-file "$CERT_DIR/cert.pem" -key-file "$CERT_DIR/key.pem" $list
-
-chmod 644 "$CERT_DIR/cert.pem" 2>/dev/null || true
-chgrp nginx "$CERT_DIR/key.pem" 2>/dev/null || true
-chmod 640 "$CERT_DIR/key.pem" 2>/dev/null || true
 
 PORT="${PORT:-8000}"
 NGINX_HTTP_DIR="/etc/nginx/http.d"

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -103,6 +103,60 @@ docker run -d -p 8443:8000 --name proxbox-api-tls \
   emersonfelipesp/proxbox-api:latest-nginx
 ```
 
+### Mounting custom certificates
+
+Both the `nginx` and `granian` images detect pre-existing certificates at startup.
+If `cert.pem` **and** `key.pem` are already present inside `$MKCERT_CERT_DIR` (default `/certs`),
+mkcert generation is **skipped entirely** — the container uses those files as-is.
+This lets you mount your own CA-signed, Let's Encrypt, or corporate certificates without
+any special flags.
+
+```bash
+docker run -d -p 8443:8000 --name proxbox-api-nginx \
+  -v ./certs:/certs:ro \
+  emersonfelipesp/proxbox-api:latest-nginx
+```
+
+The `./certs` directory must contain at minimum:
+
+| File | Description |
+|------|-------------|
+| `cert.pem` | PEM-encoded certificate (may be a full chain) |
+| `key.pem` | PEM-encoded private key (PKCS#1 or PKCS#8) |
+
+Docker Compose example:
+
+```yaml
+services:
+  proxbox-api:
+    image: emersonfelipesp/proxbox-api:latest-nginx
+    container_name: proxbox-api
+    restart: unless-stopped
+    ports:
+      - "8443:8000"
+    volumes:
+      - ./certs:/certs:ro
+```
+
+#### Granian image and PKCS#8 keys
+
+Granian's TLS layer requires the private key in **PKCS#8 format**.
+The entrypoint handles this automatically:
+
+1. If `key-pkcs8.pem` is present in the mounted directory → use it directly.
+2. If `key-pkcs8.pem` is absent and the directory is **writable** → convert `key.pem`
+   in place and write `key-pkcs8.pem` there.
+3. If `key-pkcs8.pem` is absent and the directory is **read-only** → convert and write
+   to `/tmp/key-pkcs8.pem` (ephemeral; not persisted across container restarts).
+
+To pre-convert your key and avoid the `/tmp` fallback:
+
+```bash
+openssl pkcs8 -topk8 -nocrypt -in ./certs/key.pem -out ./certs/key-pkcs8.pem
+```
+
+Then mount the directory containing all three files (`cert.pem`, `key.pem`, `key-pkcs8.pem`).
+
 ### Binding to IPv6 / dual-stack
 
 To listen on both IPv4 and IPv6, set `PROXBOX_BIND_HOST=::`:


### PR DESCRIPTION
## Summary

Fixes #126 — the `*-nginx` and `*-granian` images crash at startup when the user mounts a read-only `/certs` volume because both entrypoints call `mkcert` unconditionally, attempting to write into the mounted directory.

- **`docker/entrypoint-nginx.sh`**: Wrap the entire mkcert block in a presence check. If `cert.pem` and `key.pem` already exist in `$MKCERT_CERT_DIR`, mkcert generation is skipped. The `mkdir -p` call moves inside the else branch so it only runs when the directory needs to be created.
- **`docker/entrypoint-granian.sh`**: Same guard, plus PKCS#8 key handling for read-only mounts: if `key-pkcs8.pem` is absent and `$CERT_DIR` is read-only, the conversion falls back to `/tmp/key-pkcs8.pem`.
- **`docs/getting-started/installation.md`**: New "Mounting custom certificates" subsection with `docker run` and Compose examples, and granian-specific PKCS#8 guidance.

## Root cause

Both `docker/entrypoint-nginx.sh` and `docker/entrypoint-granian.sh` call `mkcert` unconditionally with no detection of pre-existing certificate files. When a user mounts a read-only `/certs` volume, mkcert tries to write `cert.pem`/`key.pem` there and fails:

```
ERROR: failed to save certificate: open /certs/cert.pem: read-only file system
```

## Test plan

- [ ] Build nginx image: `docker build --target nginx -t proxbox-api:nginx .`
- [ ] Build granian image: `docker build --target granian -t proxbox-api:granian .`
- [ ] nginx + read-only custom certs: `docker run -v ./certs:/certs:ro proxbox-api:nginx` — should log "Custom certificates detected" and start normally
- [ ] granian + read-only custom certs (no pkcs8): should convert to `/tmp/key-pkcs8.pem` and start normally
- [ ] granian + read-only custom certs (with pre-supplied pkcs8): should use `$CERT_DIR/key-pkcs8.pem` directly
- [ ] Default (no volume mount): mkcert auto-generation still works as before
- [ ] CI e2e-docker matrix: existing tests pass (no `/certs` volume mounted, auto-generate path unchanged)