### PR TITLE
fix(virtual_disks): remove stale cluster_status kwarg from resolve_vm_config (closes #143)

### DIFF
--- a/proxbox_api/services/sync/virtual_disks.py
+++ b/proxbox_api/services/sync/virtual_disks.py
@@ -229,7 +229,6 @@ async def create_virtual_disks(  # noqa: C901
             try:
                 vm_config = await resolve_vm_config(
                     pxs=pxs,
-                    cluster_status=cluster_status,
                     node=node_name,
                     vm_type=vm_type,
                     vmid=vmid,

--- a/tests/test_virtual_disks_sync.py
+++ b/tests/test_virtual_disks_sync.py
@@ -70,7 +70,6 @@ def test_create_virtual_disks_uses_custom_fields_proxmox_vm_id(monkeypatch):
     assert calls["resolve_vm_config"] == [
         {
             "pxs": [],
-            "cluster_status": [],
             "node": "pve01",
             "vm_type": "qemu",
             "vmid": "101",


### PR DESCRIPTION
## Summary

Fixes #143 — virtual disk sync fails with `resolve_vm_config() got an unexpected keyword argument 'cluster_status'` for every VM.

**Root cause:** `resolve_vm_config()` had its `cluster_status` parameter removed in v0.0.13 (#134), but the call site in `proxbox_api/services/sync/virtual_disks.py` was never updated. Every disk sync attempt raised a `TypeError` that was silently caught and logged as a warning, causing all virtual disk creation to be skipped.

**Changes:**
- `proxbox_api/services/sync/virtual_disks.py` — remove the stale `cluster_status=cluster_status` keyword argument from the `resolve_vm_config()` call
- `tests/test_virtual_disks_sync.py` — remove `"cluster_status": []` from the assertion dict that checked the (incorrect) call kwargs

## Test plan

- [x] `pytest tests/test_virtual_disks_sync.py tests/test_session_and_helpers.py` — 56 passed
- [x] `ruff check proxbox_api/services/sync/virtual_disks.py tests/test_virtual_disks_sync.py` — all checks passed
- [ ] Full CI suite green