### PR TITLE
Release v0.0.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ proxbox_api = ["static/*", "static/**/*", "generated/**/*.json", "generated/**/*
 
 [project]
 name = "proxbox_api"
-version = "0.0.13rc4"
+version = "0.0.13"
 description = "Proxbox API service made using FastAPI"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1505,7 +1505,7 @@ wheels = [
 
 [[package]]
 name = "proxbox-api"
-version = "0.0.13rc4"
+version = "0.0.13"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Final v0.0.13 release. Brings the `release/v0.0.13` branch (bumped to `0.0.13` final) onto `main` so the publish workflow can be triggered by tagging `v0.0.13`.

Includes:
- `fix(sync)`: drop dead `cluster_status` kwarg from `get_vm_config` calls (23dcb00)
- Version bumps through `rc1` → `rc4` → `0.0.13`
- `ruff format` reformat (b0d053a)

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run python -m compileall proxbox_api` clean
- [x] All rc TestPyPI gates passed (rc4 was the last green rc)