### PR TITLE
fix: prevent CD-ROM PATCH storm, fix bulk reconcile counter and strict lookup

### DIFF
--- a/proxbox_api/netbox_rest.py
+++ b/proxbox_api/netbox_rest.py
@@ -1671,6 +1671,9 @@ class BulkReconcilePhase:
     batch_size: int | None = None
     batch_delay_ms: int | None = None
     selector: Callable[[list[RestRecord]], RestRecord | None] | None = None
+    lookup_query_field_map: dict[str, str] | None = None
+    strict_lookup: bool = False
+    nullable_fields: set[str] | frozenset[str] | None = None
 
 
 def _normalize_bulk_batch_size(batch_size: int | None) -> int:
@@ -1768,6 +1771,8 @@ async def rest_bulk_reconcile_async(  # noqa: C901
     selector: Callable[[list[RestRecord]], RestRecord | None] | None = None,
     base_query: dict[str, object] | None = None,
     lookup_query_field_map: dict[str, str] | None = None,
+    strict_lookup: bool = False,
+    nullable_fields: set[str] | frozenset[str] | None = None,
 ) -> BulkReconcileResult:
     if not payloads:
         return BulkReconcileResult(records=[], created=0, updated=0, unchanged=0, failed=0)
@@ -1862,6 +1867,10 @@ async def rest_bulk_reconcile_async(  # noqa: C901
             for key, value in desired_payload.items()
             if current_payload.get(key) != value
         }
+        if nullable_fields:
+            for field in nullable_fields:
+                if current_payload.get(field) is not None and field not in patch_payload:
+                    patch_payload[field] = None
         if patchable_fields is not None:
             allowed = {str(field) for field in patchable_fields}
             patch_payload = {key: value for key, value in patch_payload.items() if key in allowed}
@@ -1872,6 +1881,7 @@ async def rest_bulk_reconcile_async(  # noqa: C901
             unchanged += 1
 
     created = 0
+    updated = 0
     failed = 0
     for offset in range(0, len(to_create), resolved_batch_size):
         batch = to_create[offset : offset + resolved_batch_size]
@@ -1892,7 +1902,7 @@ async def rest_bulk_reconcile_async(  # noqa: C901
             )
             for payload, lookup in batch:
                 try:
-                    record = await rest_reconcile_async(
+                    reconcile_result = await rest_reconcile_async_with_status(
                         nb,
                         path,
                         lookup=lookup,
@@ -1901,9 +1911,15 @@ async def rest_bulk_reconcile_async(  # noqa: C901
                         current_normalizer=current_normalizer,
                         patchable_fields=patchable_fields,
                         lookup_query_field_map=lookup_query_field_map,
+                        strict_lookup=strict_lookup,
                     )
-                    records.append(record)
-                    created += 1
+                    records.append(reconcile_result.record)
+                    if reconcile_result.status == "created":
+                        created += 1
+                    elif reconcile_result.status == "updated":
+                        updated += 1
+                    else:
+                        unchanged += 1
                 except Exception as reconcile_exc:
                     logger.error(
                         "Per-item reconcile failed for %s with lookup %s: %s",
@@ -1916,7 +1932,6 @@ async def rest_bulk_reconcile_async(  # noqa: C901
         if offset + resolved_batch_size < len(to_create) and resolved_batch_delay_ms > 0:
             await asyncio.sleep(resolved_batch_delay_ms / 1000.0)
 
-    updated = 0
     for offset in range(0, len(to_patch), resolved_batch_size):
         batch = to_patch[offset : offset + resolved_batch_size]
         none_id_count = sum(1 for record, _, _ in batch if record.id is None)
@@ -1999,6 +2014,9 @@ async def rest_bulk_reconcile_phases_async(
             batch_size=phase.batch_size,
             batch_delay_ms=phase.batch_delay_ms,
             selector=phase.selector,
+            lookup_query_field_map=phase.lookup_query_field_map,
+            strict_lookup=phase.strict_lookup,
+            nullable_fields=phase.nullable_fields,
         )
     return results
 

--- a/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
+++ b/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
@@ -970,12 +970,14 @@ async def _create_vm_disk_parallel(
             current_normalizer=lambda record: {
                 "virtual_machine": record.get("virtual_machine"),
                 "name": record.get("name"),
-                "size": record.get("size"),
+                "size": record.get("size") if record.get("size") is not None else 0,
                 "storage": record.get("storage"),
                 "description": record.get("description"),
                 "tags": record.get("tags"),
                 "custom_fields": record.get("custom_fields"),
             },
+            strict_lookup=True,
+            nullable_fields={"storage"},
         )
         return disk
     except Exception as exc:

--- a/proxbox_api/services/sync/individual/virtual_disk_sync.py
+++ b/proxbox_api/services/sync/individual/virtual_disk_sync.py
@@ -212,12 +212,14 @@ async def sync_virtual_disk_individual(
             current_normalizer=lambda record: {
                 "virtual_machine": record.get("virtual_machine"),
                 "name": record.get("name"),
-                "size": record.get("size"),
+                "size": record.get("size") if record.get("size") is not None else 0,
                 "storage": record.get("storage"),
                 "description": record.get("description"),
                 "tags": record.get("tags"),
                 "custom_fields": record.get("custom_fields"),
             },
+            strict_lookup=True,
+            nullable_fields={"storage"},
         )
 
         netbox_object = disk_record.serialize() if hasattr(disk_record, "serialize") else None

--- a/proxbox_api/services/sync/virtual_disks.py
+++ b/proxbox_api/services/sync/virtual_disks.py
@@ -279,6 +279,7 @@ async def create_virtual_disks(  # noqa: C901
                     "virtual_machine": vm_id,
                     "name": disk_entry.name,
                     "size": disk_entry.size_mb,
+                    "storage": storage_id,
                     "description": disk_entry.description,
                     "tags": tag_refs,
                 }
@@ -296,13 +297,16 @@ async def create_virtual_disks(  # noqa: C901
                     current_normalizer=lambda record: {
                         "virtual_machine": record.get("virtual_machine"),
                         "name": record.get("name"),
-                        "size": record.get("size"),
+                        "size": record.get("size") if record.get("size") is not None else 0,
+                        "storage": record.get("storage"),
                         "description": record.get("description"),
                         "tags": record.get("tags"),
                         "custom_fields": record.get("custom_fields"),
                     },
                     base_query={"virtual_machine_id": vm_id},
                     lookup_query_field_map={"virtual_machine": "virtual_machine_id"},
+                    strict_lookup=True,
+                    nullable_fields={"storage"},
                 )
                 disks_created = bulk_result.created
                 disks_updated = bulk_result.updated

--- a/proxbox_api/services/sync/vm_network.py
+++ b/proxbox_api/services/sync/vm_network.py
@@ -334,12 +334,14 @@ async def sync_vm_disks(
                 current_normalizer=lambda record: {
                     "virtual_machine": record.get("virtual_machine"),
                     "name": record.get("name"),
-                    "size": record.get("size"),
+                    "size": record.get("size") if record.get("size") is not None else 0,
                     "storage": record.get("storage"),
                     "description": record.get("description"),
                     "tags": record.get("tags"),
                     "custom_fields": record.get("custom_fields"),
                 },
+                strict_lookup=True,
+                nullable_fields={"storage"},
             )
             disk_count += 1
         except Exception as e:

--- a/tests/test_virtual_disks_sync.py
+++ b/tests/test_virtual_disks_sync.py
@@ -226,3 +226,84 @@ def test_all_cdrom_vm_synced_as_zero_size(monkeypatch):
     assert all(p["size"] == 0 for p in reconciled_payloads)
     assert result["count"] == 1
     assert result["created"] == 1
+
+
+def test_cdrom_no_patch_storm_when_existing_has_null_size(monkeypatch):
+    """Re-syncing a CD-ROM disk must not generate a spurious PATCH when the
+    existing NetBox record has size=NULL.
+
+    Without the normalizer fix, comparing desired size=0 against current size=None
+    triggers a PATCH on every sync run. The normalizer must return 0 for None
+    so the comparison sees no diff.
+    """
+    from unittest.mock import MagicMock
+
+    from proxbox_api.netbox_rest import rest_bulk_reconcile_async
+    from proxbox_api.proxmox_to_netbox.models import NetBoxVirtualDiskSyncState
+
+    existing_record = MagicMock()
+    existing_record.id = 10
+    existing_record.serialize.return_value = {
+        "virtual_machine": {"id": 7},
+        "name": "ide0",
+        "size": None,
+        "storage": None,
+        "description": "",
+        "tags": [],
+        "custom_fields": {},
+    }
+
+    patched: list = []
+
+    async def _fake_list_paginated(_nb, _path, *, base_query=None, **kwargs):
+        return [existing_record]
+
+    async def _fake_bulk_create(_nb, _path, entries):
+        return []
+
+    async def _fake_bulk_patch(_nb, _path, entries):
+        patched.extend(entries)
+        return []
+
+    monkeypatch.setattr("proxbox_api.netbox_rest.rest_list_paginated_async", _fake_list_paginated)
+    monkeypatch.setattr("proxbox_api.netbox_rest.rest_bulk_create_async", _fake_bulk_create)
+    monkeypatch.setattr("proxbox_api.netbox_rest.rest_bulk_patch_async", _fake_bulk_patch)
+
+    import asyncio
+
+    result = asyncio.run(
+        rest_bulk_reconcile_async(
+            object(),
+            "/api/virtualization/virtual-disks/",
+            payloads=[
+                {
+                    "virtual_machine": 7,
+                    "name": "ide0",
+                    "size": 0,
+                    "storage": None,
+                    "description": "",
+                    "tags": [],
+                    "custom_fields": {},
+                }
+            ],
+            lookup_fields=["virtual_machine", "name"],
+            schema=NetBoxVirtualDiskSyncState,
+            current_normalizer=lambda record: {
+                "virtual_machine": record.get("virtual_machine"),
+                "name": record.get("name"),
+                "size": record.get("size") if record.get("size") is not None else 0,
+                "storage": record.get("storage"),
+                "description": record.get("description"),
+                "tags": record.get("tags"),
+                "custom_fields": record.get("custom_fields"),
+            },
+            base_query={"virtual_machine_id": 7},
+            lookup_query_field_map={"virtual_machine": "virtual_machine_id"},
+            strict_lookup=True,
+        )
+    )
+
+    assert patched == [], "no PATCH should be issued when existing size=NULL matches desired size=0"
+    assert result.unchanged == 1
+    assert result.created == 0
+    assert result.updated == 0


### PR DESCRIPTION
## Summary

Addresses 8 code-review findings from the GH#157 follow-up review:

- **CD-ROM PATCH storm** — existing NetBox records with `size=NULL` triggered a spurious PATCH on every sync run because the normalizer returned `None` while the desired payload sent `size=0`. All four virtual-disk reconcile sites (bulk, per-VM parallel, vm_network, individual) now normalize `size=None → 0` so the comparison sees no diff.
- **Cross-VM name-only fallback** — added `strict_lookup=True` to all virtual-disk `rest_reconcile_async` / `rest_bulk_reconcile_async` calls so the `_candidate_reuse_lookups` name-only fallback (`{"name":"scsi0"}`) is suppressed, preventing matches across unrelated VMs.
- **Fallback counter overcounting** — the bulk-reconcile create-fallback loop used `created += 1` unconditionally even for PATCH and no-op outcomes. Replaced with `rest_reconcile_async_with_status` and increments the correct counter based on returned status. Also moved `updated = 0` initialization before the create loop.
- **`BulkReconcilePhase` missing `lookup_query_field_map`** — the new param added to `rest_bulk_reconcile_async` was missing from the dataclass and not forwarded in `rest_bulk_reconcile_phases_async`. Added `lookup_query_field_map`, `strict_lookup`, and `nullable_fields` to both.
- **`storage` FK missing from bulk payloads** — `virtual_disks.py` omitted the storage FK that `vm_network.py` already included. Added it and updated the normalizer.
- **Storage FK stale value clearing** — added `nullable_fields={"storage"}` to all virtual-disk reconcile calls so the NetBox storage FK is explicitly cleared when a Proxmox storage disappears.
- **Test coverage** — added `test_cdrom_no_patch_storm_when_existing_has_null_size` which exercises the full `rest_bulk_reconcile_async` path with a pre-seeded record having `size=NULL` and asserts no PATCH is generated.

## Test plan

- [ ] `uv run pytest tests/test_virtual_disks_sync.py` — 4 tests including new regression
- [ ] `uv run pytest tests/test_bulk_sync_error_accounting.py tests/test_individual_sync.py tests/test_patchable_fields.py tests/test_vm_sync.py` — pre-existing tests still pass
- [ ] CI green on this PR