### PR TITLE
feat: Proxmox VE 9.2 compatibility — bump proxmox-sdk to v0.0.6

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -398,6 +398,35 @@ cancelled to avoid wasted CI and to keep the run history clean.
 - Added NetBox v4.6.1 to `.github/netbox-versions.json` certified versions.
 - Paired consumer: `netbox-proxbox v0.0.17`.
 
+### What was done for v0.0.14
+
+- Bumped `pyproject.toml` to `0.0.14`.
+- Bumped `proxmox-sdk` dependency from `0.0.5.post1` → `0.0.6` (PVE 9.2 schema, 675 operations / 449 endpoints, up from 646/389 in 9.1.11). Also bumped `proxmox-sdk[pbs]` and `proxmox-sdk[pdm]` optional extras.
+- New routes — **HA (PVE 9.2)**:
+  - `POST /proxmox/cluster/ha/disarm` — disarm HA stack cluster-wide (maintenance mode).
+  - `POST /proxmox/cluster/ha/arm` — re-arm HA stack.
+  - `GET /proxmox/cluster/ha/manager-status` — live HA CRM manager status.
+  - `GET /proxmox/cluster/ha/crs` — Cluster Resource Scheduler configuration extracted from datacenter options.
+- New routes — **SDN fabrics (PVE 9.2)**:
+  - `GET /proxmox/sdn/fabrics` — list SDN fabrics (WireGuard, BGP, VXLAN, OSPF types).
+  - `GET /proxmox/sdn/fabrics/all` — list all SDN fabrics including inherited ones.
+  - `GET /proxmox/sdn/route-maps` — SDN route-map objects.
+  - `GET /proxmox/sdn/prefix-lists` — SDN prefix-list objects.
+- New routes — **Datacenter (PVE 9.2)**:
+  - `GET /proxmox/datacenter/cpu-models` — list custom CPU models.
+  - `GET /proxmox/datacenter/cpu-models/{cputype}` — get a single custom CPU model.
+  - `POST /proxmox/datacenter/cpu-models` — create a custom CPU model.
+  - `PUT /proxmox/datacenter/cpu-models/{cputype}` — update a custom CPU model.
+  - `DELETE /proxmox/datacenter/cpu-models/{cputype}` — delete a custom CPU model.
+  - `GET /proxmox/datacenter/options` — datacenter options including CRS sub-object and `location` field.
+- New routes — **Access tokens (PVE 9.2)**:
+  - `GET /proxmox/access/tokens/{userid}/{tokenid}` — read API token info.
+  - `PUT /proxmox/access/tokens/{userid}/{tokenid}/regenerate` — regenerate token secret in-place.
+- Extended routes — **Nodes (PVE 9.2)**:
+  - `GET /proxmox/nodes/{node}/storage/{storage}/identity` — PBS storage instance ID.
+  - `GET /proxmox/nodes/{node}/config` — node configuration including new `location` field.
+- Tracked in issue: <https://github.com/emersonfelipesp/proxbox-api/issues/152>.
+
 ### Don't
 
 - Don't add `twine --skip-existing` to the upload step. If a version is

--- a/proxbox_api/app/factory.py
+++ b/proxbox_api/app/factory.py
@@ -46,12 +46,15 @@ from proxbox_api.routes.intent.deletion_requests import router as deletion_reque
 from proxbox_api.routes.intent.vm_tags import router as vm_tags_router
 from proxbox_api.routes.netbox import router as netbox_router
 from proxbox_api.routes.proxmox import router as proxmox_router
+from proxbox_api.routes.proxmox.access import router as px_access_router
 from proxbox_api.routes.proxmox.cluster import router as px_cluster_router
+from proxbox_api.routes.proxmox.datacenter import router as px_datacenter_router
 from proxbox_api.routes.proxmox.firewall import router as px_firewall_router
 from proxbox_api.routes.proxmox.ha import router as px_ha_router
 from proxbox_api.routes.proxmox.nodes import router as px_nodes_router
 from proxbox_api.routes.proxmox.replication import router as px_replication_router
 from proxbox_api.routes.proxmox.runtime_generated import register_generated_proxmox_routes
+from proxbox_api.routes.proxmox.sdn import router as px_sdn_router
 from proxbox_api.routes.proxmox_actions import router as proxmox_actions_router
 from proxbox_api.routes.sync.active import router as sync_active_router
 from proxbox_api.routes.sync.individual import router as sync_individual_router
@@ -432,6 +435,9 @@ def create_app() -> FastAPI:  # noqa: C901
         app.include_router(px_ha_router, prefix="/proxmox/cluster", tags=["proxmox / ha"])
         app.include_router(px_replication_router, prefix="/proxmox", tags=["proxmox / replication"])
         app.include_router(px_firewall_router, prefix="/proxmox", tags=["proxmox / firewall"])
+        app.include_router(px_sdn_router, prefix="/proxmox", tags=["proxmox / sdn"])
+        app.include_router(px_datacenter_router, prefix="/proxmox", tags=["proxmox / datacenter"])
+        app.include_router(px_access_router, prefix="/proxmox", tags=["proxmox / access"])
         app.include_router(
             proxmox_actions_router, prefix="/proxmox", tags=["proxmox / operational verbs"]
         )

--- a/proxbox_api/routes/proxmox/access.py
+++ b/proxbox_api/routes/proxmox/access.py
@@ -1,0 +1,143 @@
+"""Proxmox access-control endpoints.
+
+Exposes PVE 9.2 API token management operations:
+- ``GET /access/tokens/{userid}/{tokenid}`` — read token info.
+- ``PUT /access/tokens/{userid}/{tokenid}/regenerate`` — regenerate the
+  secret of an existing API token in-place (PVE 9.2+).  All associated
+  ACL entries are preserved; no delete-and-recreate required.
+
+All routes proxy the Proxmox ``/access/users/{userid}/token/{tokenid}``
+surface and require the caller to specify a ``cluster_name`` when more
+than one Proxmox cluster is configured, because token namespaces are
+per-cluster.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+
+from proxbox_api.logger import logger
+from proxbox_api.proxmox_async import resolve_async
+from proxbox_api.services.sync.individual.helpers import resolve_proxmox_session_for_request
+from proxbox_api.session.proxmox import ProxmoxSessionsDep
+
+router = APIRouter()
+
+
+class AccessTokenInfoSchema(BaseModel):
+    """Information about a Proxmox API token."""
+
+    cluster_name: str | None = None
+    userid: str | None = None
+    tokenid: str | None = None
+    comment: str | None = None
+    privsep: bool | None = None
+    expire: int | None = None
+    value: str | None = None
+    status: str = "ok"
+    error: str | None = None
+
+
+def _to_token_info(
+    cluster_name: str, userid: str, tokenid: str, raw: object
+) -> AccessTokenInfoSchema:
+    data: dict[str, object] = {}
+    if hasattr(raw, "model_dump"):
+        data = raw.model_dump(mode="python", by_alias=True, exclude_none=True)
+    elif isinstance(raw, dict):
+        data = dict(raw)
+    return AccessTokenInfoSchema(
+        cluster_name=cluster_name,
+        userid=userid,
+        tokenid=tokenid,
+        comment=str(data.get("comment")) if data.get("comment") is not None else None,
+        privsep=bool(data.get("privsep")) if data.get("privsep") is not None else None,
+        expire=int(data["expire"]) if isinstance(data.get("expire"), (int, str)) else None,
+        value=str(data.get("value")) if data.get("value") is not None else None,
+    )
+
+
+@router.get("/access/tokens/{userid}/{tokenid}", response_model=AccessTokenInfoSchema | None)
+async def read_token(
+    pxs: ProxmoxSessionsDep,
+    userid: str,
+    tokenid: str,
+    cluster_name: str | None = Query(None, description="Target cluster name"),
+) -> AccessTokenInfoSchema | None:
+    """Retrieve info for a Proxmox API token.
+
+    Proxies ``GET /access/users/{userid}/token/{tokenid}``.  Returns
+    ``null`` when the token does not exist on any configured cluster.
+    """
+    for px in pxs:
+        if cluster_name and px.name != cluster_name:
+            continue
+        try:
+            raw = await resolve_async(px.session(f"access/users/{userid}/token/{tokenid}").get())
+            if raw is not None:
+                return _to_token_info(px.name, userid, tokenid, raw)
+        except Exception:  # noqa: BLE001
+            logger.debug("Token %s/%s not found on cluster %s", userid, tokenid, px.name)
+    return None
+
+
+class TokenRegenerateResponseSchema(BaseModel):
+    """Response from a token regenerate request.
+
+    On success, ``value`` contains the new secret.  Store it immediately
+    — Proxmox will never return the plaintext secret again.
+    """
+
+    cluster_name: str | None = None
+    userid: str | None = None
+    tokenid: str | None = None
+    value: str | None = None
+    full_tokenid: str | None = None
+    status: str = "ok"
+    error: str | None = None
+
+
+@router.put(
+    "/access/tokens/{userid}/{tokenid}/regenerate", response_model=TokenRegenerateResponseSchema
+)
+async def regenerate_token(
+    pxs: ProxmoxSessionsDep,
+    userid: str,
+    tokenid: str,
+    cluster_name: str | None = Query(
+        None, description="Target cluster name (required when multiple clusters are configured)"
+    ),
+) -> TokenRegenerateResponseSchema:
+    """Regenerate the secret of an existing API token in-place (PVE 9.2+).
+
+    Proxies ``PUT /access/users/{userid}/token/{tokenid}`` with
+    ``regenerate=1``.  All associated ACL entries are preserved.
+
+    **Store the returned ``value`` immediately** — it cannot be retrieved
+    again after this call.
+    """
+    px = resolve_proxmox_session_for_request(
+        pxs, cluster_name, resource_name="regenerate API token"
+    )
+    try:
+        raw = await resolve_async(
+            px.session(f"access/users/{userid}/token/{tokenid}").put(regenerate=1)
+        )
+        data: dict[str, object] = {}
+        if hasattr(raw, "model_dump"):
+            data = raw.model_dump(mode="python", by_alias=True, exclude_none=True)
+        elif isinstance(raw, dict):
+            data = dict(raw)
+        return TokenRegenerateResponseSchema(
+            cluster_name=px.name,
+            userid=userid,
+            tokenid=tokenid,
+            value=str(data.get("value")) if data.get("value") is not None else None,
+            full_tokenid=str(data.get("full-tokenid") or data.get("full_tokenid"))
+            if (data.get("full-tokenid") or data.get("full_tokenid")) is not None
+            else None,
+        )
+    except Exception as exc:
+        logger.exception("Error regenerating token %s/%s on cluster %s", userid, tokenid, px.name)
+        raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/proxbox_api/routes/proxmox/datacenter.py
+++ b/proxbox_api/routes/proxmox/datacenter.py
@@ -284,10 +284,9 @@ async def datacenter_options(pxs: ProxmoxSessionsDep) -> list[DatacenterOptionsS
                     if isinstance(data.get("max_workers"), (int, str))
                     else None,
                     migration_unsecure=bool(
-                        data.get("migration_unsecure") or data.get("migration-unsecure")
+                        data.get("migration_unsecure", data.get("migration-unsecure"))
                     )
-                    if (data.get("migration_unsecure") or data.get("migration-unsecure"))
-                    is not None
+                    if "migration_unsecure" in data or "migration-unsecure" in data
                     else None,
                     next_id=dict(data["next_id"])
                     if isinstance(data.get("next_id"), dict)

--- a/proxbox_api/routes/proxmox/datacenter.py
+++ b/proxbox_api/routes/proxmox/datacenter.py
@@ -1,0 +1,305 @@
+"""Proxmox datacenter-level endpoints.
+
+Exposes PVE 9.2 features:
+- Custom CPU models CRUD (``GET/POST /cluster/qemu/custom-cpu-models``,
+  ``GET/PUT/DELETE /cluster/qemu/custom-cpu-models/{cputype}``) — allows
+  managing the set of virtual CPU models exposed to VMs from the API.
+- Datacenter options (``GET/PUT /cluster/options``) — includes the PVE 9.2
+  CRS sub-object and the new node physical ``location`` field.
+
+All write routes (POST, PUT, DELETE) require that the request is directed
+to a single cluster via the ``cluster_name`` query parameter.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+
+from proxbox_api.logger import logger
+from proxbox_api.proxmox_async import resolve_async
+from proxbox_api.services.sync.individual.helpers import resolve_proxmox_session_for_request
+from proxbox_api.session.proxmox import ProxmoxSessionsDep
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Custom CPU models (PVE 9.2)
+# ---------------------------------------------------------------------------
+
+
+class CustomCpuModelSchema(BaseModel):
+    """A custom CPU model definition."""
+
+    cluster_name: str | None = None
+    cputype: str | None = None
+    base_cputype: str | None = None
+    flags: str | None = None
+    vendor_id: str | None = None
+    level: int | None = None
+    description: str | None = None
+    status: str = "ok"
+    error: str | None = None
+
+
+def _to_cpu_model(cluster_name: str, raw: object) -> CustomCpuModelSchema:
+    data: dict[str, object] = {}
+    if hasattr(raw, "model_dump"):
+        data = raw.model_dump(mode="python", by_alias=True, exclude_none=True)
+    elif isinstance(raw, dict):
+        data = dict(raw)
+    return CustomCpuModelSchema(
+        cluster_name=cluster_name,
+        cputype=str(data.get("cputype") or data.get("name"))
+        if (data.get("cputype") or data.get("name")) is not None
+        else None,
+        base_cputype=str(data.get("base-cputype") or data.get("base_cputype"))
+        if (data.get("base-cputype") or data.get("base_cputype")) is not None
+        else None,
+        flags=str(data.get("flags")) if data.get("flags") is not None else None,
+        vendor_id=str(data.get("vendor_id") or data.get("vendor-id"))
+        if (data.get("vendor_id") or data.get("vendor-id")) is not None
+        else None,
+        level=int(data["level"]) if isinstance(data.get("level"), (int, str)) else None,
+        description=str(data.get("description")) if data.get("description") is not None else None,
+    )
+
+
+@router.get("/datacenter/cpu-models", response_model=list[CustomCpuModelSchema])
+async def list_custom_cpu_models(pxs: ProxmoxSessionsDep) -> list[CustomCpuModelSchema]:
+    """List all custom CPU models across all clusters (PVE 9.2+).
+
+    Proxies ``GET /cluster/qemu/custom-cpu-models``.  Custom CPU models
+    allow tailoring the virtual CPU exposed to VMs to a specific feature
+    set, enabling cluster-wide compatibility management.
+    """
+    results: list[CustomCpuModelSchema] = []
+    for px in pxs:
+        try:
+            raw = await resolve_async(px.session("cluster/qemu/custom-cpu-models").get())
+            rows = raw if isinstance(raw, list) else (raw.root if hasattr(raw, "root") else [raw])
+            for row in rows:
+                results.append(_to_cpu_model(px.name, row))
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Error fetching custom CPU models for Proxmox cluster %s", px.name)
+            results.append(
+                CustomCpuModelSchema(cluster_name=px.name, status="error", error=str(exc))
+            )
+    return results
+
+
+@router.get("/datacenter/cpu-models/{cputype}", response_model=CustomCpuModelSchema | None)
+async def get_custom_cpu_model(
+    pxs: ProxmoxSessionsDep,
+    cputype: str,
+    cluster_name: str | None = Query(None, description="Target cluster name"),
+) -> CustomCpuModelSchema | None:
+    """Get a single custom CPU model by name (PVE 9.2+).
+
+    Proxies ``GET /cluster/qemu/custom-cpu-models/{cputype}``.
+    Returns ``null`` when no cluster has a model with that name.
+    """
+    for px in pxs:
+        if cluster_name and px.name != cluster_name:
+            continue
+        try:
+            raw = await resolve_async(px.session(f"cluster/qemu/custom-cpu-models/{cputype}").get())
+            if raw is not None:
+                return _to_cpu_model(px.name, raw)
+        except Exception:  # noqa: BLE001
+            logger.debug("Custom CPU model %s not found on cluster %s", cputype, px.name)
+    return None
+
+
+class CustomCpuModelCreateSchema(BaseModel):
+    """Payload for creating a custom CPU model."""
+
+    cputype: str
+    base_cputype: str | None = None
+    flags: str | None = None
+    vendor_id: str | None = None
+    level: int | None = None
+    description: str | None = None
+
+
+@router.post("/datacenter/cpu-models", response_model=CustomCpuModelSchema)
+async def create_custom_cpu_model(
+    pxs: ProxmoxSessionsDep,
+    payload: CustomCpuModelCreateSchema,
+    cluster_name: str | None = Query(None, description="Target cluster name"),
+) -> CustomCpuModelSchema:
+    """Create a custom CPU model (PVE 9.2+).
+
+    Proxies ``POST /cluster/qemu/custom-cpu-models``.
+    Specify ``cluster_name`` to target a specific cluster when more than
+    one is configured.
+    """
+    px = resolve_proxmox_session_for_request(
+        pxs, cluster_name, resource_name="create custom CPU model"
+    )
+    body: dict[str, object] = {"cputype": payload.cputype}
+    if payload.base_cputype is not None:
+        body["base-cputype"] = payload.base_cputype
+    if payload.flags is not None:
+        body["flags"] = payload.flags
+    if payload.vendor_id is not None:
+        body["vendor-id"] = payload.vendor_id
+    if payload.level is not None:
+        body["level"] = payload.level
+    if payload.description is not None:
+        body["description"] = payload.description
+    try:
+        raw = await resolve_async(px.session("cluster/qemu/custom-cpu-models").post(**body))
+        if raw is None:
+            return _to_cpu_model(px.name, {"cputype": payload.cputype})
+        return _to_cpu_model(px.name, raw)
+    except Exception as exc:
+        logger.exception("Error creating custom CPU model on cluster %s", px.name)
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+class CustomCpuModelUpdateSchema(BaseModel):
+    """Payload for updating a custom CPU model."""
+
+    base_cputype: str | None = None
+    flags: str | None = None
+    vendor_id: str | None = None
+    level: int | None = None
+    description: str | None = None
+
+
+@router.put("/datacenter/cpu-models/{cputype}", response_model=CustomCpuModelSchema)
+async def update_custom_cpu_model(
+    pxs: ProxmoxSessionsDep,
+    cputype: str,
+    payload: CustomCpuModelUpdateSchema,
+    cluster_name: str | None = Query(None, description="Target cluster name"),
+) -> CustomCpuModelSchema:
+    """Update a custom CPU model (PVE 9.2+).
+
+    Proxies ``PUT /cluster/qemu/custom-cpu-models/{cputype}``.
+    """
+    px = resolve_proxmox_session_for_request(
+        pxs, cluster_name, resource_name="update custom CPU model"
+    )
+    body: dict[str, object] = {}
+    if payload.base_cputype is not None:
+        body["base-cputype"] = payload.base_cputype
+    if payload.flags is not None:
+        body["flags"] = payload.flags
+    if payload.vendor_id is not None:
+        body["vendor-id"] = payload.vendor_id
+    if payload.level is not None:
+        body["level"] = payload.level
+    if payload.description is not None:
+        body["description"] = payload.description
+    try:
+        raw = await resolve_async(
+            px.session(f"cluster/qemu/custom-cpu-models/{cputype}").put(**body)
+        )
+        if raw is None:
+            return _to_cpu_model(px.name, {"cputype": cputype})
+        return _to_cpu_model(px.name, raw)
+    except Exception as exc:
+        logger.exception("Error updating custom CPU model %s on cluster %s", cputype, px.name)
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@router.delete("/datacenter/cpu-models/{cputype}", response_model=CustomCpuModelSchema)
+async def delete_custom_cpu_model(
+    pxs: ProxmoxSessionsDep,
+    cputype: str,
+    cluster_name: str | None = Query(None, description="Target cluster name"),
+) -> CustomCpuModelSchema:
+    """Delete a custom CPU model (PVE 9.2+).
+
+    Proxies ``DELETE /cluster/qemu/custom-cpu-models/{cputype}``.
+    """
+    px = resolve_proxmox_session_for_request(
+        pxs, cluster_name, resource_name="delete custom CPU model"
+    )
+    try:
+        await resolve_async(px.session(f"cluster/qemu/custom-cpu-models/{cputype}").delete())
+        return CustomCpuModelSchema(cluster_name=px.name, cputype=cputype)
+    except Exception as exc:
+        logger.exception("Error deleting custom CPU model %s on cluster %s", cputype, px.name)
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# Datacenter options — includes CRS and node location (PVE 9.2)
+# ---------------------------------------------------------------------------
+
+
+class DatacenterOptionsSchema(BaseModel):
+    """Datacenter-level options from ``GET /cluster/options``.
+
+    Includes the PVE 9.2 ``crs`` sub-object (Cluster Resource Scheduler
+    configuration) and the ``location`` field for physical site mapping.
+    All fields are optional — only populated values are returned.
+    """
+
+    cluster_name: str | None = None
+    keyboard: str | None = None
+    language: str | None = None
+    email_from: str | None = None
+    max_workers: int | None = None
+    migration_unsecure: bool | None = None
+    next_id: dict[str, object] | None = None
+    notify: dict[str, object] | None = None
+    crs: dict[str, object] | None = None
+    location: str | None = None
+    status: str = "ok"
+    error: str | None = None
+
+
+@router.get("/datacenter/options", response_model=list[DatacenterOptionsSchema])
+async def datacenter_options(pxs: ProxmoxSessionsDep) -> list[DatacenterOptionsSchema]:
+    """Retrieve datacenter options across all clusters.
+
+    Proxies ``GET /cluster/options``.  Exposes the PVE 9.2 ``crs``
+    sub-object (CRS dynamic load balancer mode) and the new ``location``
+    field for physical site mapping.
+    """
+    results: list[DatacenterOptionsSchema] = []
+    for px in pxs:
+        try:
+            raw = await resolve_async(px.session("cluster/options").get())
+            data: dict[str, object] = {}
+            if hasattr(raw, "model_dump"):
+                data = raw.model_dump(mode="python", by_alias=True, exclude_none=True)
+            elif isinstance(raw, dict):
+                data = dict(raw)
+            crs = data.get("crs")
+            results.append(
+                DatacenterOptionsSchema(
+                    cluster_name=px.name,
+                    keyboard=str(data["keyboard"]) if data.get("keyboard") is not None else None,
+                    language=str(data["language"]) if data.get("language") is not None else None,
+                    email_from=str(data.get("email_from") or data.get("email-from"))
+                    if (data.get("email_from") or data.get("email-from")) is not None
+                    else None,
+                    max_workers=int(data["max_workers"])
+                    if isinstance(data.get("max_workers"), (int, str))
+                    else None,
+                    migration_unsecure=bool(
+                        data.get("migration_unsecure") or data.get("migration-unsecure")
+                    )
+                    if (data.get("migration_unsecure") or data.get("migration-unsecure"))
+                    is not None
+                    else None,
+                    next_id=dict(data["next_id"])
+                    if isinstance(data.get("next_id"), dict)
+                    else None,
+                    notify=dict(data["notify"]) if isinstance(data.get("notify"), dict) else None,
+                    crs=dict(crs) if isinstance(crs, dict) else None,
+                    location=str(data["location"]) if data.get("location") is not None else None,
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Error fetching datacenter options for Proxmox cluster %s", px.name)
+            results.append(
+                DatacenterOptionsSchema(cluster_name=px.name, status="error", error=str(exc))
+            )
+    return results

--- a/proxbox_api/routes/proxmox/ha.py
+++ b/proxbox_api/routes/proxmox/ha.py
@@ -12,8 +12,16 @@ silently).  Use the new `/ha/rules` endpoint for PVE 9.x HA rule data.
 `/ha/summary` now includes both `groups` and `rules` so consumers can
 handle mixed-version clusters.
 
-All endpoints are read-only by design. HA mutations (add/remove/migrate)
-are intentionally out of scope and will land in a follow-up release.
+PVE 9.2 additions (disarm/arm HA stack, manager status, CRS config):
+- ``POST /ha/disarm`` / ``POST /ha/arm`` — disarm/arm the HA stack
+  cluster-wide via the new ``cluster/ha/status/disarm-ha`` and
+  ``cluster/ha/status/arm-ha`` CRM commands.  Safe for planned
+  maintenance windows without triggering node fencing.
+- ``GET /ha/manager-status`` — CRM manager status (queue depths, CRS
+  scheduling state).
+- ``GET /ha/crs`` — CRS (Cluster Resource Scheduler) configuration
+  extracted from datacenter options; drives the PVE 9.2 dynamic load
+  balancer that migrates HA-managed guests to lower node imbalance.
 """
 
 from __future__ import annotations
@@ -26,6 +34,7 @@ from fastapi import APIRouter
 from pydantic import BaseModel
 
 from proxbox_api.logger import logger
+from proxbox_api.proxmox_async import resolve_async
 from proxbox_api.services.proxmox_helpers import (
     get_ha_groups,
     get_ha_resources,
@@ -434,3 +443,150 @@ def _runtime_index(cluster_name: str, status_rows: list[object]) -> dict[str, Ha
         if item.sid:
             index[item.sid] = item
     return index
+
+
+# ---------------------------------------------------------------------------
+# PVE 9.2 additions: disarm/arm, manager-status, CRS config
+# ---------------------------------------------------------------------------
+
+
+class HaManagerStatusSchema(BaseModel):
+    """CRM manager status from ``/cluster/ha/status/manager_status``."""
+
+    cluster_name: str | None = None
+    manager_status: str | None = None
+    timestamp: int | None = None
+    quorum_ok: bool | None = None
+    mode: str | None = None
+
+
+class HaDisarmResultSchema(BaseModel):
+    """Result of a disarm-ha or arm-ha CRM command."""
+
+    cluster_name: str | None = None
+    status: str = "ok"
+    error: str | None = None
+
+
+class HaCrsConfigSchema(BaseModel):
+    """CRS (Cluster Resource Scheduler) configuration (PVE 9.2+).
+
+    Extracted from the ``crs`` sub-object of ``GET /cluster/options``.
+    CRS drives the dynamic load balancer that migrates HA-managed guests
+    to lower the overall node imbalance across the cluster.
+    """
+
+    cluster_name: str | None = None
+    ha: str | None = None
+    status: str = "ok"
+    error: str | None = None
+
+
+@router.post("/ha/disarm", response_model=list[HaDisarmResultSchema])
+async def ha_disarm(pxs: ProxmoxSessionsDep) -> list[HaDisarmResultSchema]:
+    """Disarm the HA stack cluster-wide (PVE 9.2+).
+
+    Calls ``POST /cluster/ha/status/disarm-ha`` on each configured
+    Proxmox cluster.  While disarmed, HA-managed guests are **not**
+    automatically restarted or migrated, and no fencing events are
+    triggered.  Use ``POST /ha/arm`` to re-enable HA after maintenance.
+    """
+    results: list[HaDisarmResultSchema] = []
+    for px in pxs:
+        try:
+            await resolve_async(px.session("cluster/ha/status/disarm-ha").post())
+            results.append(HaDisarmResultSchema(cluster_name=px.name))
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Error disarming HA for Proxmox cluster %s", px.name)
+            results.append(
+                HaDisarmResultSchema(cluster_name=px.name, status="error", error=str(exc))
+            )
+    return results
+
+
+@router.post("/ha/arm", response_model=list[HaDisarmResultSchema])
+async def ha_arm(pxs: ProxmoxSessionsDep) -> list[HaDisarmResultSchema]:
+    """Re-arm the HA stack cluster-wide (PVE 9.2+).
+
+    Calls ``POST /cluster/ha/status/arm-ha`` on each configured
+    Proxmox cluster.  HA resources return to their previous state after
+    the maintenance window is completed.
+    """
+    results: list[HaDisarmResultSchema] = []
+    for px in pxs:
+        try:
+            await resolve_async(px.session("cluster/ha/status/arm-ha").post())
+            results.append(HaDisarmResultSchema(cluster_name=px.name))
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Error arming HA for Proxmox cluster %s", px.name)
+            results.append(
+                HaDisarmResultSchema(cluster_name=px.name, status="error", error=str(exc))
+            )
+    return results
+
+
+@router.get("/ha/manager-status", response_model=list[HaManagerStatusSchema])
+async def ha_manager_status(pxs: ProxmoxSessionsDep) -> list[HaManagerStatusSchema]:
+    """Retrieve CRM manager status across all clusters (PVE 9.2+).
+
+    Proxies ``GET /cluster/ha/status/manager_status``.  Returns queue
+    depths, CRS scheduling state, and quorum health per cluster.
+    """
+    results: list[HaManagerStatusSchema] = []
+    for px in pxs:
+        try:
+            raw = await resolve_async(px.session("cluster/ha/status/manager_status").get())
+            data: dict[str, object] = {}
+            if hasattr(raw, "model_dump"):
+                data = raw.model_dump(mode="python", by_alias=True, exclude_none=True)
+            elif isinstance(raw, dict):
+                data = raw
+            results.append(
+                HaManagerStatusSchema(
+                    cluster_name=px.name,
+                    manager_status=str(data.get("manager_status"))
+                    if data.get("manager_status") is not None
+                    else None,
+                    timestamp=data.get("timestamp")
+                    if isinstance(data.get("timestamp"), int)
+                    else None,
+                    quorum_ok=_coerce_bool(data.get("quorum_ok") or data.get("quorum-ok")),
+                    mode=str(data.get("mode")) if data.get("mode") is not None else None,
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Error fetching HA manager status for Proxmox cluster %s", px.name)
+            results.append(
+                HaManagerStatusSchema(cluster_name=px.name, manager_status=f"error: {exc}")
+            )
+    return results
+
+
+@router.get("/ha/crs", response_model=list[HaCrsConfigSchema])
+async def ha_crs(pxs: ProxmoxSessionsDep) -> list[HaCrsConfigSchema]:
+    """Retrieve CRS (Cluster Resource Scheduler) config across all clusters (PVE 9.2+).
+
+    Extracts the ``crs`` sub-object from ``GET /cluster/options``.
+    The CRS ``ha`` field controls the scheduling mode:
+    ``static`` (pre-9.2 default), ``basic``, or ``dynamic`` (PVE 9.2).
+    """
+    results: list[HaCrsConfigSchema] = []
+    for px in pxs:
+        try:
+            raw = await resolve_async(px.session("cluster/options").get())
+            data: dict[str, object] = {}
+            if hasattr(raw, "model_dump"):
+                data = raw.model_dump(mode="python", by_alias=True, exclude_none=True)
+            elif isinstance(raw, dict):
+                data = raw
+            crs = data.get("crs")
+            crs_ha: str | None = None
+            if isinstance(crs, dict):
+                crs_ha = str(crs.get("ha")) if crs.get("ha") is not None else None
+            elif isinstance(crs, str):
+                crs_ha = crs
+            results.append(HaCrsConfigSchema(cluster_name=px.name, ha=crs_ha))
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Error fetching CRS config for Proxmox cluster %s", px.name)
+            results.append(HaCrsConfigSchema(cluster_name=px.name, status="error", error=str(exc)))
+    return results

--- a/proxbox_api/routes/proxmox/ha.py
+++ b/proxbox_api/routes/proxmox/ha.py
@@ -192,8 +192,12 @@ def _status_item_to_schema(cluster_name: str, item: object) -> HaStatusItemSchem
         request_state=data.get("request_state") or data.get("request-state"),
         quorate=_coerce_bool(data.get("quorate")),
         failback=_coerce_bool(data.get("failback")),
-        max_relocate=_coerce_int(data.get("max_relocate") or data.get("max-relocate")),
-        max_restart=_coerce_int(data.get("max_restart") or data.get("max-restart")),
+        max_relocate=_coerce_int(
+            data.get("max_relocate") if "max_relocate" in data else data.get("max-relocate")
+        ),
+        max_restart=_coerce_int(
+            data.get("max_restart") if "max_restart" in data else data.get("max-restart")
+        ),
         timestamp=_coerce_int(data.get("timestamp")),
     )
 
@@ -550,7 +554,9 @@ async def ha_manager_status(pxs: ProxmoxSessionsDep) -> list[HaManagerStatusSche
                     timestamp=data.get("timestamp")
                     if isinstance(data.get("timestamp"), int)
                     else None,
-                    quorum_ok=_coerce_bool(data.get("quorum_ok") or data.get("quorum-ok")),
+                    quorum_ok=_coerce_bool(
+                        data.get("quorum_ok") if "quorum_ok" in data else data.get("quorum-ok")
+                    ),
                     mode=str(data.get("mode")) if data.get("mode") is not None else None,
                 )
             )

--- a/proxbox_api/routes/proxmox/nodes.py
+++ b/proxbox_api/routes/proxmox/nodes.py
@@ -229,3 +229,139 @@ async def node_qemu(
         )
 
     return [{px.name: json_result}]
+
+
+# ---------------------------------------------------------------------------
+# PVE 9.2: PBS storage identity + node physical location
+# ---------------------------------------------------------------------------
+
+
+class PbsStorageIdentitySchema(BaseModel):
+    """Instance ID of a Proxmox Backup Server storage (PVE 9.2+)."""
+
+    cluster_name: str | None = None
+    node: str | None = None
+    storage: str | None = None
+    instance_id: str | None = None
+    status: str = "ok"
+    error: str | None = None
+
+
+@router.get("/{node}/storage/{storage}/identity", response_model=PbsStorageIdentitySchema)
+async def get_pbs_storage_identity(
+    pxs: ProxmoxSessionsDep,
+    node: Annotated[
+        str,
+        Path(
+            title="Proxmox Node",
+            description="Proxmox Node name (ex. 'pve01').",
+            pattern=NODE_PATTERN,
+        ),
+    ],
+    storage: Annotated[str, Path(title="Storage ID", description="Proxmox storage identifier.")],
+    cluster_name: Annotated[
+        str | None,
+        Query(
+            title="Cluster Name",
+            description="Optional cluster name to disambiguate multi-session deployments.",
+        ),
+    ] = None,
+) -> PbsStorageIdentitySchema:
+    """Return the instance ID of a Proxmox Backup Server storage (PVE 9.2+).
+
+    Proxies ``GET /nodes/{node}/storage/{storage}/identity``.  Used by
+    Proxmox Datacenter Manager to map PBS storages onto their
+    corresponding PBS remotes.
+    """
+    px = resolve_proxmox_session_for_request(
+        pxs, cluster_name, resource_name="PBS storage identity"
+    )
+    try:
+        raw = await resolve_async(px.session(f"nodes/{node}/storage/{storage}/identity").get())
+        data: dict[str, object] = {}
+        if hasattr(raw, "model_dump"):
+            data = raw.model_dump(mode="python", by_alias=True, exclude_none=True)
+        elif isinstance(raw, dict):
+            data = dict(raw)
+        return PbsStorageIdentitySchema(
+            cluster_name=px.name,
+            node=node,
+            storage=storage,
+            instance_id=str(data.get("instance-id") or data.get("instance_id"))
+            if (data.get("instance-id") or data.get("instance_id")) is not None
+            else None,
+        )
+    except ResourceException as error:
+        raise ProxboxException(
+            message="Error fetching PBS storage identity from Proxmox",
+            python_exception=str(error),
+        )
+
+
+class NodeConfigSchema(BaseModel):
+    """Selected fields from ``GET /nodes/{node}/config`` (PVE 9.2+).
+
+    Surfaces the new ``location`` property added in PVE 9.2 alongside
+    existing node-level configuration fields.
+    """
+
+    cluster_name: str | None = None
+    node: str | None = None
+    description: str | None = None
+    wakeonlan: str | None = None
+    startall_onboot_delay: int | None = None
+    location: str | None = None
+    status: str = "ok"
+    error: str | None = None
+
+
+@router.get("/{node}/config", response_model=NodeConfigSchema)
+async def get_node_config(
+    pxs: ProxmoxSessionsDep,
+    node: Annotated[
+        str,
+        Path(
+            title="Proxmox Node",
+            description="Proxmox Node name (ex. 'pve01').",
+            pattern=NODE_PATTERN,
+        ),
+    ],
+    cluster_name: Annotated[
+        str | None,
+        Query(
+            title="Cluster Name",
+            description="Optional cluster name to disambiguate multi-session deployments.",
+        ),
+    ] = None,
+) -> NodeConfigSchema:
+    """Retrieve node configuration including the PVE 9.2 ``location`` field.
+
+    Proxies ``GET /nodes/{node}/config``.  The ``location`` field maps
+    the node to a physical site and renders as an OpenStreetMap link in
+    the Proxmox web interface.
+    """
+    px = resolve_proxmox_session_for_request(pxs, cluster_name, resource_name="node config")
+    try:
+        raw = await resolve_async(px.session(f"nodes/{node}/config").get())
+        data: dict[str, object] = {}
+        if hasattr(raw, "model_dump"):
+            data = raw.model_dump(mode="python", by_alias=True, exclude_none=True)
+        elif isinstance(raw, dict):
+            data = dict(raw)
+        return NodeConfigSchema(
+            cluster_name=px.name,
+            node=node,
+            description=str(data.get("description"))
+            if data.get("description") is not None
+            else None,
+            wakeonlan=str(data.get("wakeonlan")) if data.get("wakeonlan") is not None else None,
+            startall_onboot_delay=int(data["startall_onboot_delay"])
+            if isinstance(data.get("startall_onboot_delay"), (int, str))
+            else None,
+            location=str(data.get("location")) if data.get("location") is not None else None,
+        )
+    except ResourceException as error:
+        raise ProxboxException(
+            message="Error fetching node config from Proxmox",
+            python_exception=str(error),
+        )

--- a/proxbox_api/routes/proxmox/sdn.py
+++ b/proxbox_api/routes/proxmox/sdn.py
@@ -1,0 +1,204 @@
+"""Proxmox SDN (Software Defined Networking) endpoints (read-only).
+
+Surfaces PVE 9.2 SDN fabric, route-map, and prefix-list objects
+so operators can inspect WireGuard/BGP fabrics and their routing policy
+objects without leaving the Proxbox API surface.
+
+All endpoints are read-only.  SDN mutations require cluster-level
+access and remain intentionally out of scope for this proxy layer.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from proxbox_api.logger import logger
+from proxbox_api.proxmox_async import resolve_async
+from proxbox_api.session.proxmox import ProxmoxSessionsDep
+
+router = APIRouter()
+
+
+class SdnFabricSchema(BaseModel):
+    """A single SDN fabric object."""
+
+    cluster_name: str | None = None
+    fabric: str | None = None
+    type: str | None = None
+    advertise_subnets: bool | None = None
+    disable_arp_nd_suppression: bool | None = None
+    vrf_vxlan: int | None = None
+    peers: str | None = None
+    asn: int | None = None
+    status: str = "ok"
+    error: str | None = None
+
+
+class SdnRouteMapSchema(BaseModel):
+    """A single SDN route-map entry."""
+
+    cluster_name: str | None = None
+    name: str | None = None
+    action: str | None = None
+    match_peer: str | None = None
+    match_ip: str | None = None
+    set_community: str | None = None
+    order: int | None = None
+    status: str = "ok"
+    error: str | None = None
+
+
+class SdnPrefixListSchema(BaseModel):
+    """A single SDN prefix-list entry."""
+
+    cluster_name: str | None = None
+    name: str | None = None
+    cidr: str | None = None
+    action: str | None = None
+    le: int | None = None
+    ge: int | None = None
+    status: str = "ok"
+    error: str | None = None
+
+
+def _to_fabric(cluster_name: str, raw: object) -> SdnFabricSchema:
+    data: dict[str, object] = {}
+    if hasattr(raw, "model_dump"):
+        data = raw.model_dump(mode="python", by_alias=True, exclude_none=True)
+    elif isinstance(raw, dict):
+        data = dict(raw)
+    return SdnFabricSchema(
+        cluster_name=cluster_name,
+        fabric=str(data.get("fabric")) if data.get("fabric") is not None else None,
+        type=str(data.get("type")) if data.get("type") is not None else None,
+        advertise_subnets=bool(data.get("advertise_subnets"))
+        if "advertise_subnets" in data
+        else None,
+        disable_arp_nd_suppression=bool(data.get("disable_arp_nd_suppression"))
+        if "disable_arp_nd_suppression" in data
+        else None,
+        vrf_vxlan=int(data["vrf_vxlan"]) if isinstance(data.get("vrf_vxlan"), (int, str)) else None,
+        asn=int(data["asn"]) if isinstance(data.get("asn"), (int, str)) else None,
+        peers=str(data.get("peers")) if data.get("peers") is not None else None,
+    )
+
+
+def _to_route_map(cluster_name: str, raw: object) -> SdnRouteMapSchema:
+    data: dict[str, object] = {}
+    if hasattr(raw, "model_dump"):
+        data = raw.model_dump(mode="python", by_alias=True, exclude_none=True)
+    elif isinstance(raw, dict):
+        data = dict(raw)
+    return SdnRouteMapSchema(
+        cluster_name=cluster_name,
+        name=str(data.get("name")) if data.get("name") is not None else None,
+        action=str(data.get("action")) if data.get("action") is not None else None,
+        match_peer=str(data.get("match-peer") or data.get("match_peer"))
+        if (data.get("match-peer") or data.get("match_peer")) is not None
+        else None,
+        match_ip=str(data.get("match-ip") or data.get("match_ip"))
+        if (data.get("match-ip") or data.get("match_ip")) is not None
+        else None,
+        set_community=str(data.get("set-community") or data.get("set_community"))
+        if (data.get("set-community") or data.get("set_community")) is not None
+        else None,
+        order=int(data["order"]) if isinstance(data.get("order"), (int, str)) else None,
+    )
+
+
+def _to_prefix_list(cluster_name: str, raw: object) -> SdnPrefixListSchema:
+    data: dict[str, object] = {}
+    if hasattr(raw, "model_dump"):
+        data = raw.model_dump(mode="python", by_alias=True, exclude_none=True)
+    elif isinstance(raw, dict):
+        data = dict(raw)
+    return SdnPrefixListSchema(
+        cluster_name=cluster_name,
+        name=str(data.get("name")) if data.get("name") is not None else None,
+        cidr=str(data.get("cidr")) if data.get("cidr") is not None else None,
+        action=str(data.get("action")) if data.get("action") is not None else None,
+        le=int(data["le"]) if isinstance(data.get("le"), (int, str)) else None,
+        ge=int(data["ge"]) if isinstance(data.get("ge"), (int, str)) else None,
+    )
+
+
+@router.get("/sdn/fabrics", response_model=list[SdnFabricSchema])
+async def sdn_fabrics(pxs: ProxmoxSessionsDep) -> list[SdnFabricSchema]:
+    """List SDN fabrics across all configured Proxmox clusters (PVE 9.2+).
+
+    Proxies ``GET /cluster/sdn/fabrics``.  Returns WireGuard and BGP
+    fabric objects (and any pre-existing VXLAN/OSPF fabrics).
+    """
+    results: list[SdnFabricSchema] = []
+    for px in pxs:
+        try:
+            raw = await resolve_async(px.session("cluster/sdn/fabrics").get())
+            rows = raw if isinstance(raw, list) else (raw.root if hasattr(raw, "root") else [raw])
+            for row in rows:
+                results.append(_to_fabric(px.name, row))
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Error fetching SDN fabrics for Proxmox cluster %s", px.name)
+            results.append(SdnFabricSchema(cluster_name=px.name, status="error", error=str(exc)))
+    return results
+
+
+@router.get("/sdn/fabrics/all", response_model=list[SdnFabricSchema])
+async def sdn_fabrics_all(pxs: ProxmoxSessionsDep) -> list[SdnFabricSchema]:
+    """List all SDN fabrics (including inherited) across all clusters (PVE 9.2+).
+
+    Proxies ``GET /cluster/sdn/fabrics/all``.
+    """
+    results: list[SdnFabricSchema] = []
+    for px in pxs:
+        try:
+            raw = await resolve_async(px.session("cluster/sdn/fabrics/all").get())
+            rows = raw if isinstance(raw, list) else (raw.root if hasattr(raw, "root") else [raw])
+            for row in rows:
+                results.append(_to_fabric(px.name, row))
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Error fetching all SDN fabrics for Proxmox cluster %s", px.name)
+            results.append(SdnFabricSchema(cluster_name=px.name, status="error", error=str(exc)))
+    return results
+
+
+@router.get("/sdn/route-maps", response_model=list[SdnRouteMapSchema])
+async def sdn_route_maps(pxs: ProxmoxSessionsDep) -> list[SdnRouteMapSchema]:
+    """List SDN route-map objects across all clusters (PVE 9.2+).
+
+    Proxies ``GET /cluster/sdn/route-maps``.  Route maps allow
+    fine-grained BGP/EVPN route filtering for SDN BGP fabric protocols.
+    """
+    results: list[SdnRouteMapSchema] = []
+    for px in pxs:
+        try:
+            raw = await resolve_async(px.session("cluster/sdn/route-maps").get())
+            rows = raw if isinstance(raw, list) else (raw.root if hasattr(raw, "root") else [raw])
+            for row in rows:
+                results.append(_to_route_map(px.name, row))
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Error fetching SDN route-maps for Proxmox cluster %s", px.name)
+            results.append(SdnRouteMapSchema(cluster_name=px.name, status="error", error=str(exc)))
+    return results
+
+
+@router.get("/sdn/prefix-lists", response_model=list[SdnPrefixListSchema])
+async def sdn_prefix_lists(pxs: ProxmoxSessionsDep) -> list[SdnPrefixListSchema]:
+    """List SDN prefix-list objects across all clusters (PVE 9.2+).
+
+    Proxies ``GET /cluster/sdn/prefix-lists``.  Prefix lists define
+    CIDR ranges used by route maps for BGP/EVPN route filtering.
+    """
+    results: list[SdnPrefixListSchema] = []
+    for px in pxs:
+        try:
+            raw = await resolve_async(px.session("cluster/sdn/prefix-lists").get())
+            rows = raw if isinstance(raw, list) else (raw.root if hasattr(raw, "root") else [raw])
+            for row in rows:
+                results.append(_to_prefix_list(px.name, row))
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Error fetching SDN prefix-lists for Proxmox cluster %s", px.name)
+            results.append(
+                SdnPrefixListSchema(cluster_name=px.name, status="error", error=str(exc))
+            )
+    return results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,13 @@ proxbox_api = ["static/*", "static/**/*", "generated/**/*.json", "generated/**/*
 
 [project]
 name = "proxbox_api"
-version = "0.0.13"
+version = "0.0.14"
 description = "Proxbox API service made using FastAPI"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "fastapi[standard]==0.136.1",
-    "proxmox-sdk==0.0.5.post1",
+    "proxmox-sdk==0.0.6",
     "netbox-sdk==0.0.8.post1",
     "sqlmodel==0.0.38",
     "pydantic==2.13.3",
@@ -52,10 +52,10 @@ granian = [
     "granian>=2.7.4",
 ]
 pbs = [
-    "proxmox-sdk[pbs]==0.0.5.post1",
+    "proxmox-sdk[pbs]==0.0.6",
 ]
 pdm = [
-    "proxmox-sdk[pdm]==0.0.5.post1",
+    "proxmox-sdk[pdm]==0.0.6",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -1505,7 +1505,7 @@ wheels = [
 
 [[package]]
 name = "proxbox-api"
-version = "0.0.13"
+version = "0.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -1573,9 +1573,9 @@ requires-dist = [
     { name = "netbox-sdk", specifier = "==0.0.8.post1" },
     { name = "playwright", marker = "extra == 'playwright'", specifier = ">=1.58.0" },
     { name = "playwright", marker = "extra == 'test'", specifier = ">=1.58.0" },
-    { name = "proxmox-sdk", specifier = "==0.0.5.post1" },
-    { name = "proxmox-sdk", extras = ["pbs"], marker = "extra == 'pbs'", specifier = "==0.0.5.post1" },
-    { name = "proxmox-sdk", extras = ["pdm"], marker = "extra == 'pdm'", specifier = "==0.0.5.post1" },
+    { name = "proxmox-sdk", specifier = "==0.0.6" },
+    { name = "proxmox-sdk", extras = ["pbs"], marker = "extra == 'pbs'", specifier = "==0.0.6" },
+    { name = "proxmox-sdk", extras = ["pdm"], marker = "extra == 'pdm'", specifier = "==0.0.6" },
     { name = "pydantic", specifier = "==2.13.3" },
     { name = "pytest", marker = "extra == 'e2e'", specifier = ">=9.0.3" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3" },
@@ -1617,7 +1617,7 @@ dev = [{ name = "ruff", specifier = ">=0.15.8" }]
 
 [[package]]
 name = "proxmox-sdk"
-version = "0.0.5.post1"
+version = "0.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1626,9 +1626,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "slowapi" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/b0/7e4c1f56c42e5eeca7223759b44e4d4967d0ad9195bb88b51cc9c464f2de/proxmox_sdk-0.0.5.post1.tar.gz", hash = "sha256:51f946a94e7ba5e9c3d90ec3a1eeef2e9b6a2310cd5ca650005ccf3883d3b3f6", size = 826849, upload-time = "2026-05-16T21:59:34.635Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/e0/0a6eb16809bd1d26cf99f208c4fa8b50b96c7ada05d0e5ecee41a10f97db/proxmox_sdk-0.0.6.tar.gz", hash = "sha256:89bb44697883910d97bea615178ab2a48397d16a1c11485b29537b9057cd8c2b", size = 2063601, upload-time = "2026-05-21T17:50:53.341Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/d7/241e26495214d90c04c6504ff311722a376b0bb76c444bb374ed10f916ce/proxmox_sdk-0.0.5.post1-py3-none-any.whl", hash = "sha256:bfc7bf04be487e6b1de76ab7c9faddf4721b92410157a04a79da068ca169b7f4", size = 897924, upload-time = "2026-05-16T21:59:32.621Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ef/3377c76592ccb5e5e87d15f5f34ce68dadfbf42ca6309c9a5191a3a189fa/proxmox_sdk-0.0.6-py3-none-any.whl", hash = "sha256:0383a714d43fcf2d40f1193d256fcfd37ba98aa2f5d8e79ed776c30a0cc67664", size = 2208696, upload-time = "2026-05-21T17:50:52.053Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements Proxmox VE 9.2 compatibility by bumping `proxmox-sdk` from `0.0.5.post1` to `0.0.6` and adding 15 new API endpoints that expose the new PVE 9.2 surface.

Closes #152

### Dependency bump
- `proxmox-sdk 0.0.5.post1` → `proxmox-sdk 0.0.6` (PVE 9.2 schema: 675 operations / 449 endpoints, up from 646/389)
- Package version: `0.0.13` → `0.0.14`

### New endpoints

**HA — Dynamic Load Balancing (CRS)**
- `POST /proxmox/cluster/ha/disarm` — disarm HA stack cluster-wide (maintenance)
- `POST /proxmox/cluster/ha/arm` — re-arm HA stack
- `GET  /proxmox/cluster/ha/manager-status` — live CRM manager status with quorum info
- `GET  /proxmox/cluster/ha/crs` — CRS configuration extracted from `GET /cluster/options`

**SDN — WireGuard & BGP Fabric Protocols (read-only)**
- `GET /proxmox/sdn/fabrics` — list SDN fabrics (WireGuard, BGP, VXLAN, OSPF)
- `GET /proxmox/sdn/fabrics/all` — all fabrics including inherited
- `GET /proxmox/sdn/route-maps` — SDN route-map policy objects
- `GET /proxmox/sdn/prefix-lists` — SDN prefix-list objects

**Datacenter — Custom CPU Models CRUD**
- `GET  /proxmox/datacenter/cpu-models`
- `GET  /proxmox/datacenter/cpu-models/{cputype}`
- `POST /proxmox/datacenter/cpu-models`
- `PUT  /proxmox/datacenter/cpu-models/{cputype}`
- `DELETE /proxmox/datacenter/cpu-models/{cputype}`
- `GET  /proxmox/datacenter/options` — includes CRS sub-object and new `location` field

**Access Tokens — In-place Secret Regeneration**
- `GET /proxmox/access/tokens/{userid}/{tokenid}` — read token info
- `PUT /proxmox/access/tokens/{userid}/{tokenid}/regenerate` — regenerate secret without delete-and-recreate

**Nodes — PBS Identity & Physical Location**
- `GET /proxmox/nodes/{node}/storage/{storage}/identity` — PBS storage instance ID
- `GET /proxmox/nodes/{node}/config` — node config including new `location` field

## Test plan

- [x] All new routes registered: verified via `python -c "import proxbox_api.main; ..."` listing 14 new route paths
- [x] `uv run ruff check .` — 0 issues
- [x] `uv run ruff format --check .` — 0 issues
- [x] `uv run python -c "import proxbox_api.main"` — clean import
- [x] `uv lock` updated (proxmox-sdk 0.0.5.post1 → 0.0.6)
- [ ] CI matrix with `PROXMOX_MOCK_SCHEMA_VERSION=latest` (now mirrors 9.2)