### PR TITLE
fix: use _parse_proxmox_kv_flag for QEMU agent checks in sync_vm (#491)

### DIFF
--- a/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
+++ b/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
@@ -37,6 +37,7 @@ from proxbox_api.proxmox_to_netbox.models import (
     NetBoxVirtualMachineInterfaceSyncState,
     NetBoxVlanSyncState,
     ProxmoxVmConfigInput,
+    _parse_proxmox_kv_flag,
 )
 from proxbox_api.routes.extras import CreateCustomFieldsDep
 from proxbox_api.routes.proxmox import get_vm_config
@@ -157,7 +158,7 @@ async def _resolve_vm_dns_name(
     if vm_type != "qemu" or proxmox_session is None or not node or vmid is None:
         return None
 
-    if isinstance(vm_config, dict) and not vm_config.get("agent"):
+    if isinstance(vm_config, dict) and not _parse_proxmox_kv_flag(vm_config.get("agent")):
         return None
 
     try:
@@ -2464,7 +2465,7 @@ async def create_only_vm_interfaces(  # noqa: C901
             logger.warning("Could not fetch VM config for %s (vmid=%s): %s", vm_name, vmid, exc)
 
         guest_agent_interfaces: list[dict[str, object]] = []
-        if vm_type == "qemu" and vm_config.get("agent"):
+        if vm_type == "qemu" and _parse_proxmox_kv_flag(vm_config.get("agent")):
             if proxmox_session and resource_node:
                 guest_agent_interfaces = (
                     await get_qemu_guest_agent_network_interfaces(
@@ -2965,7 +2966,7 @@ async def create_only_vm_ip_addresses(  # noqa: C901
             )
 
         guest_agent_interfaces: list[dict[str, object]] = []
-        if vm_type == "qemu" and vm_config.get("agent"):
+        if vm_type == "qemu" and _parse_proxmox_kv_flag(vm_config.get("agent")):
             if proxmox_session and resource_node:
                 guest_agent_interfaces = (
                     await get_qemu_guest_agent_network_interfaces(

--- a/tests/test_qemu_guest_agent_sync.py
+++ b/tests/test_qemu_guest_agent_sync.py
@@ -987,7 +987,9 @@ def test_agent_kv_flag_disabled_skips_guest_agent_fetch(monkeypatch):
     )
     guest_agent_calls: list = []
     primary_ip_calls: list = []
-    _install_ip_only_patches(monkeypatch, vm_config=data["vm_config"], primary_ip_calls=primary_ip_calls)
+    _install_ip_only_patches(
+        monkeypatch, vm_config=data["vm_config"], primary_ip_calls=primary_ip_calls
+    )
 
     async def _spy_guest_ifaces(*args, **kwargs):
         guest_agent_calls.append(args)
@@ -1009,9 +1011,7 @@ def test_agent_kv_flag_disabled_skips_guest_agent_fetch(monkeypatch):
         )
     )
 
-    assert guest_agent_calls == [], (
-        "Guest agent must not be fetched when agent KV flag head is '0'"
-    )
+    assert guest_agent_calls == [], "Guest agent must not be fetched when agent KV flag head is '0'"
 
 
 def test_agent_kv_flag_enabled_calls_guest_agent_fetch(monkeypatch):
@@ -1024,7 +1024,9 @@ def test_agent_kv_flag_enabled_calls_guest_agent_fetch(monkeypatch):
     )
     guest_agent_calls: list = []
     primary_ip_calls: list = []
-    _install_ip_only_patches(monkeypatch, vm_config=data["vm_config"], primary_ip_calls=primary_ip_calls)
+    _install_ip_only_patches(
+        monkeypatch, vm_config=data["vm_config"], primary_ip_calls=primary_ip_calls
+    )
 
     async def _spy_guest_ifaces(*args, **kwargs):
         guest_agent_calls.append(args)
@@ -1046,6 +1048,4 @@ def test_agent_kv_flag_enabled_calls_guest_agent_fetch(monkeypatch):
         )
     )
 
-    assert len(guest_agent_calls) == 1, (
-        "Guest agent must be fetched when agent KV flag head is '1'"
-    )
+    assert len(guest_agent_calls) == 1, "Guest agent must be fetched when agent KV flag head is '1'"

--- a/tests/test_qemu_guest_agent_sync.py
+++ b/tests/test_qemu_guest_agent_sync.py
@@ -928,3 +928,124 @@ def test_vm_only_ip_sync_prefers_ipv4_primary_when_guest_reports_ipv6_first(monk
     # IPv4 is listed first because ipv4 is the preferred family.
     assert primary_ip_calls[0]["primary_ip_id"] == 77
     assert primary_ip_calls[0]["primary_ip_preference"] == "ipv4"
+
+
+def _install_ip_only_patches(monkeypatch, *, vm_config: dict, primary_ip_calls: list):
+    """Install the minimal set of monkeypatches needed by create_only_vm_ip_addresses."""
+
+    def _fake_get_vm_config(*args, **kwargs):
+        return vm_config
+
+    async def _fake_bulk_reconcile_ips(nb, payloads, **_kwargs):
+        return [{"id": 77, "address": p.get("address", "")} for p in payloads]
+
+    async def _fake_rest_list(*args, **kwargs):
+        return [{"id": 66, "name": "net0", "virtual_machine": 55}]
+
+    async def _fake_rest_first(*args, **kwargs):
+        return {"id": 77, "address": "10.0.0.20/24"}
+
+    async def _fake_set_primary_ip(**kwargs):
+        primary_ip_calls.append(kwargs)
+        return True
+
+    async def _fake_resolve_netbox_vm(*args, **kwargs):
+        return {"id": 55, "name": "vm01"}
+
+    async def _fake_load_snapshot(nb):
+        return [{"id": 55, "name": "vm01", "custom_fields": {"proxmox_vm_id": 101}}]
+
+    for attr, val in [
+        ("get_vm_config", _fake_get_vm_config),
+        ("resolve_vm_sync_concurrency", lambda: 1),
+        ("_resolve_netbox_virtual_machine_by_proxmox_id", _fake_resolve_netbox_vm),
+        ("_load_netbox_virtual_machine_snapshot", _fake_load_snapshot),
+    ]:
+        monkeypatch.setattr(
+            f"proxbox_api.routes.virtualization.virtual_machines.sync_vm.{attr}",
+            val,
+        )
+    monkeypatch.setattr("proxbox_api.netbox_rest.rest_list_async", _fake_rest_list)
+    monkeypatch.setattr("proxbox_api.netbox_rest.rest_first_async", _fake_rest_first)
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.network.bulk_reconcile_vm_interface_ips",
+        _fake_bulk_reconcile_ips,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.vm_network.set_primary_ip",
+        _fake_set_primary_ip,
+    )
+
+
+def test_agent_kv_flag_disabled_skips_guest_agent_fetch(monkeypatch):
+    """agent='0,fstrim_cloned_disks=1' must NOT trigger guest-agent fetch (closes #491)."""
+    data = _vm_sync_inputs(
+        {
+            "agent": "0,fstrim_cloned_disks=1",
+            "net0": "virtio=AA:BB:CC:DD:EE:FF,bridge=vmbr0,ip=10.0.0.20/24",
+        }
+    )
+    guest_agent_calls: list = []
+    primary_ip_calls: list = []
+    _install_ip_only_patches(monkeypatch, vm_config=data["vm_config"], primary_ip_calls=primary_ip_calls)
+
+    async def _spy_guest_ifaces(*args, **kwargs):
+        guest_agent_calls.append(args)
+        return []
+
+    monkeypatch.setattr(
+        "proxbox_api.routes.virtualization.virtual_machines.sync_vm.get_qemu_guest_agent_network_interfaces",
+        _spy_guest_ifaces,
+    )
+
+    asyncio.run(
+        create_only_vm_ip_addresses(
+            netbox_session=data["netbox_session"],
+            pxs=data["pxs"],
+            cluster_status=data["cluster_status"],
+            cluster_resources=data["cluster_resources"],
+            custom_fields=data["custom_fields"],
+            tag=data["tag"],
+        )
+    )
+
+    assert guest_agent_calls == [], (
+        "Guest agent must not be fetched when agent KV flag head is '0'"
+    )
+
+
+def test_agent_kv_flag_enabled_calls_guest_agent_fetch(monkeypatch):
+    """agent='1,fstrim_cloned_disks=1' MUST trigger guest-agent fetch (closes #491)."""
+    data = _vm_sync_inputs(
+        {
+            "agent": "1,fstrim_cloned_disks=1",
+            "net0": "virtio=AA:BB:CC:DD:EE:FF,bridge=vmbr0",
+        }
+    )
+    guest_agent_calls: list = []
+    primary_ip_calls: list = []
+    _install_ip_only_patches(monkeypatch, vm_config=data["vm_config"], primary_ip_calls=primary_ip_calls)
+
+    async def _spy_guest_ifaces(*args, **kwargs):
+        guest_agent_calls.append(args)
+        return []
+
+    monkeypatch.setattr(
+        "proxbox_api.routes.virtualization.virtual_machines.sync_vm.get_qemu_guest_agent_network_interfaces",
+        _spy_guest_ifaces,
+    )
+
+    asyncio.run(
+        create_only_vm_ip_addresses(
+            netbox_session=data["netbox_session"],
+            pxs=data["pxs"],
+            cluster_status=data["cluster_status"],
+            cluster_resources=data["cluster_resources"],
+            custom_fields=data["custom_fields"],
+            tag=data["tag"],
+        )
+    )
+
+    assert len(guest_agent_calls) == 1, (
+        "Guest agent must be fetched when agent KV flag head is '1'"
+    )


### PR DESCRIPTION
## Summary

- **Root cause**: Three agent-enabled guards in `sync_vm.py` used a raw `vm_config.get("agent")` truthy check. Proxmox VE returns the `agent` config field as a KV string like `"1,fstrim_cloned_disks=1"` or `"0,fstrim_cloned_disks=1"`. The raw check treats `"0,fstrim_cloned_disks=1"` as truthy (non-empty string), incorrectly triggering guest-agent fetches when the agent is explicitly disabled. The existing `_parse_proxmox_kv_flag` helper already handles this correctly but was only wired up in the `create_virtual_machines` path via `ProxmoxVmConfigInput.qemu_agent_enabled`.
- **Fix**: Replace all three raw checks with `_parse_proxmox_kv_flag(vm_config.get("agent"))` in `_resolve_vm_dns_name`, `create_only_vm_interfaces`, and `create_only_vm_ip_addresses`.
- **Tests**: Add two regression tests that drive `create_only_vm_ip_addresses` with `agent="0,fstrim_cloned_disks=1"` (must skip guest agent) and `agent="1,fstrim_cloned_disks=1"` (must call guest agent).

## Test plan

- [x] `uv run pytest tests/test_qemu_guest_agent_sync.py` — 16 passed (includes 2 new tests)
- [x] `uv run pytest tests/test_qemu_guest_agent_sync.py tests/test_vm_sync.py tests/test_qemu_guest_agent_helpers.py tests/test_proxmox_vm_config_input.py` — 115 passed
- [x] `uv run ruff check proxbox_api/routes/virtualization/virtual_machines/sync_vm.py tests/test_qemu_guest_agent_sync.py` — all checks passed

Closes #491