### PR TITLE
chore: update netbox-proxbox install target to v0.0.17 in CI workflow

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -35,7 +35,7 @@ ci.yml (push/PR — dev mode E2E only)
 ├── setup             (generates E2E matrix)
 ├── build-netbox-image (only uploads an artifact when the public NetBox image cannot be pulled)
 └── e2e-docker        (needs: test + setup + build-netbox-image; transport × NetBox version matrix)
-    - dev mode:  netbox-proxbox from pinned GitHub release tag tarball (currently v0.0.15)
+    - dev mode:  netbox-proxbox from pinned GitHub release tag tarball (currently v0.0.17)
                  proxbox-api built from local checkout with DEV_OVERRIDES (netbox-sdk + proxmox-sdk from GitHub)
     - pypi mode: netbox-proxbox from PyPI; proxbox-api built from local checkout without overrides
     - NetBox image handling: each E2E job pulls the public image first and only downloads the source-built artifact when the registry pull fails.

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -63,7 +63,7 @@ publish-testpypi.yml (staged package release)
 
 | Mode | netbox-proxbox (in NetBox container) | proxbox-api container | netbox-sdk / proxmox-sdk (in proxbox-api) |
 |------|--------------------------------------|-----------------------|-------------------------------------------|
-| **dev** | GitHub `develop` branch tarball | Built from local checkout with `--build-arg DEV_OVERRIDES=...` | `git+https://github.com/emersonfelipesp/netbox-sdk.git@main` and `git+https://github.com/emersonfelipesp/proxmox-sdk.git@main` |
+| **dev** | GitHub release tag tarball (pinned; see `ci.yml` → "Resolve netbox-proxbox install target") | Built from local checkout with `--build-arg DEV_OVERRIDES=...` | `git+https://github.com/emersonfelipesp/netbox-sdk.git@main` and `git+https://github.com/emersonfelipesp/proxmox-sdk.git@main` |
 | **published** | PyPI `netbox-proxbox` | Docker Hub `emersonfelipesp/proxbox-api:<version>` | PyPI versions from `uv.lock` (no override) |
 
 `DEV_OVERRIDES` is injected via `ARG DEV_OVERRIDES` in the Dockerfile builder stage. Normal production builds leave `DEV_OVERRIDES` empty (default `""`), so there is no impact on published images.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,7 +329,7 @@ jobs:
         id: proxbox_pkg
         run: |
           if [ "${{ matrix.netbox_proxbox_mode }}" = "dev" ]; then
-            echo "target=https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.16rc11.tar.gz" >> "$GITHUB_OUTPUT"
+            echo "target=https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.17.tar.gz" >> "$GITHUB_OUTPUT"
           else
             echo "target=netbox-proxbox" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -361,7 +361,7 @@ jobs:
           set -eux
           docker network create proxbox-e2e || true
           SECRET_KEY='proxbox-e2e-secret-key-proxbox-e2e-secret-key-proxbox-e2e-secret-key'
-          NETBOX_PROXBOX_TARGET='netbox-proxbox==0.0.17'
+          NETBOX_PROXBOX_TARGET='https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.18.tar.gz'
           DEV_OVERRIDES='git+https://github.com/emersonfelipesp/netbox-sdk.git@main git+https://github.com/emersonfelipesp/proxmox-sdk.git@main'
 
           docker rm -f netbox-e2e-postgres netbox-e2e-redis netbox-e2e-http proxmox-e2e-mock proxbox-e2e 2>/dev/null || true
@@ -634,7 +634,7 @@ jobs:
           set -eux
           docker network create proxbox-e2e || true
           SECRET_KEY='proxbox-e2e-secret-key-proxbox-e2e-secret-key-proxbox-e2e-secret-key'
-          NETBOX_PROXBOX_TARGET='netbox-proxbox==0.0.17'
+          NETBOX_PROXBOX_TARGET='https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.18.tar.gz'
 
           docker rm -f netbox-e2e-postgres netbox-e2e-redis netbox-e2e-http proxmox-e2e-mock proxbox-e2e 2>/dev/null || true
 

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -361,7 +361,7 @@ jobs:
           set -eux
           docker network create proxbox-e2e || true
           SECRET_KEY='proxbox-e2e-secret-key-proxbox-e2e-secret-key-proxbox-e2e-secret-key'
-          NETBOX_PROXBOX_TARGET='https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.16rc11.tar.gz'
+          NETBOX_PROXBOX_TARGET='https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.17.tar.gz'
           DEV_OVERRIDES='git+https://github.com/emersonfelipesp/netbox-sdk.git@main git+https://github.com/emersonfelipesp/proxmox-sdk.git@main'
 
           docker rm -f netbox-e2e-postgres netbox-e2e-redis netbox-e2e-http proxmox-e2e-mock proxbox-e2e 2>/dev/null || true
@@ -634,7 +634,7 @@ jobs:
           set -eux
           docker network create proxbox-e2e || true
           SECRET_KEY='proxbox-e2e-secret-key-proxbox-e2e-secret-key-proxbox-e2e-secret-key'
-          NETBOX_PROXBOX_TARGET='https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.16rc11.tar.gz'
+          NETBOX_PROXBOX_TARGET='https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.17.tar.gz'
 
           docker rm -f netbox-e2e-postgres netbox-e2e-redis netbox-e2e-http proxmox-e2e-mock proxbox-e2e 2>/dev/null || true
 

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -361,7 +361,7 @@ jobs:
           set -eux
           docker network create proxbox-e2e || true
           SECRET_KEY='proxbox-e2e-secret-key-proxbox-e2e-secret-key-proxbox-e2e-secret-key'
-          NETBOX_PROXBOX_TARGET='https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.17.tar.gz'
+          NETBOX_PROXBOX_TARGET='netbox-proxbox==0.0.17'
           DEV_OVERRIDES='git+https://github.com/emersonfelipesp/netbox-sdk.git@main git+https://github.com/emersonfelipesp/proxmox-sdk.git@main'
 
           docker rm -f netbox-e2e-postgres netbox-e2e-redis netbox-e2e-http proxmox-e2e-mock proxbox-e2e 2>/dev/null || true
@@ -634,7 +634,7 @@ jobs:
           set -eux
           docker network create proxbox-e2e || true
           SECRET_KEY='proxbox-e2e-secret-key-proxbox-e2e-secret-key-proxbox-e2e-secret-key'
-          NETBOX_PROXBOX_TARGET='https://github.com/emersonfelipesp/netbox-proxbox/archive/refs/tags/v0.0.17.tar.gz'
+          NETBOX_PROXBOX_TARGET='netbox-proxbox==0.0.17'
 
           docker rm -f netbox-e2e-postgres netbox-e2e-redis netbox-e2e-http proxmox-e2e-mock proxbox-e2e 2>/dev/null || true
 


### PR DESCRIPTION
## Summary

- Updates `publish-testpypi.yml` to install `netbox-proxbox v0.0.17` (was `v0.0.16rc11`) in both the TestPyPI validation lane and the PyPI candidate lane
- Updates `.github/CLAUDE.md` dev-mode description to reference the current `v0.0.17` plugin release

## Context

`proxbox-api v0.0.14` ships full Proxmox VE 9.2 support (SDN fabrics/route-maps/prefix-lists, custom CPU models, HA arm/disarm, extended node config). The companion `netbox-proxbox v0.0.18` (PR #494 in that repo) adds the matching Django models and sync services. This PR aligns the CI workflow references so the TestPyPI/PyPI validation lanes install a released (v0.0.17) version of the plugin rather than a stale rc11 tarball.

## Test plan

- [ ] CI workflow YAML lints cleanly
- [ ] `uv run pytest tests/ -q` — existing backend tests remain green