### PR TITLE
fix: sync CD-ROM drives to NetBox with size=0; fix fallback lookup filter (#157)

### DIFF
--- a/proxbox_api/netbox_rest.py
+++ b/proxbox_api/netbox_rest.py
@@ -1101,6 +1101,7 @@ async def _rest_reconcile_async_impl(  # noqa: C901
     patchable_fields: set[str] | frozenset[str] | None = None,
     nullable_fields: set[str] | frozenset[str] | None = None,
     strict_lookup: bool = False,
+    lookup_query_field_map: dict[str, str] | None = None,
 ) -> tuple[RestRecord, ReconcileStatus]:
     """Internal: reconcile and return ``(record, status)``.
 
@@ -1122,7 +1123,15 @@ async def _rest_reconcile_async_impl(  # noqa: C901
             [lookup] if strict_lookup else _candidate_reuse_lookups(lookup, desired_payload)
         )
         for candidate in candidates:
-            existing_record = await rest_first_async(nb, path, query={**candidate, "limit": 2})
+            if lookup_query_field_map:
+                query_candidate = {
+                    lookup_query_field_map.get(k, k): v for k, v in candidate.items()
+                }
+            else:
+                query_candidate = candidate
+            existing_record = await rest_first_async(
+                nb, path, query={**query_candidate, "limit": 2}
+            )
             if existing_record:
                 return existing_record
         return None
@@ -1234,6 +1243,7 @@ async def rest_reconcile_async(
     patchable_fields: set[str] | frozenset[str] | None = None,
     nullable_fields: set[str] | frozenset[str] | None = None,
     strict_lookup: bool = False,
+    lookup_query_field_map: dict[str, str] | None = None,
 ) -> RestRecord:
     """Reconcile a NetBox record with the desired payload.
 
@@ -1252,6 +1262,13 @@ async def rest_reconcile_async(
             Use this to clear stale FK or choice values that are no longer managed
             by this sync path (e.g. the VMInterface ``bridge`` FK after switching
             to the ``proxbox_bridge`` custom field).
+        lookup_query_field_map: Optional mapping of payload field names to the
+            corresponding NetBox filter query parameter names used in GET requests.
+            For example ``{"virtual_machine": "virtual_machine_id"}`` maps the
+            integer FK field ``virtual_machine`` in the payload to the
+            ``virtual_machine_id`` query parameter that NetBox uses for integer-ID
+            filtering.  Only applies to the ``_find_existing`` GET query; the
+            payload keys used for CREATE/PATCH are not affected.
     """
     record, _ = await _rest_reconcile_async_impl(
         nb,
@@ -1263,6 +1280,7 @@ async def rest_reconcile_async(
         patchable_fields=patchable_fields,
         nullable_fields=nullable_fields,
         strict_lookup=strict_lookup,
+        lookup_query_field_map=lookup_query_field_map,
     )
     return record
 
@@ -1278,6 +1296,7 @@ async def rest_reconcile_async_with_status(
     patchable_fields: set[str] | frozenset[str] | None = None,
     nullable_fields: set[str] | frozenset[str] | None = None,
     strict_lookup: bool = False,
+    lookup_query_field_map: dict[str, str] | None = None,
 ) -> ReconcileResult:
     """Reconcile a NetBox record and report ``created`` / ``updated`` / ``unchanged``.
 
@@ -1295,6 +1314,7 @@ async def rest_reconcile_async_with_status(
         patchable_fields=patchable_fields,
         nullable_fields=nullable_fields,
         strict_lookup=strict_lookup,
+        lookup_query_field_map=lookup_query_field_map,
     )
     return ReconcileResult(record=record, status=status)
 
@@ -1747,6 +1767,7 @@ async def rest_bulk_reconcile_async(  # noqa: C901
     batch_delay_ms: int | None = None,
     selector: Callable[[list[RestRecord]], RestRecord | None] | None = None,
     base_query: dict[str, object] | None = None,
+    lookup_query_field_map: dict[str, str] | None = None,
 ) -> BulkReconcileResult:
     if not payloads:
         return BulkReconcileResult(records=[], created=0, updated=0, unchanged=0, failed=0)
@@ -1879,6 +1900,7 @@ async def rest_bulk_reconcile_async(  # noqa: C901
                         schema=schema,
                         current_normalizer=current_normalizer,
                         patchable_fields=patchable_fields,
+                        lookup_query_field_map=lookup_query_field_map,
                     )
                     records.append(record)
                     created += 1

--- a/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
+++ b/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
@@ -960,7 +960,7 @@ async def _create_vm_disk_parallel(
             payload={
                 "virtual_machine": virtual_machine.get("id"),
                 "name": disk_entry.name,
-                "size": disk_entry.size,
+                "size": disk_entry.size_mb,
                 "storage": storage_record.get("id") if storage_record else None,
                 "description": disk_entry.description,
                 "tags": tag_refs,

--- a/proxbox_api/services/sync/virtual_disks.py
+++ b/proxbox_api/services/sync/virtual_disks.py
@@ -278,7 +278,7 @@ async def create_virtual_disks(  # noqa: C901
                 disk_payload: dict[str, object] = {
                     "virtual_machine": vm_id,
                     "name": disk_entry.name,
-                    "size": disk_entry.size,
+                    "size": disk_entry.size_mb,
                     "description": disk_entry.description,
                     "tags": tag_refs,
                 }
@@ -302,6 +302,7 @@ async def create_virtual_disks(  # noqa: C901
                         "custom_fields": record.get("custom_fields"),
                     },
                     base_query={"virtual_machine_id": vm_id},
+                    lookup_query_field_map={"virtual_machine": "virtual_machine_id"},
                 )
                 disks_created = bulk_result.created
                 disks_updated = bulk_result.updated

--- a/proxbox_api/services/sync/vm_network.py
+++ b/proxbox_api/services/sync/vm_network.py
@@ -324,7 +324,7 @@ async def sync_vm_disks(
                 payload={
                     "virtual_machine": vm_id,
                     "name": disk_entry.name,
-                    "size": disk_entry.size,
+                    "size": disk_entry.size_mb,
                     "storage": storage_record.get("id") if storage_record else None,
                     "description": disk_entry.description,
                     "tags": tag_refs,

--- a/tests/test_virtual_disks_sync.py
+++ b/tests/test_virtual_disks_sync.py
@@ -79,3 +79,150 @@ def test_create_virtual_disks_uses_custom_fields_proxmox_vm_id(monkeypatch):
     assert reconciled_payloads[0]["virtual_machine"] == 7
     assert reconciled_payloads[0]["name"] == "scsi0"
     assert reconciled_payloads[0].get("custom_fields", {}).get("proxbox_storage_id") == 42
+
+
+def test_cdrom_disk_is_included_with_size_zero(monkeypatch):
+    """CD-ROM drives (size=None) must appear in the reconcile payloads with size=0.
+
+    Regression test for GH#157 / GH#145: ide0 with media=cdrom has no size
+    field.  Previously the entry was skipped or sent with size=None, causing
+    NetBox to reject with 'size: This field is required.'  The fix uses
+    ProxmoxDiskEntry.size_mb which returns 0 for null-size entries, so CD-ROM
+    drives are created in NetBox with size=0 (valid for PositiveIntegerField).
+    """
+    reconciled_payloads: list[dict] = []
+    bulk_reconcile_kwargs: list[dict] = []
+
+    async def _fake_rest_list(_nb, _path, query=None):
+        if _path == "/api/virtualization/virtual-machines/":
+            return [
+                {
+                    "id": 38,
+                    "name": "vm-cdrom",
+                    "cluster": {"name": "cluster-a"},
+                    "custom_fields": {"proxmox_vm_id": 124},
+                }
+            ]
+        if _path == "/api/plugins/proxbox/storage/":
+            return []
+        return []
+
+    async def _fake_resolve_vm_config(**kwargs):
+        # VM config has a regular disk (scsi0) and a CD-ROM drive (ide0).
+        return {
+            "scsi0": "local-lvm:vm-124-disk-0,size=32G",
+            "ide0": "none,media=cdrom",
+        }
+
+    async def _fake_bulk_reconcile(_nb, _path, *, payloads, **kwargs):
+        reconciled_payloads.extend(payloads)
+        bulk_reconcile_kwargs.append(kwargs)
+        return SimpleNamespace(records=[], created=len(payloads), updated=0, unchanged=0, failed=0)
+
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.virtual_disks.rest_list_async",
+        _fake_rest_list,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.virtual_disks.resolve_vm_config",
+        _fake_resolve_vm_config,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.virtual_disks.rest_bulk_reconcile_async",
+        _fake_bulk_reconcile,
+    )
+
+    result = asyncio.run(
+        create_virtual_disks(
+            netbox_session=object(),
+            pxs=[],
+            cluster_status=[],
+            cluster_resources=[
+                {
+                    "cluster-a": [
+                        {"type": "qemu", "name": "vm-cdrom", "vmid": "124", "node": "pve01"}
+                    ]
+                }
+            ],
+            tag=None,
+            use_websocket=False,
+            use_css=False,
+        )
+    )
+
+    # Both disks must be in the payloads: scsi0 with real size, ide0 (CD-ROM) with size=0.
+    assert len(reconciled_payloads) == 2
+    names = {p["name"]: p["size"] for p in reconciled_payloads}
+    assert names["scsi0"] == 32 * 1024  # 32 GiB in MiB
+    assert names["ide0"] == 0  # CD-ROM → size_mb returns 0
+    assert result["count"] == 1
+    assert result["created"] == 1
+
+    # lookup_query_field_map must be forwarded so the fallback GET query uses
+    # virtual_machine_id instead of virtual_machine (GH#157 bug 2).
+    assert bulk_reconcile_kwargs[0].get("lookup_query_field_map") == {
+        "virtual_machine": "virtual_machine_id"
+    }
+
+
+def test_all_cdrom_vm_synced_as_zero_size(monkeypatch):
+    """A VM with only CD-ROM drives still creates disk entries in NetBox (size=0)."""
+    reconciled_payloads: list[dict] = []
+
+    async def _fake_rest_list(_nb, _path, query=None):
+        if _path == "/api/virtualization/virtual-machines/":
+            return [
+                {
+                    "id": 55,
+                    "name": "vm-nodata",
+                    "cluster": {"name": "cluster-b"},
+                    "custom_fields": {"proxmox_vm_id": 55},
+                }
+            ]
+        if _path == "/api/plugins/proxbox/storage/":
+            return []
+        return []
+
+    async def _fake_resolve_vm_config(**kwargs):
+        return {"ide0": "none,media=cdrom", "ide2": "local:iso/ubuntu.iso,media=cdrom"}
+
+    async def _fake_bulk_reconcile(_nb, _path, *, payloads, **kwargs):
+        reconciled_payloads.extend(payloads)
+        return SimpleNamespace(records=[], created=len(payloads), updated=0, unchanged=0, failed=0)
+
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.virtual_disks.rest_list_async",
+        _fake_rest_list,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.virtual_disks.resolve_vm_config",
+        _fake_resolve_vm_config,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.virtual_disks.rest_bulk_reconcile_async",
+        _fake_bulk_reconcile,
+    )
+
+    result = asyncio.run(
+        create_virtual_disks(
+            netbox_session=object(),
+            pxs=[],
+            cluster_status=[],
+            cluster_resources=[
+                {
+                    "cluster-b": [
+                        {"type": "qemu", "name": "vm-nodata", "vmid": "55", "node": "pve01"}
+                    ]
+                }
+            ],
+            tag=None,
+            use_websocket=False,
+            use_css=False,
+        )
+    )
+
+    # Both CD-ROM drives must be synced to NetBox with size=0.
+    assert len(reconciled_payloads) == 2
+    assert all(p["size"] == 0 for p in reconciled_payloads)
+    assert result["count"] == 1
+    assert result["created"] == 1


### PR DESCRIPTION
Fixes #157. Also resolves the same reporter's closed issue #145.

## Summary

Two bugs caused virtual disk sync to fail with `{'size': ['This field is required.']}` when a VM has CD-ROM drives.

- **CD-ROM drives synced as size=0** — CD-ROM entries (`ide0: none,media=cdrom`) are parsed with `size=None`. Instead of skipping them, all three sync paths now use `disk_entry.size_mb` (a computed property that returns `0` for null-size entries). `size=0` is valid for NetBox's `PositiveIntegerField` on `VirtualDisk`, so CD-ROM drives are now created in NetBox rather than dropped or rejected.

- **Fix fallback reconcile filter** — added `lookup_query_field_map` parameter to `rest_bulk_reconcile_async` / `rest_reconcile_async` / `_rest_reconcile_async_impl`. The map remaps field names only in the `_find_existing()` GET query, not in CREATE/PATCH payloads. Virtual disk sync passes `{"virtual_machine": "virtual_machine_id"}` so the fallback uses `?virtual_machine_id=38` (integer FK filter) instead of `?virtual_machine=38` (name/slug filter, which NetBox rejects).

## Root cause

1. `parse_disk_entry()` returns `ProxmoxDiskEntry(size=None)` for CD-ROM drives. The payload was sent with `size=None`; `model_dump(exclude_none=True)` dropped it; NetBox rejected: `{'size': ['This field is required.']}`. Fix: use `disk_entry.size_mb` which returns `0` for null-size entries — NetBox `PositiveIntegerField` accepts `0`.

2. When the bulk create failed (due to bug 1), the fallback built a GET query from `lookup_fields=["virtual_machine", "name"]` sending `?virtual_machine=38`. NetBox interprets `virtual_machine` as a name/slug filter; the correct integer-ID filter is `virtual_machine_id`. Fix: `lookup_query_field_map={"virtual_machine": "virtual_machine_id"}`.

## Test plan

- [x] `test_cdrom_disk_is_included_with_size_zero` — VM with scsi0 (32G) + ide0 (CD-ROM): both in payloads; ide0 has `size=0`; `lookup_query_field_map` forwarded
- [x] `test_all_cdrom_vm_synced_as_zero_size` — VM with only CD-ROM drives: all synced to NetBox with `size=0`
- [x] `test_create_virtual_disks_uses_custom_fields_proxmox_vm_id` — existing test still passes
- [x] All 115 disk/network/reconcile tests pass