### PR TITLE
fix: represent CD-ROM drives as nullable-size VirtualDisk entries

### DIFF
--- a/proxbox_api/proxmox_to_netbox/models.py
+++ b/proxbox_api/proxmox_to_netbox/models.py
@@ -741,7 +741,7 @@ class NetBoxVirtualDiskSyncState(BaseModel):
 
     virtual_machine: int
     name: str
-    size: int
+    size: int | None = None
     storage: int | None = None
     description: str | None = None
     tags: list[NetBoxTagRef] = Field(default_factory=list)

--- a/proxbox_api/proxmox_to_netbox/schemas/disks.py
+++ b/proxbox_api/proxmox_to_netbox/schemas/disks.py
@@ -19,6 +19,21 @@ DISK_KEY_PATTERN = re.compile(r"^(scsi|ide|sata|virtio|mp)\d+$|^rootfs$|^efidisk
 UNUSED_DISK_PATTERN = re.compile(r"^unused\d+$")
 
 
+def _is_cdrom(disk_info: dict[str, object]) -> bool:
+    """Return True when disk_info carries ``media=cdrom``."""
+    return str(disk_info.get("media", "")).lower() == "cdrom"
+
+
+def _cdrom_description(storage_info: str) -> str:
+    """Build a human-readable description for a CD-ROM drive.
+
+    ``none`` (empty slot) → ``"CD-ROM drive"``
+    ``local:iso/debian.iso`` (mounted ISO) → ``"CD-ROM drive | ISO: local:iso/debian.iso"``
+    """
+    iso_path = storage_info if storage_info and storage_info.lower() != "none" else ""
+    return f"CD-ROM drive | ISO: {iso_path}" if iso_path else "CD-ROM drive"
+
+
 def size_str_to_mb(size_str: str) -> int:
     """Convert Proxmox size string (e.g., '32G', '512M', '1T') to MB."""
     if not size_str:
@@ -71,6 +86,19 @@ def parse_disk_entry(key: str, raw_value: str) -> ProxmoxDiskEntry | None:
         if "=" in part:
             k, v = part.split("=", 1)
             disk_info[k.strip()] = v.strip()
+
+    # CD-ROM drives carry ``media=cdrom`` and have no ``size=`` field by design.
+    # Represent them as virtual-disk entries with null size so operators can
+    # see which optical drives are attached.  They contribute 0 to the VM-level
+    # disk aggregate so NetBox reconciliation is not affected.
+    if _is_cdrom(disk_info):
+        return ProxmoxDiskEntry(
+            name=key,
+            raw_value=raw_value,
+            size=None,
+            storage=storage_info,
+            description=_cdrom_description(storage_info),
+        )
 
     size_mb = size_str_to_mb(disk_info.get("size", "0"))
     if size_mb <= 0:
@@ -138,7 +166,7 @@ class ProxmoxDiskEntry(ProxboxBaseModel):
 
     name: str
     raw_value: str
-    size: int = 0
+    size: int | None = None
     storage: str | None = None
     storage_name: str | None = None
     format: str | None = None
@@ -151,7 +179,9 @@ class ProxmoxDiskEntry(ProxboxBaseModel):
 
     @field_validator("size", mode="before")
     @classmethod
-    def parse_size(cls, v: object) -> int:
+    def parse_size(cls, v: object) -> int | None:
+        if v is None:
+            return None
         if isinstance(v, int):
             return v
         return size_str_to_mb(str(v))
@@ -159,5 +189,5 @@ class ProxmoxDiskEntry(ProxboxBaseModel):
     @computed_field(return_type=int)
     @property
     def size_mb(self) -> int:
-        """Alias for size to provide consistent naming."""
-        return self.size
+        """Alias for size in MB; returns 0 for CD-ROM/null-size entries."""
+        return self.size if self.size is not None else 0

--- a/tests/test_proxmox_disk_parsing.py
+++ b/tests/test_proxmox_disk_parsing.py
@@ -149,3 +149,59 @@ def test_size_str_to_mb_units():
     assert size_str_to_mb("1T") == 1024 * 1024
     assert size_str_to_mb("32G") == 32 * 1024
     assert size_str_to_mb("garbage") == 0
+
+
+# --- CD-ROM drive tests (issue #145) ---
+
+
+def test_parse_disk_entry_cdrom_empty_slot_returns_entry(proxbox_caplog):
+    """``ide2: none,media=cdrom`` — empty CD-ROM slot must produce a
+    VirtualDisk entry with null size instead of being dropped with a warning.
+    """
+    proxbox_caplog.set_level(logging.WARNING)
+    entry = parse_disk_entry("ide2", "none,media=cdrom")
+    assert entry is not None
+    assert entry.name == "ide2"
+    assert entry.size is None
+    assert entry.size_mb == 0
+    assert entry.description is not None
+    assert "CD-ROM" in entry.description
+    # Must NOT emit the passthrough/raw-disk warning.
+    assert not any(record.levelno == logging.WARNING for record in proxbox_caplog.records)
+
+
+def test_parse_disk_entry_cdrom_with_iso_returns_entry():
+    """``sata0: local:iso/debian.iso,media=cdrom`` — ISO path must appear in
+    the description so operators know which image is mounted.
+    """
+    entry = parse_disk_entry("sata0", "local:iso/debian.iso,media=cdrom")
+    assert entry is not None
+    assert entry.name == "sata0"
+    assert entry.size is None
+    assert entry.description is not None
+    assert "local:iso/debian.iso" in entry.description
+    assert "CD-ROM" in entry.description
+
+
+def test_parse_disk_entry_cdrom_ide_key_accepted():
+    """CD-ROM entries on ``ide0`` (common default slot) are also parsed."""
+    entry = parse_disk_entry("ide0", "none,media=cdrom")
+    assert entry is not None
+    assert entry.size is None
+
+
+def test_parse_vm_config_disks_includes_cdrom_entries():
+    """CD-ROM disks must appear alongside normal disks in the parsed list
+    and must not inflate the VM-level disk aggregate.
+    """
+    config = {
+        "scsi0": "local-lvm:vm-100-disk-0,size=32G",
+        "ide2": "none,media=cdrom",
+    }
+    entries = parse_vm_config_disks(config)
+    names = {e.name for e in entries}
+    assert "ide2" in names
+    assert "scsi0" in names
+    # CD-ROM contributes 0 to the aggregate via size_mb.
+    aggregate = sum(e.size_mb for e in entries)
+    assert aggregate == 32 * 1024


### PR DESCRIPTION
## Summary

Closes #145.

- CD-ROM drives (`ide2: none,media=cdrom`, `sata0: local:iso/debian.iso,media=cdrom`) were silently dropped with a WARNING that misclassified them as passthrough/raw disks. They now appear in NetBox as `VirtualDisk` entries with `size=null` and a human-readable description.
- Passthrough/raw disk handling is unchanged (still skipped with WARNING).
- The VM-level disk aggregate is unaffected — `size_mb` returns 0 for null entries so the NetBox reconciliation invariant holds.

## Changes

| File | Change |
|------|--------|
| `proxbox_api/proxmox_to_netbox/schemas/disks.py` | Detect `media=cdrom` before the size skip guard; return `ProxmoxDiskEntry(size=None)` with description; widen `ProxmoxDiskEntry.size` to `int \| None = None` |
| `proxbox_api/proxmox_to_netbox/models.py` | Widen `NetBoxVirtualDiskSyncState.size` from `int` to `int \| None = None` |
| `tests/test_proxmox_disk_parsing.py` | Add 4 regression tests for CD-ROM scenarios |

## Before / After

| Disk config | Before | After |
|---|---|---|
| `ide2: none,media=cdrom` | Skipped + WARNING | `VirtualDisk(name="ide2", size=null, description="CD-ROM drive")` |
| `sata0: local:iso/debian.iso,media=cdrom` | Skipped + WARNING | `VirtualDisk(name="sata0", size=null, description="CD-ROM drive | ISO: local:iso/debian.iso")` |
| `scsi2: /dev/sdb` (raw passthrough) | Skipped + WARNING | Still skipped + WARNING (no change) |

## Test plan

- [x] `uv run pytest tests/test_proxmox_disk_parsing.py -v` — all 16 tests pass (4 new)
- [x] `uv run pytest tests/test_proxmox_to_netbox_contracts.py tests/test_virtual_disks_sync.py tests/test_schema_contracts.py` — all pass, no regressions
- [x] `uv run ruff check` — clean