### PR TITLE
fix: guard against FastAPI Query default leaking as run_id (closes #132)

### DIFF
--- a/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
+++ b/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
@@ -1288,7 +1288,7 @@ async def create_virtual_machines(  # noqa: C901
             supports_virtual_machine_type_field=supports_vm_type,
         )
     )
-    effective_run_id = run_id or str(uuid.uuid4())
+    effective_run_id = run_id if isinstance(run_id, str) and run_id else str(uuid.uuid4())
 
     filtered_cluster_resources = cluster_resources
     bridge: WebSocketSSEBridge | None = (

--- a/proxbox_api/services/sync/vm_helpers.py
+++ b/proxbox_api/services/sync/vm_helpers.py
@@ -375,7 +375,7 @@ async def stamp_vm_last_run_id(
     This runs as a separate narrow PATCH so the stamp is written regardless of
     the operator's `overwrite_vm_custom_fields` gate.
     """
-    if not run_id or not vm_record:
+    if not isinstance(run_id, str) or not run_id or not vm_record:
         return
 
     record = _coerce_vm_record_to_dict(vm_record)

--- a/tests/test_proxbox_last_run_id_stamp.py
+++ b/tests/test_proxbox_last_run_id_stamp.py
@@ -313,6 +313,39 @@ async def test_stamp_survives_unserializable_existing_custom_field(
     assert "some_object_field" not in payload_cf
 
 
+@pytest.mark.asyncio
+async def test_stamp_skips_when_run_id_is_fastapi_query_object(
+    patch_recorder: _PatchRecorder,
+) -> None:
+    """A fastapi.params.Query default must not reach the PATCH payload.
+
+    Reproduces GitHub issue #132: when `create_virtual_machines` is called
+    programmatically without passing `run_id=`, Python uses the FastAPI
+    `Query(default=None)` sentinel as the default value. That object is
+    truthy, so the old guard `effective_run_id = run_id or str(uuid.uuid4())`
+    propagated the Query object instead of generating a fresh UUID, causing:
+
+        TypeError: Object of type Query is not JSON serializable
+
+    The fix is two-pronged:
+      1. `effective_run_id = run_id if isinstance(run_id, str) and run_id else str(uuid.uuid4())`
+         in sync_vm.py prevents the Query from ever reaching stamp_vm_last_run_id.
+      2. The isinstance guard added here makes stamp_vm_last_run_id self-defensive
+         so it silently no-ops rather than raising if a non-str leaks through.
+    """
+    from fastapi.params import Query as FastAPIQuery
+
+    query_default = FastAPIQuery(default=None, title="Run ID")
+
+    vm_record = {"id": 64, "name": "example01.example.com", "custom_fields": {}}
+
+    await stamp_vm_last_run_id(nb=object(), vm_record=vm_record, run_id=query_default)
+
+    assert patch_recorder.calls == [], (
+        "stamp_vm_last_run_id must not issue a PATCH when run_id is a FastAPI Query object"
+    )
+
+
 def test_module_exports_helpers() -> None:
     """The helper is importable from the module's public surface."""
     assert hasattr(vm_helpers, "stamp_vm_last_run_id")


### PR DESCRIPTION
## Summary

Fixes issue #132 — `Object of type Query is not JSON serializable` when syncing VMs via WebSocket or direct programmatic calls (i.e. not the full-update HTTP path).

### Root cause

`create_virtual_machines` declares its `run_id` parameter using FastAPI's dependency syntax:

```python
run_id: str | None = Query(default=None, title="Run ID", ...)
```

When called over HTTP, FastAPI resolves `Query(default=None)` → `None`. When called **programmatically without `run_id=`** (WebSocket handlers, single-VM dispatch, stream endpoint), Python uses the `Query(...)` object itself as the default — which is **truthy**.

```python
effective_run_id = run_id or str(uuid.uuid4())
# run_id is Query(...), truthy → effective_run_id = Query object (not a str)
```

That object propagated to `stamp_vm_last_run_id` and into the PATCH body:

```python
{"custom_fields": {"proxbox_last_run_id": <Query object>}}
```

aiohttp then raised `TypeError: Object of type Query is not JSON serializable`.

### Fix

Two-pronged minimal change:

1. **`sync_vm.py`** — replace the truthy-check with an `isinstance` guard:

   ```python
   # Before
   effective_run_id = run_id or str(uuid.uuid4())
   # After
   effective_run_id = run_id if isinstance(run_id, str) and run_id else str(uuid.uuid4())
   ```

2. **`vm_helpers.py`** — make `stamp_vm_last_run_id` self-defensive:

   ```python
   # Before
   if not run_id or not vm_record:
   # After
   if not isinstance(run_id, str) or not run_id or not vm_record:
   ```

### Affected call sites (those that omit `run_id=`)

- `proxbox_api/app/websockets.py` — 3 call sites
- `sync_vm.py` internal single-VM dispatch (line 1081)
- `create_virtual_machines_stream` (line 3489)

The two call sites in `full_update.py` that pass `run_id=operation_id` explicitly were already correct.

### Relationship to #120 / PR #125

Issue #120 was fixed by removing the `{**current_cf, ...}` spread (merged in 0.0.12.post1). This is a **separate** bug: the `run_id` *itself* is the non-serializable value, not a value in the existing custom fields.

## Test plan

- [x] New regression test `test_stamp_skips_when_run_id_is_fastapi_query_object` — passes a real `fastapi.params.Query` object as `run_id` and asserts no PATCH is issued
- [x] All 18 existing `test_proxbox_last_run_id_stamp.py` tests pass
- [x] `ruff check` on all changed files — clean

Closes #132