### PR TITLE
fix: skip bootstrap when no NetBox endpoint is configured (closes #130)

### DIFF
--- a/proxbox_api/app/factory.py
+++ b/proxbox_api/app/factory.py
@@ -298,6 +298,21 @@ async def _run_bootstrap_pass(app: FastAPI) -> None:
         )
         return
 
+    if nb is None:
+        app.state.bootstrap_status = BootstrapStatus(
+            ok=False,
+            skipped=True,
+            reason="no_netbox_session",
+        )
+        logger.warning(
+            "NetBox bootstrap skipped: no NetBox endpoint is configured. "
+            "To fix this, add a NetBox endpoint via the Proxbox API admin UI "
+            "(POST /netbox/endpoints/) or the Next.js admin panel. "
+            "See the installation docs: "
+            "https://emersonfelipesp.github.io/proxbox-api/installation/"
+        )
+        return
+
     try:
         status = await run_netbox_bootstrap(nb, enabled=True)
     except Exception as exc:  # noqa: BLE001

--- a/tests/test_netbox_bootstrap.py
+++ b/tests/test_netbox_bootstrap.py
@@ -461,6 +461,43 @@ async def test_bootstrap_status_as_dict_round_trip() -> None:
 
 
 @pytest.mark.asyncio
+async def test_run_bootstrap_pass_skips_when_no_netbox_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_run_bootstrap_pass must short-circuit and emit exactly one warning when
+    get_raw_netbox_session returns None (issue #130).
+
+    Before the fix, ``run_netbox_bootstrap`` was called with ``nb=None``
+    causing ~20 per-upsert warning log lines instead of one.
+    """
+    from unittest.mock import MagicMock
+
+    from proxbox_api.app import factory
+    from proxbox_api.app import netbox_session as nb_session_module
+    from proxbox_api.services import netbox_bootstrap as nb_bootstrap_module
+
+    # Fake app with a state object
+    fake_app = MagicMock()
+    fake_app.state = MagicMock()
+
+    # get_raw_netbox_session returns None — simulates no endpoint configured
+    monkeypatch.setattr(nb_session_module, "get_raw_netbox_session", lambda: None)
+
+    # run_netbox_bootstrap must NOT be called; raise if it is
+    async def _must_not_be_called(*_a: object, **_kw: object) -> None:
+        raise AssertionError("run_netbox_bootstrap must not be called when nb is None")
+
+    monkeypatch.setattr(nb_bootstrap_module, "run_netbox_bootstrap", _must_not_be_called)
+
+    await factory._run_bootstrap_pass(fake_app)
+
+    status = fake_app.state.bootstrap_status
+    assert status.skipped is True, "bootstrap_status.skipped must be True when no endpoint"
+    assert status.ok is False, "bootstrap_status.ok must be False when no endpoint"
+    assert "no_netbox_session" in (status.reason or "")
+
+
+@pytest.mark.asyncio
 async def test_run_netbox_bootstrap_skips_vm_types_on_old_netbox(
     patch_rest: dict[str, Any],
     freeze_last_updated: None,

--- a/tests/test_session_and_helpers.py
+++ b/tests/test_session_and_helpers.py
@@ -1728,9 +1728,7 @@ def test_proxmox_routes_use_typed_helpers_for_sync_dependencies():
 
     cluster_status_payload = asyncio.run(cluster_status(pxs))
     cluster_resources_payload = asyncio.run(cluster_resources(pxs, type=None))
-    vm_config_payload = asyncio.run(
-        get_vm_config(pxs, node="pve01", type="qemu", vmid=101)
-    )
+    vm_config_payload = asyncio.run(get_vm_config(pxs, node="pve01", type="qemu", vmid=101))
     backup_payload = asyncio.run(
         get_proxmox_node_storage_content(
             pxs,

--- a/tests/test_session_and_helpers.py
+++ b/tests/test_session_and_helpers.py
@@ -36,10 +36,10 @@ from proxbox_api.routes.proxmox import (
     get_vm_config,
     proxmox_version,
 )
-from proxbox_api.services.proxmox.config import resolve_vm_config
 from proxbox_api.routes.proxmox.cluster import cluster_resources, cluster_status
 from proxbox_api.routes.proxmox.nodes import get_node_network
 from proxbox_api.routes.proxmox.replication import cluster_replication
+from proxbox_api.services.proxmox.config import resolve_vm_config
 from proxbox_api.services.proxmox_helpers import (
     get_cluster_resources as get_typed_cluster_resources,
 )


### PR DESCRIPTION
## Summary

Fixes #130 — on a fresh `proxbox-api` install (no NetBox endpoint configured yet), the app flooded the log with ~20 warning lines from individual bootstrap upsert steps instead of one clean message.

**Root cause:** `_run_bootstrap_pass()` in `proxbox_api/app/factory.py` called `get_raw_netbox_session()`, which **returns `None`** (not raises) when no endpoint is in the database. The existing `except Exception` guard never fired because there was no exception — so `nb = None` fell through to `run_netbox_bootstrap(nb=None, enabled=True)`, which iterates ~20 upsert steps with a `None` session, each producing its own warning log entry.

**Fix:** Add a `None` guard immediately after `nb = get_raw_netbox_session()` that short-circuits with `skipped=True` and logs one actionable message telling the operator how to add a NetBox endpoint.

## Changes

- `proxbox_api/app/factory.py` — 12-line `None` guard in `_run_bootstrap_pass()` after the `try/except` block
- `tests/test_netbox_bootstrap.py` — regression test `test_run_bootstrap_pass_skips_when_no_netbox_session` that monkeypatches `get_raw_netbox_session` to return `None` and asserts `run_netbox_bootstrap` is never called and `bootstrap_status.skipped is True`

## Test plan

- [x] New test `test_run_bootstrap_pass_skips_when_no_netbox_session` passes
- [x] All 76 bootstrap/session/smoke tests pass (`tests/test_netbox_bootstrap.py`, `tests/test_main_smoke.py`, `tests/test_session_and_helpers.py`)
- [x] `ruff check` clean on changed files