### PR TITLE
docs(pt-BR): sync installation guide with EN version including custom cert section

### DIFF
--- a/docs/pt-BR/getting-started/installation.md
+++ b/docs/pt-BR/getting-started/installation.md
@@ -8,12 +8,151 @@ Esta pagina documenta formas suportadas para executar o `proxbox-api`.
 - `uv` (recomendado) ou `pip`
 - Acesso de rede aos destinos NetBox e Proxmox
 
-## Opcao 1: Docker
+## Opcao 1: Docker (recomendado para inicio rapido)
+
+Todas as imagens Docker sao baseadas em **Alpine** (menor footprint). Tres variantes estao disponiveis:
+
+| Variante | Tags | Descricao |
+|---------|------|-----------|
+| **Raw** (padrao) | `latest`, `<versao>` | Uvicorn puro, somente HTTP. Imagem menor. |
+| **Nginx** | `latest-nginx`, `<versao>-nginx` | nginx encerra HTTPS via mkcert; proxy para uvicorn. |
+| **Granian** | `latest-granian`, `<versao>-granian` | Granian (servidor ASGI em Rust) com TLS nativo via mkcert. |
+
+### Imagem Raw — somente HTTP (padrao)
+
+Opcao mais simples. Sem proxy na frente, HTTP puro. Ideal para desenvolvimento local ou atras de um reverse proxy proprio.
 
 ```bash
 docker pull emersonfelipesp/proxbox-api:latest
 docker run -d -p 8000:8000 --name proxbox-api emersonfelipesp/proxbox-api:latest
 ```
+
+URL do servico:
+
+- <http://127.0.0.1:8000>
+
+### Imagem Nginx — HTTPS com mkcert
+
+O nginx encerra HTTPS usando certificados [mkcert](https://github.com/FiloSottile/mkcert) gerados automaticamente e faz proxy para o uvicorn dentro do container.
+
+```bash
+docker pull emersonfelipesp/proxbox-api:latest-nginx
+docker run -d -p 8443:8000 --name proxbox-api-nginx \
+  emersonfelipesp/proxbox-api:latest-nginx
+```
+
+URL do servico:
+
+- <https://127.0.0.1:8443> (autoassinado, confiavel no host do container)
+
+#### Conectando netbox-proxbox a imagem nginx
+
+A imagem nginx e somente HTTPS — requisicoes HTTP simples para a porta TLS retornam um corpo JSON `400` com `{"error":"plain_http_on_https_port", ...}` (gerado pelo codigo interno `497` do nginx). Ao configurar o **FastAPI Endpoint** no plugin `netbox-proxbox` do NetBox, defina:
+
+| Campo | Valor |
+|-------|-------|
+| **Usar HTTPS** | ✓ habilitado |
+| **Verificar SSL** | ✗ desabilitado (ao usar o certificado mkcert embutido) |
+| **Porta** | a porta do host mapeada para a porta `8000` do container (normalmente `8800` ou `8443`) |
+
+As opcoes `Usar HTTPS` e `Verificar SSL` sao independentes no
+`netbox-proxbox >= 0.0.16` — consulte a
+[issue #352](https://github.com/emersonfelipesp/netbox-proxbox/issues/352) para
+mais contexto. Versoes anteriores do plugin acoplam os dois flags, tornando a
+combinacao imagem-nginx + certificado-autoassinado inalcancavel.
+
+### Imagem Granian — HTTPS com mkcert (sem nginx)
+
+[Granian](https://github.com/emmett-framework/granian) e um servidor ASGI baseado em Rust com TLS nativo e HTTP/2. Um unico processo gerencia tudo — sem nginx ou supervisord.
+
+```bash
+docker pull emersonfelipesp/proxbox-api:latest-granian
+docker run -d -p 8443:8000 --name proxbox-api-granian \
+  emersonfelipesp/proxbox-api:latest-granian
+```
+
+URL do servico:
+
+- <https://127.0.0.1:8443>
+
+### Variaveis de ambiente Docker em tempo de execucao
+
+Comuns a todas as imagens (`raw`, `nginx`, `granian`):
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `PORT` | `8000` | Porta em que o servidor escuta |
+| `PROXBOX_BIND_HOST` | `0.0.0.0` | Endereco ao qual o servidor faz bind. Use `::` para dual-stack IPv4 + IPv6. Respeitado pelas imagens `raw` e `granian`; a imagem `nginx` escuta em ambas as pilhas incondicionalmente. |
+
+Especificas do mkcert (apenas para as imagens `nginx` e `granian`):
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `MKCERT_CERT_DIR` | `/certs` | Diretorio onde os certificados sao armazenados |
+| `MKCERT_EXTRA_NAMES` | — | SANs extras (separados por virgula ou espaco), ex: `proxbox.lan,10.0.0.5` |
+| `CAROOT` | — | Monte um volume aqui para persistir a CA local entre reinicializacoes |
+
+Exemplo com SANs extras:
+
+```bash
+docker run -d -p 8443:8000 --name proxbox-api-tls \
+  -e MKCERT_EXTRA_NAMES='myhost.local,192.168.1.10' \
+  emersonfelipesp/proxbox-api:latest-nginx
+```
+
+### Montando certificados personalizados
+
+As imagens `nginx` e `granian` detectam certificados pre-existentes na inicializacao.
+Se `cert.pem` **e** `key.pem` ja estiverem presentes dentro de `$MKCERT_CERT_DIR` (padrao `/certs`),
+a geracao do mkcert e **ignorada completamente** — o container usa esses arquivos diretamente.
+Isso permite montar seus proprios certificados assinados por CA, Let's Encrypt ou corporativos sem
+nenhuma flag especial.
+
+```bash
+docker run -d -p 8443:8000 --name proxbox-api-nginx \
+  -v ./certs:/certs:ro \
+  emersonfelipesp/proxbox-api:latest-nginx
+```
+
+O diretorio `./certs` deve conter no minimo:
+
+| Arquivo | Descricao |
+|---------|-----------|
+| `cert.pem` | Certificado codificado em PEM (pode ser uma cadeia completa) |
+| `key.pem` | Chave privada codificada em PEM (PKCS#1 ou PKCS#8) |
+
+Exemplo com Docker Compose:
+
+```yaml
+services:
+  proxbox-api:
+    image: emersonfelipesp/proxbox-api:latest-nginx
+    container_name: proxbox-api
+    restart: unless-stopped
+    ports:
+      - "8443:8000"
+    volumes:
+      - ./certs:/certs:ro
+```
+
+#### Imagem Granian e chaves PKCS#8
+
+A camada TLS do Granian requer a chave privada no **formato PKCS#8**.
+O entrypoint trata isso automaticamente:
+
+1. Se `key-pkcs8.pem` estiver presente no diretorio montado → usa diretamente.
+2. Se `key-pkcs8.pem` estiver ausente e o diretorio for **gravavel** → converte `key.pem`
+   no local e escreve `key-pkcs8.pem` la.
+3. Se `key-pkcs8.pem` estiver ausente e o diretorio for **somente leitura** → converte e escreve
+   em `/tmp/key-pkcs8.pem` (efemero; nao persistido entre reinicializacoes do container).
+
+Para pre-converter sua chave e evitar o fallback para `/tmp`:
+
+```bash
+openssl pkcs8 -topk8 -nocrypt -in ./certs/key.pem -out ./certs/key-pkcs8.pem
+```
+
+Em seguida, monte o diretorio contendo os tres arquivos (`cert.pem`, `key.pem`, `key-pkcs8.pem`).
 
 ### Bind em IPv6 / dual-stack
 
@@ -38,6 +177,17 @@ environment:
   PROXBOX_BIND_HOST: "::"         # formato mapa: o YAML remove as aspas
 ```
 
+### Build a partir do codigo-fonte
+
+```bash
+git clone https://github.com/emersonfelipesp/proxbox-api.git
+cd proxbox-api
+
+docker build -t proxbox-api:raw .                          # raw (padrao)
+docker build --target nginx -t proxbox-api:nginx .         # nginx
+docker build --target granian -t proxbox-api:granian .     # granian
+```
+
 ## Opcao 2: PyPI
 
 O pacote esta publicado no [PyPI](https://pypi.org/project/proxbox-api/) como `proxbox-api`.
@@ -60,14 +210,32 @@ python -m uvicorn proxbox_api.main:app --host 0.0.0.0 --port 8000
 
 ## Opcao 3: Codigo-fonte local
 
+Clone o repositorio:
+
 ```bash
 git clone https://github.com/emersonfelipesp/proxbox-api.git
 cd proxbox-api
+```
+
+Instale as dependencias de runtime:
+
+```bash
 pip install -e .
+```
+
+Ou use `uv`:
+
+```bash
+uv sync
+```
+
+Execute a API:
+
+```bash
 uv run fastapi run proxbox_api.main:app --host 0.0.0.0 --port 8000
 ```
 
-Alternativa:
+Alternativa com uvicorn:
 
 ```bash
 uv run uvicorn proxbox_api.main:app --host 0.0.0.0 --port 8000 --reload
@@ -78,6 +246,8 @@ O comando `fastapi run` nao expoe opcoes de TLS; para HTTPS no proprio processo 
 ## TLS sem Docker
 
 ### Certificados locais (mkcert)
+
+Para HTTPS confiavel somente na sua propria maquina:
 
 ```bash
 mkcert -install


### PR DESCRIPTION
## Summary

- Rewrites the Brazilian Portuguese installation guide (`docs/pt-BR/getting-started/installation.md`) to match the current English version
- Adds the three-variant image table (Raw / Nginx / Granian) that was missing
- Adds `### Imagem Nginx — HTTPS com mkcert` section with FastAPIEndpoint configuration table
- Adds `### Imagem Granian — HTTPS com mkcert (sem nginx)` section
- Adds Docker runtime environment variables tables (common + mkcert-specific)
- Adds `### Montando certificados personalizados` — Portuguese translation of the custom cert mounting section added in PR #127
- Adds `#### Imagem Granian e chaves PKCS#8` subsection covering the three-step PKCS#8 resolution logic
- Adds `### Build a partir do codigo-fonte` section
- Preserves all existing content (IPv6 dual-stack, Compose quoting caveat, PyPI, source, TLS sem Docker, Verificar instalacao)

## Test plan

- [ ] Verify `Montando certificados personalizados` section is present in the PT-BR file
- [ ] Verify all code blocks (commands, YAML) are identical to the EN version
- [ ] Run `uv run mkdocs build` locally to confirm no MkDocs warnings