### PR TITLE
fix: logging verbosity control and netbox_sdk.client suppression (#133)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,7 @@ the `netbox-proxbox` side, do all five — the existing fields in
 - `PROXBOX_ENCRYPTION_KEY`: secret key used to encrypt credentials (NetBox token, Proxmox password/token) at rest in the local SQLite database. The raw value is hashed with SHA-256 to derive a Fernet key. Resolution order: env var > `ProxboxPluginSettings.encryption_key` (configurable from the NetBox plugin settings page) > local key file (default `<repo_root>/data/encryption.key`, managed via the `/admin/encryption/*` endpoints) > none. Startup never aborts; if no key is configured, credentials are stored in plaintext and a CRITICAL log is emitted on first encryption attempt.
 - `PROXBOX_ENCRYPTION_KEY_FILE`: optional override for the local key file path used when neither the env var nor the plugin settings provide a key. Defaults to `<repo_root>/data/encryption.key`.
 - `PROXBOX_ALLOW_PLAINTEXT_CREDENTIALS`: legacy opt-in flag for plaintext credential storage. No longer required for startup; kept for compatibility with operators who scripted it.
+- `PROXBOX_LOG_LEVEL`: console log verbosity (default `INFO`). Valid values: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` (case-insensitive). Controls only the console handler; the in-memory buffer always receives DEBUG+ and the rotating file handler always writes WARNING+. Setting `DEBUG` also enables full `netbox_sdk.client` per-request tracing which is suppressed at all other levels to prevent INFO-level flooding.
 
 ### Plugin-managed (env override optional, defaults shown)
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Common to all images (`raw`, `nginx`, `granian`):
 |----------|---------|-------------|
 | `PORT` | `8000` | Port the server listens on |
 | `PROXBOX_BIND_HOST` | `0.0.0.0` | Bind address for the API server. Set to `::` for IPv4 + IPv6 dual-stack. Honored by the `raw` and `granian` images; the `nginx` image listens on both stacks unconditionally. |
+| `PROXBOX_LOG_LEVEL` | `INFO` | Console log verbosity. Valid values: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`. Set to `DEBUG` for verbose tracing (also enables full `netbox_sdk.client` request tracing). The in-memory log buffer and rotating file handler are unaffected. |
 
 mkcert-specific (only for `nginx` and `granian`):
 

--- a/proxbox_api/app/factory.py
+++ b/proxbox_api/app/factory.py
@@ -335,7 +335,7 @@ def create_app() -> FastAPI:  # noqa: C901
     if os.path.isdir(static_dir):
         app.mount("/static", StaticFiles(directory=static_dir), name="static")
     else:
-        logger.info(
+        logger.debug(
             "Static asset directory not found; skipping /static mount", extra={"path": static_dir}
         )
 
@@ -360,7 +360,7 @@ def create_app() -> FastAPI:  # noqa: C901
         )
 
     origins = build_cors_origins(bootstrap.netbox_endpoints)
-    logger.info("CORS allow_origins configured (%d entries)", len(origins))
+    logger.debug("CORS allow_origins configured (%d entries)", len(origins))
 
     app.add_middleware(
         CORSMiddleware,

--- a/proxbox_api/logger.py
+++ b/proxbox_api/logger.py
@@ -2,6 +2,8 @@
 
 import contextvars
 import logging
+import os
+import sys
 import time
 from collections.abc import Callable
 from functools import wraps
@@ -11,6 +13,42 @@ from typing import ParamSpec, TypeVar
 from fastapi import WebSocket
 
 from proxbox_api.constants import DEFAULT_LOG_PATH
+
+# Third-party loggers that are verbose at INFO but rarely operator-meaningful.
+# Suppressed to WARNING by default; restored to DEBUG when PROXBOX_LOG_LEVEL=DEBUG.
+_THIRD_PARTY_NOISY = [
+    "netbox_sdk.client",
+    "netbox_sdk.schema",
+]
+
+_VALID_LEVELS = frozenset({"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"})
+
+
+def _parse_log_level(raw: str, default: int = logging.INFO) -> int:
+    """Convert a level name string to a logging level integer.
+
+    Falls back to *default* and writes a warning to stderr when *raw* is not
+    a recognised level name.  stderr is used because the proxbox logger has not
+    been constructed yet at the call site.
+    """
+    normalized = raw.strip().upper()
+    if normalized not in _VALID_LEVELS:
+        sys.stderr.write(f"proxbox: unknown PROXBOX_LOG_LEVEL={raw!r}, defaulting to INFO\n")
+        return default
+    return getattr(logging, normalized)
+
+
+def _configure_third_party_levels(console_level: int) -> None:
+    """Set the floor level for known noisy third-party loggers.
+
+    When the operator requests DEBUG output, third-party loggers are left at
+    DEBUG so full SDK tracing is visible.  Otherwise they are raised to WARNING
+    so they do not flood INFO output.
+    """
+    floor = logging.DEBUG if console_level <= logging.DEBUG else logging.WARNING
+    for name in _THIRD_PARTY_NOISY:
+        logging.getLogger(name).setLevel(floor)
+
 
 # Context variable for operation tracking
 _operation_context: contextvars.ContextVar[dict[str, object]] = contextvars.ContextVar(
@@ -123,30 +161,31 @@ def configure_file_logging_path(
 
 
 def setup_logger() -> logging.Logger:
-    # Create a logger
     app_logger = logging.getLogger("proxbox")
 
+    # Logger itself accepts all levels; handlers decide what reaches the output.
     app_logger.setLevel(logging.DEBUG)
 
-    # # Create a console handler
     console_handler = logging.StreamHandler()
 
-    # Log all messages in the console
-    console_handler.setLevel(logging.DEBUG)
+    # Console level is controlled by PROXBOX_LOG_LEVEL (default INFO).
+    # The in-memory buffer and rotating file handler are unaffected: they
+    # always receive DEBUG+ and WARNING+ respectively.
+    console_level = _parse_log_level(os.environ.get("PROXBOX_LOG_LEVEL", "INFO"))
+    console_handler.setLevel(console_level)
 
-    # Create a formatter with colors
     formatter = ColorizedFormatter(
         "%(name)s [%(asctime)s] [%(levelname)-8s] %(module)s: %(message)s"
     )
-    # formatter = logging.Formatter('[%(asctime)s] [%(levelname)s] %(module)s: %(message)s')
-    # Set the formatter for the console handler and file handler
     console_handler.setFormatter(formatter)
 
-    # Add the handlers to the logger
     app_logger.addHandler(console_handler)
     configure_file_logging_path(DEFAULT_LOG_PATH, target_logger=app_logger)
 
     app_logger.propagate = False
+
+    # Suppress known verbose third-party loggers unless the operator requested DEBUG.
+    _configure_third_party_levels(console_level)
 
     return app_logger
 
@@ -183,7 +222,7 @@ class OperationLogger:
         new_context = {"operation": self.operation, **self.context}
         _operation_context.set(new_context)
 
-        logger.info(f"Starting {self.operation}", extra=new_context)
+        logger.debug(f"Starting {self.operation}", extra=new_context)
         return self
 
     async def __aexit__(

--- a/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
+++ b/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
@@ -2293,7 +2293,7 @@ async def create_virtual_machines(  # noqa: C901
             return_exceptions=True,
         )
 
-        logger.info(
+        logger.debug(
             "VM creation gather complete: %d cluster result(s)",
             len(result_list),
         )

--- a/tests/test_logger_settings.py
+++ b/tests/test_logger_settings.py
@@ -1,4 +1,4 @@
-"""Tests for backend file log destination configuration."""
+"""Tests for backend file log destination and console level configuration."""
 
 from __future__ import annotations
 
@@ -6,7 +6,12 @@ import logging
 
 import proxbox_api.logger as logger_module
 from proxbox_api.constants import DEFAULT_LOG_PATH
-from proxbox_api.logger import configure_file_logging_path, logger
+from proxbox_api.logger import (
+    _configure_third_party_levels,
+    _parse_log_level,
+    configure_file_logging_path,
+    logger,
+)
 
 
 class _FakeTimedRotatingFileHandler(logging.Handler):
@@ -94,3 +99,123 @@ def test_bootstrap_applies_backend_log_file_path_from_settings(monkeypatch):
     bootstrap._configure_backend_file_logging()
 
     assert captured["path"] == "/tmp/from-settings.log"
+
+
+# ---------------------------------------------------------------------------
+# PROXBOX_LOG_LEVEL env var and console handler level
+# ---------------------------------------------------------------------------
+
+
+def test_parse_log_level_defaults_to_info_when_env_not_set():
+    assert _parse_log_level("INFO") == logging.INFO
+
+
+def test_parse_log_level_accepts_debug():
+    assert _parse_log_level("DEBUG") == logging.DEBUG
+
+
+def test_parse_log_level_is_case_insensitive():
+    assert _parse_log_level("debug") == logging.DEBUG
+    assert _parse_log_level("Warning") == logging.WARNING
+
+
+def test_parse_log_level_falls_back_to_info_for_unknown_value(capsys):
+    result = _parse_log_level("NONSENSE")
+    assert result == logging.INFO
+    captured = capsys.readouterr()
+    assert "PROXBOX_LOG_LEVEL" in captured.err
+    assert "NONSENSE" in captured.err
+
+
+def test_console_handler_level_defaults_to_info_without_env_var(monkeypatch):
+    """setup_logger() must set the console handler to INFO when PROXBOX_LOG_LEVEL is absent."""
+    monkeypatch.delenv("PROXBOX_LOG_LEVEL", raising=False)
+    monkeypatch.setattr(logger_module, "TimedRotatingFileHandler", _FakeTimedRotatingFileHandler)
+
+    original_handlers = list(logger.handlers)
+    logger.handlers = []
+    _FakeTimedRotatingFileHandler.created_paths = []
+    _FakeTimedRotatingFileHandler.fail_paths = set()
+    try:
+        result_logger = logger_module.setup_logger()
+        console_handlers = [
+            h
+            for h in result_logger.handlers
+            if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+        ]
+        assert console_handlers, "expected at least one StreamHandler"
+        assert console_handlers[0].level == logging.INFO
+    finally:
+        logger.handlers = original_handlers
+
+
+def test_console_handler_level_follows_proxbox_log_level_env_var(monkeypatch):
+    """PROXBOX_LOG_LEVEL=DEBUG must lower the console handler to DEBUG."""
+    monkeypatch.setenv("PROXBOX_LOG_LEVEL", "DEBUG")
+    monkeypatch.setattr(logger_module, "TimedRotatingFileHandler", _FakeTimedRotatingFileHandler)
+
+    original_handlers = list(logger.handlers)
+    logger.handlers = []
+    _FakeTimedRotatingFileHandler.created_paths = []
+    _FakeTimedRotatingFileHandler.fail_paths = set()
+    try:
+        result_logger = logger_module.setup_logger()
+        console_handlers = [
+            h
+            for h in result_logger.handlers
+            if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+        ]
+        assert console_handlers, "expected at least one StreamHandler"
+        assert console_handlers[0].level == logging.DEBUG
+    finally:
+        logger.handlers = original_handlers
+
+
+def test_invalid_proxbox_log_level_falls_back_to_info(monkeypatch, capsys):
+    """An unrecognised PROXBOX_LOG_LEVEL must fall back to INFO and emit a stderr warning."""
+    monkeypatch.setenv("PROXBOX_LOG_LEVEL", "BANANAS")
+    monkeypatch.setattr(logger_module, "TimedRotatingFileHandler", _FakeTimedRotatingFileHandler)
+
+    original_handlers = list(logger.handlers)
+    logger.handlers = []
+    _FakeTimedRotatingFileHandler.created_paths = []
+    _FakeTimedRotatingFileHandler.fail_paths = set()
+    try:
+        result_logger = logger_module.setup_logger()
+        console_handlers = [
+            h
+            for h in result_logger.handlers
+            if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+        ]
+        assert console_handlers[0].level == logging.INFO
+        err = capsys.readouterr().err
+        assert "PROXBOX_LOG_LEVEL" in err
+    finally:
+        logger.handlers = original_handlers
+
+
+# ---------------------------------------------------------------------------
+# Third-party logger suppression
+# ---------------------------------------------------------------------------
+
+
+def test_third_party_loggers_suppressed_to_warning_at_info_level():
+    """`_configure_third_party_levels(INFO)` must raise netbox_sdk.client to WARNING."""
+    nb_client_logger = logging.getLogger("netbox_sdk.client")
+    original_level = nb_client_logger.level
+    try:
+        _configure_third_party_levels(logging.INFO)
+        assert nb_client_logger.level == logging.WARNING
+    finally:
+        nb_client_logger.setLevel(original_level)
+
+
+def test_third_party_loggers_not_suppressed_at_debug_level():
+    """`_configure_third_party_levels(DEBUG)` must leave netbox_sdk.client at DEBUG."""
+    nb_client_logger = logging.getLogger("netbox_sdk.client")
+    original_level = nb_client_logger.level
+    try:
+        _configure_third_party_levels(logging.DEBUG)
+        assert nb_client_logger.level == logging.DEBUG
+    finally:
+        nb_client_logger.setLevel(original_level)


### PR DESCRIPTION
## Summary

Fixes #133 — proxbox-api was flooding logs with dozens of `INFO - api request starting/completed` lines per sync run, and there was no way to change log verbosity without code changes.

**Root causes:**
- `netbox_sdk.client` propagates to the root (uvicorn) logger at INFO for every NetBox API call, producing format-inconsistent noise alongside proxbox's own structured output.
- The console handler was hardcoded to `DEBUG` with no operator control.
- Some internal messages (`"Starting {operation}"`) were logged at INFO when DEBUG is the correct level.

**Changes:**

- **`PROXBOX_LOG_LEVEL` env var** (default `INFO`): controls the console handler verbosity. Valid values: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`. The in-memory buffer always receives `DEBUG+`; the rotating file handler always writes `WARNING+`.
- **Third-party logger suppression**: `netbox_sdk.client` and `netbox_sdk.schema` are raised to `WARNING` when `PROXBOX_LOG_LEVEL >= INFO`. At `PROXBOX_LOG_LEVEL=DEBUG` they're left at `DEBUG` so full per-request SDK tracing is available on demand.
- **INFO → DEBUG demotions**: `OperationLogger.__aenter__` "Starting {operation}" (function entry trace, not operator-meaningful); two low-value startup messages in `factory.py`; sync_vm.py intermediate gather counter.
- **9 new tests** in `tests/test_logger_settings.py` covering level parsing, env var wiring, invalid level fallback, and third-party suppression.
- **Docs**: README env vars table + CLAUDE.md process-only env var list.

## Test plan

- [ ] `uv run pytest tests/test_logger_settings.py -v` — 12 tests pass (3 existing + 9 new)
- [ ] `uv run pytest tests/test_log_buffer.py tests/test_structured_logging.py -v` — all pass
- [ ] `uv run ruff check proxbox_api/logger.py proxbox_api/app/factory.py tests/test_logger_settings.py`
- [ ] `uv run python -c "import proxbox_api.main"` — no INFO flood on startup
- [ ] Start the server with default settings; trigger a sync; confirm no `api request starting` lines at INFO
- [ ] `PROXBOX_LOG_LEVEL=DEBUG` — confirm `api request starting` lines are visible again