### PR TITLE
feat: add Proxmox VE 9.2 to cloud-init template version catalog

### DIFF
--- a/proxbox_api/routes/cloud/cloud_init_templates.py
+++ b/proxbox_api/routes/cloud/cloud_init_templates.py
@@ -47,6 +47,14 @@ class ProxmoxProductVersion:
 PRODUCT_CATALOG: dict[ProxmoxProductType, list[ProxmoxProductVersion]] = {
     ProxmoxProductType.pve: [
         ProxmoxProductVersion(
+            version="9.2",
+            debian_codename="bookworm",
+            package_name="proxmox-ve",
+            repo_component="pve-no-subscription",
+            repo_suite="pve",
+            extra_services=["pve-cluster", "pvedaemon", "pvestatd"],
+        ),
+        ProxmoxProductVersion(
             version="8.4",
             debian_codename="bookworm",
             package_name="proxmox-ve",


### PR DESCRIPTION
## Summary

Proxmox VE 9.2 is now available ([release announcement](https://forum.proxmox.com/threads/proxmox-virtual-environment-9-2-available.183742/)).

Adds `9.2/bookworm` as the first (default) entry in `PRODUCT_CATALOG[ProxmoxProductType.pve]` inside `proxbox_api/routes/cloud/cloud_init_templates.py`.

The generated `#cloud-config` user-data for PVE 9.2 is identical in structure to PVE 8.x — same Debian Bookworm base, same `pve-no-subscription` repository component, same `proxmox-ve` package, same enabled services (`pve-cluster`, `pvedaemon`, `pvestatd`). Only the version label changes.

## Files Changed

- `proxbox_api/routes/cloud/cloud_init_templates.py` — new `ProxmoxProductVersion("9.2", ...)` entry prepended to the PVE list

## Acceptance Criteria

- [ ] `GET /cloud/templates/versions` returns `pve: [{version: "9.2", ...}, ...]` with 9.2 as the first entry
- [ ] `find_product_version(ProxmoxProductType.pve, None)` returns the PVE 9.2 entry (default = first)
- [ ] `find_product_version(ProxmoxProductType.pve, "9.2")` returns the PVE 9.2 entry
- [ ] `generate_cloud_init_userdata(ProxmoxProductType.pve, pv_9_2)` produces valid cloud-config YAML

## Related

- Tracked in N-MultiCloud/nms#75