### PR TITLE
fix: replace deprecated listen...http2 with standalone http2 on directive

### DIFF
--- a/docker/nginx/proxbox-https.conf.template
+++ b/docker/nginx/proxbox-https.conf.template
@@ -1,6 +1,7 @@
 server {
-    listen __PORT__ ssl http2;
-    listen [::]:__PORT__ ssl http2;
+    listen __PORT__ ssl;
+    listen [::]:__PORT__ ssl;
+    http2 on;
     ssl_certificate __CERT__;
     ssl_certificate_key __KEY__;
 

--- a/tests/docker/test_nginx_config.py
+++ b/tests/docker/test_nginx_config.py
@@ -1,0 +1,30 @@
+"""Tests for the nginx config template shipped with the proxbox-api Docker image."""
+import re
+from pathlib import Path
+
+TEMPLATE = Path(__file__).parents[2] / "docker" / "nginx" / "proxbox-https.conf.template"
+
+
+def test_template_exists():
+    assert TEMPLATE.exists(), f"nginx config template not found at {TEMPLATE}"
+
+
+def test_no_deprecated_listen_http2():
+    """listen ... http2 inline flag was deprecated in nginx 1.25.0 (June 2023).
+    The replacement is a standalone 'http2 on;' directive at the server block level.
+    See https://nginx.org/en/docs/http/ngx_http_v2_module.html
+    """
+    content = TEMPLATE.read_text()
+    deprecated = re.search(r"listen\s+.*\bhttp2\b", content)
+    assert deprecated is None, (
+        f"Deprecated 'listen ... http2' syntax found at: {deprecated.group()!r}. "
+        "Use standalone 'http2 on;' directive instead (nginx >= 1.25.0)."
+    )
+
+
+def test_standalone_http2_directive_present():
+    """The modern http2 directive must be present so HTTP/2 is still enabled."""
+    content = TEMPLATE.read_text()
+    assert re.search(r"^\s*http2\s+on\s*;", content, re.MULTILINE), (
+        "Missing standalone 'http2 on;' directive in nginx config template."
+    )

--- a/tests/docker/test_nginx_config.py
+++ b/tests/docker/test_nginx_config.py
@@ -1,4 +1,5 @@
 """Tests for the nginx config template shipped with the proxbox-api Docker image."""
+
 import re
 from pathlib import Path
 


### PR DESCRIPTION
## Summary

- The `listen ... http2` inline flag in `docker/nginx/proxbox-https.conf.template` was deprecated in nginx 1.25.0 (June 2023), causing startup warnings on current nginx Docker images.
- Replace both IPv4 and IPv6 `listen` lines with the modern standalone `http2 on;` server-block directive.
- Add `tests/docker/test_nginx_config.py` to guard against regression.

Closes #131

## Root cause

`docker/nginx/proxbox-https.conf.template` used the old syntax:
```nginx
listen __PORT__ ssl http2;
listen [::]:__PORT__ ssl http2;
```

nginx ≥1.25.0 deprecates the inline `http2` flag in favor of:
```nginx
listen __PORT__ ssl;
listen [::]:__PORT__ ssl;
http2 on;
```

## Test plan

- [x] `tests/docker/test_nginx_config.py::test_no_deprecated_listen_http2` — asserts deprecated `listen ... http2` syntax is absent
- [x] `tests/docker/test_nginx_config.py::test_standalone_http2_directive_present` — asserts `http2 on;` is present
- [x] All 3 tests in new file pass locally