### PR TITLE
Add VM reconciliation parity fixtures and benchmarks

### DIFF
--- a/.github/workflows/rust-reconcile.yml
+++ b/.github/workflows/rust-reconcile.yml
@@ -1,0 +1,84 @@
+name: rust-reconcile
+
+on:
+  push:
+    branches: [main, testing, "v*"]
+  pull_request:
+    branches: [main, testing, "v*"]
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+env:
+  PROXBOX_ENCRYPTION_KEY: proxbox-ci-only-encryption-key-not-a-secret
+
+jobs:
+  test:
+    name: Test (${{ matrix.os }}, Python ${{ matrix.python }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ["3.12", "3.13"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python }}
+
+      - name: Sync proxbox-api dependencies
+        run: uv sync --frozen --extra test --group dev
+
+      - name: Rust unit tests
+        run: cargo test --no-default-features
+        working-directory: proxbox-reconcile-rs
+
+      - name: Install local Rust extension
+        run: uv pip install -e proxbox-reconcile-rs
+
+      - name: Strict Rust/Python parity tests
+        run: uv run pytest tests/reconciliation -q
+        env:
+          PROXBOX_RECONCILIATION_ENGINE: compare
+          PROXBOX_RECONCILIATION_COMPARE_STRICT: "true"
+          XDG_DATA_HOME: ${{ runner.temp }}/xdg-data
+
+  build-wheels:
+    name: Build wheels (${{ matrix.os }}, Python ${{ matrix.python }})
+    runs-on: ${{ matrix.os }}
+    needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ["3.12", "3.13"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Build wheel artifact
+        uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          args: --release --out dist --manifest-path proxbox-reconcile-rs/Cargo.toml
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: proxbox-reconcile-rs-${{ matrix.os }}-py${{ matrix.python }}
+          path: dist/*

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ uv run mkdocs serve   # after syncing with --extra docs
 
 Project documentation is available under `docs/` and built with MkDocs Material.
 
+The VM reconciliation engine is documented in
+[`docs/sync/reconciliation-architecture.md`](docs/sync/reconciliation-architecture.md).
+Python is the default engine; the optional Rust engine is for compare-mode validation and explicit
+opt-in testing.
+
 ### Local docs build
 
 ```bash

--- a/benchmarks/reconciliation/bench_vm_queue.py
+++ b/benchmarks/reconciliation/bench_vm_queue.py
@@ -1,0 +1,171 @@
+"""Benchmark VM reconciliation queue engines."""
+
+# ruff: noqa: E402
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from benchmarks.reconciliation.generate_vm_snapshot import build_vm_dataset
+from proxbox_api.proxmox_to_netbox.models import ProxmoxVmConfigInput
+from proxbox_api.services.sync.reconciliation.rust_bridge import (
+    _input_adapter,
+    _rust_build,
+    build_bridge_input,
+)
+from proxbox_api.services.sync.reconciliation.types import PreparedVMState
+from proxbox_api.services.sync.reconciliation.vm_queue import (
+    _adapt_to_dataclasses,
+    build_vm_operation_queue_python,
+)
+
+
+def main() -> None:
+    """Run the benchmark and print a Markdown timing table."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sizes", nargs="+", type=int, default=[100, 1000, 10000])
+    parser.add_argument("--repeat", type=int, default=3)
+    parser.add_argument("--pathological", action="store_true")
+    args = parser.parse_args()
+
+    rows = []
+    for size in args.sizes:
+        data = build_vm_dataset(size, size, pathological=args.pathological)
+        prepared_vms = [_prepared_state_from_fixture(item) for item in data["prepared_vms"]]
+        snapshot = data["netbox_snapshot"]
+        flags = data["flags"]
+
+        py_ms = _measure_ms(
+            lambda: build_vm_operation_queue_python(prepared_vms, snapshot, **flags),
+            repeat=args.repeat,
+        )
+
+        bridge_payload = build_bridge_input(
+            prepared_vms=prepared_vms,
+            netbox_snapshot=snapshot,
+            flags=flags,
+        )
+        encode_ms = _measure_ms(
+            lambda: _input_adapter.dump_json(bridge_payload), repeat=args.repeat
+        )
+
+        rust_parse_diff_serialize_ms: float | None = None
+        decode_ms: float | None = None
+        adapter_ms: float | None = None
+        full_rust_ms: float | None = None
+
+        if _rust_build is not None:
+            input_bytes = _input_adapter.dump_json(bridge_payload)
+            rust_parse_diff_serialize_ms = _measure_ms(
+                lambda: _rust_build(input_bytes), repeat=args.repeat
+            )
+            output_bytes = _rust_build(input_bytes)
+            decode_ms = _measure_ms(lambda: json.loads(output_bytes), repeat=args.repeat)
+            raw_ops = json.loads(output_bytes)
+            adapter_ms = _measure_ms(
+                lambda: _adapt_to_dataclasses(raw_ops, prepared_vms),
+                repeat=args.repeat,
+            )
+            full_rust_ms = _measure_ms(
+                lambda: _run_full_rust_path(prepared_vms, snapshot, flags),
+                repeat=args.repeat,
+            )
+
+        rows.append(
+            {
+                "size": size,
+                "snapshot": len(snapshot),
+                "python_ms": py_ms,
+                "encode_ms": encode_ms,
+                "rust_native_ms": rust_parse_diff_serialize_ms,
+                "decode_ms": decode_ms,
+                "adapter_ms": adapter_ms,
+                "full_rust_ms": full_rust_ms,
+                "speedup": py_ms / full_rust_ms if full_rust_ms else None,
+            }
+        )
+
+    _print_markdown(rows, rust_available=_rust_build is not None)
+
+
+def _prepared_state_from_fixture(data: dict[str, Any]) -> PreparedVMState:
+    return PreparedVMState(
+        cluster_name=data["cluster_name"],
+        resource=data["resource"],
+        vm_config=data.get("vm_config") or {},
+        vm_config_obj=ProxmoxVmConfigInput.model_validate(data.get("vm_config") or {}),
+        desired_payload=data["desired_payload"],
+        lookup=data.get("lookup") or {},
+        now=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        vm_type=data["vm_type"],
+    )
+
+
+def _run_full_rust_path(
+    prepared_vms: list[PreparedVMState],
+    snapshot: list[dict[str, Any]],
+    flags: dict[str, bool],
+) -> object:
+    if _rust_build is None:
+        raise RuntimeError("proxbox-reconcile-rs is not installed")
+    payload = build_bridge_input(
+        prepared_vms=prepared_vms,
+        netbox_snapshot=snapshot,
+        flags=flags,
+    )
+    input_bytes = _input_adapter.dump_json(payload)
+    output_bytes = _rust_build(input_bytes)
+    raw_ops = json.loads(output_bytes)
+    return _adapt_to_dataclasses(raw_ops, prepared_vms)
+
+
+def _measure_ms(callback: Callable[[], object], *, repeat: int) -> float:
+    samples = []
+    for _ in range(repeat):
+        start = time.perf_counter()
+        callback()
+        samples.append((time.perf_counter() - start) * 1000)
+    return statistics.median(samples)
+
+
+def _format_ms(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.2f}"
+
+
+def _format_speedup(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.2f}x"
+
+
+def _print_markdown(rows: list[dict[str, float | int | None]], *, rust_available: bool) -> None:
+    print("# VM Reconciliation Benchmark")
+    print()
+    print(f"Rust native package installed: {'yes' if rust_available else 'no'}")
+    print()
+    print(
+        "| Prepared | Snapshot | Python diff ms | Pydantic encode ms | "
+        "Rust native ms | JSON decode ms | Adapter ms | Full Rust ms | Speedup |"
+    )
+    print("| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
+    for row in rows:
+        print(
+            f"| {row['size']} | {row['snapshot']} | {_format_ms(row['python_ms'])} | "
+            f"{_format_ms(row['encode_ms'])} | {_format_ms(row['rust_native_ms'])} | "
+            f"{_format_ms(row['decode_ms'])} | {_format_ms(row['adapter_ms'])} | "
+            f"{_format_ms(row['full_rust_ms'])} | {_format_speedup(row['speedup'])} |"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/reconciliation/generate_vm_snapshot.py
+++ b/benchmarks/reconciliation/generate_vm_snapshot.py
@@ -1,0 +1,153 @@
+"""Synthetic VM reconciliation dataset generator."""
+
+from __future__ import annotations
+
+from typing import Any
+
+DEFAULT_FLAGS = {
+    "overwrite_vm_role": True,
+    "overwrite_vm_type": True,
+    "overwrite_vm_tags": True,
+    "overwrite_vm_description": True,
+    "overwrite_vm_custom_fields": True,
+    "supports_virtual_machine_type_field": True,
+}
+
+
+def build_vm_dataset(
+    prepared_count: int,
+    snapshot_count: int | None = None,
+    *,
+    pathological: bool = False,
+) -> dict[str, Any]:
+    """Build a deterministic VM reconciliation dataset."""
+
+    if snapshot_count is None:
+        snapshot_count = prepared_count
+
+    prepared_vms: list[dict[str, Any]] = []
+    snapshot: list[dict[str, Any]] = []
+
+    for index in range(prepared_count):
+        vmid = 1000 + index
+        vm_type = "lxc" if index % 4 == 1 else "qemu"
+        name = f"{vm_type}-{vmid}"
+        desired_memory = 1024 + (index % 8) * 512
+        desired_tags = [99, 200 + (index % 5)] if index % 6 == 0 else [99]
+
+        prepared_vms.append(
+            _prepared_vm_fixture(
+                vmid=vmid,
+                vm_type=vm_type,
+                name=name,
+                memory=desired_memory,
+                tags=desired_tags,
+                cluster={"id": 1} if index % 7 == 0 else 1,
+            )
+        )
+
+        if _should_skip_snapshot(index, pathological):
+            continue
+
+        snapshot_record = _snapshot_vm_fixture(
+            record_id=200000 + index,
+            vmid=vmid,
+            vm_type=vm_type,
+            name=name,
+            memory=desired_memory,
+            tags=[{"id": 77}] if index % 6 == 0 else [{"id": 99}],
+            cluster={"id": 1} if index % 3 else 1,
+        )
+
+        if index % 5 == 2:
+            snapshot_record["memory"] = max(512, desired_memory - 512)
+        if index % 5 == 3:
+            snapshot_record["description"] = "Operator-maintained description"
+        if pathological and index % 11 == 0:
+            snapshot_record["custom_fields"] = {"proxmox_vm_id": "not-an-int"}
+        if pathological and index % 13 == 0:
+            snapshot_record.pop("cluster", None)
+        snapshot.append(snapshot_record)
+
+    while len(snapshot) < snapshot_count:
+        filler_index = len(snapshot) + prepared_count
+        snapshot.append(
+            _snapshot_vm_fixture(
+                record_id=300000 + filler_index,
+                vmid=900000 + filler_index,
+                vm_type="qemu",
+                name=f"orphan-{filler_index}",
+                memory=2048,
+                tags=[{"id": 404}],
+                cluster={"id": 1},
+            )
+        )
+
+    return {
+        "prepared_vms": prepared_vms,
+        "netbox_snapshot": snapshot[:snapshot_count],
+        "flags": dict(DEFAULT_FLAGS),
+    }
+
+
+def _should_skip_snapshot(index: int, pathological: bool) -> bool:
+    if index % 5 == 1:
+        return True
+    return pathological and index % 4 == 0
+
+
+def _prepared_vm_fixture(
+    *,
+    vmid: int,
+    vm_type: str,
+    name: str,
+    memory: int,
+    tags: list[int],
+    cluster: object,
+) -> dict[str, Any]:
+    return {
+        "cluster_name": "cluster-a",
+        "resource": {"name": name, "vmid": vmid, "type": vm_type},
+        "vm_config": {},
+        "desired_payload": {
+            "name": name,
+            "status": "active",
+            "cluster": cluster,
+            "device": 10,
+            "role": 20,
+            "vcpus": 2,
+            "memory": memory,
+            "disk": 30,
+            "tags": tags,
+            "custom_fields": {"proxmox_vm_id": vmid, "proxmox_vm_type": vm_type},
+            "description": "Synced from Proxmox node pve01",
+        },
+        "lookup": {"cf_proxmox_vm_id": vmid, "cluster_id": 1},
+        "vm_type": vm_type,
+    }
+
+
+def _snapshot_vm_fixture(
+    *,
+    record_id: int,
+    vmid: int,
+    vm_type: str,
+    name: str,
+    memory: int | float,
+    tags: list[object],
+    cluster: object,
+) -> dict[str, Any]:
+    return {
+        "id": record_id,
+        "name": name,
+        "status": "active",
+        "cluster": cluster,
+        "device": {"id": 10},
+        "role": {"id": 20},
+        "vcpus": 2.0 if vmid % 9 == 0 else 2,
+        "memory": float(memory) if vmid % 10 == 0 else memory,
+        "disk": 30,
+        "tags": tags,
+        "custom_fields": {"proxmox_vm_id": vmid, "proxmox_vm_type": vm_type},
+        "description": "Synced from Proxmox node pve01",
+    }

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -34,6 +34,55 @@ For the current route and docs contract surface:
 pytest tests/test_generated_proxmox_routes.py tests/test_proxmox_codegen_docs.py tests/test_api_routes.py tests/test_stub_routes.py tests/test_admin_logs.py
 ```
 
+## Rust reconciliation tests
+
+The optional Rust reconciliation package lives in `proxbox-reconcile-rs/`.
+Python remains the default engine, so the normal test suite must pass without the native package.
+
+Run the Python fixture contracts and skip Rust parity when the native package is absent:
+
+```bash
+uv run pytest tests/reconciliation
+```
+
+Run Rust unit tests without the PyO3 extension-module link mode:
+
+```bash
+cd proxbox-reconcile-rs
+cargo test --no-default-features
+```
+
+Install the local native package into the root `uv` environment:
+
+```bash
+uv pip install -e proxbox-reconcile-rs
+```
+
+Run strict compare-mode parity:
+
+```bash
+PROXBOX_RECONCILIATION_ENGINE=compare \
+PROXBOX_RECONCILIATION_COMPARE_STRICT=true \
+uv run pytest tests/reconciliation
+```
+
+Run explicit Rust-engine tests:
+
+```bash
+PROXBOX_RECONCILIATION_ENGINE=rust uv run pytest tests/reconciliation
+```
+
+Run the synthetic benchmark harness:
+
+```bash
+uv run python benchmarks/reconciliation/bench_vm_queue.py --sizes 100 1000 10000
+uv run python benchmarks/reconciliation/bench_vm_queue.py --sizes 10000 --pathological
+```
+
+If compare mode reports mismatches, keep `PROXBOX_RECONCILIATION_ENGINE=python` in production
+and inspect `proxbox_reconcile_mismatch_total` through `/cache/metrics` or
+`/cache/metrics/prometheus`.
+
 For the v0.0.11 surface specifically (HA routes, operational verbs, the
 `allow_writes` gate, and supporting helpers):
 
@@ -218,6 +267,7 @@ python -m compileall proxbox_api
 - `pytest`
 - `python -m compileall proxbox_api`
 - `mkdocs build --strict` (when docs changed)
+- `cargo test --no-default-features` in `proxbox-reconcile-rs` (when Rust changes)
 
 ## Generated Proxmox contract checks
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -205,6 +205,34 @@ Or with `uv`:
 uv add proxbox-api
 ```
 
+### Optional Rust reconciliation engine
+
+VM reconciliation uses the Python engine by default. An optional native package,
+`proxbox-reconcile-rs`, can be installed for compare-mode validation or explicit Rust-engine
+testing after wheels are published.
+
+Once the optional package is published, install with:
+
+```bash
+pip install proxbox-api[rust]
+```
+
+Until the native package is published, install it from a local checkout:
+
+```bash
+uv sync --extra test --group dev
+uv pip install -e proxbox-reconcile-rs
+```
+
+Enable compare mode first:
+
+```bash
+PROXBOX_RECONCILIATION_ENGINE=compare uv run fastapi run proxbox_api.main:app
+```
+
+The production default remains Python. To roll back immediately, unset
+`PROXBOX_RECONCILIATION_ENGINE` or set it to `python`.
+
 Start the server:
 
 ```bash
@@ -230,6 +258,12 @@ Or use `uv`:
 
 ```bash
 uv sync
+```
+
+Install the optional Rust reconciliation package for local parity testing:
+
+```bash
+uv pip install -e proxbox-reconcile-rs
 ```
 
 Run API:

--- a/docs/pt-BR/development/testing.md
+++ b/docs/pt-BR/development/testing.md
@@ -34,6 +34,55 @@ Para a superficie atual de rotas e contratos de docs:
 pytest tests/test_generated_proxmox_routes.py tests/test_proxmox_codegen_docs.py tests/test_api_routes.py tests/test_stub_routes.py tests/test_admin_logs.py
 ```
 
+## Testes da reconciliacao Rust
+
+O pacote Rust opcional fica em `proxbox-reconcile-rs/`. Python continua sendo o engine padrao,
+entao a suite normal deve passar sem o pacote nativo.
+
+Rode os contratos Python das fixtures; a paridade Rust sera pulada se o pacote nativo nao estiver instalado:
+
+```bash
+uv run pytest tests/reconciliation
+```
+
+Rode testes unitarios Rust sem o modo de link `extension-module` do PyO3:
+
+```bash
+cd proxbox-reconcile-rs
+cargo test --no-default-features
+```
+
+Instale o pacote nativo local no ambiente `uv` raiz:
+
+```bash
+uv pip install -e proxbox-reconcile-rs
+```
+
+Rode paridade estrita em compare mode:
+
+```bash
+PROXBOX_RECONCILIATION_ENGINE=compare \
+PROXBOX_RECONCILIATION_COMPARE_STRICT=true \
+uv run pytest tests/reconciliation
+```
+
+Rode testes usando explicitamente o engine Rust:
+
+```bash
+PROXBOX_RECONCILIATION_ENGINE=rust uv run pytest tests/reconciliation
+```
+
+Rode o benchmark sintetico:
+
+```bash
+uv run python benchmarks/reconciliation/bench_vm_queue.py --sizes 100 1000 10000
+uv run python benchmarks/reconciliation/bench_vm_queue.py --sizes 10000 --pathological
+```
+
+Se o compare mode reportar divergencias, mantenha `PROXBOX_RECONCILIATION_ENGINE=python` em
+producao e inspecione `proxbox_reconcile_mismatch_total` em `/cache/metrics` ou
+`/cache/metrics/prometheus`.
+
 Para os modulos novos da v0.0.11 (HA, verbos operacionais, sync-active, parsing de metadata e resolucao de colisao de nomes):
 
 ```bash
@@ -215,6 +264,7 @@ python -m compileall proxbox_api
 - `pytest`
 - `python -m compileall proxbox_api`
 - `mkdocs build --strict` (quando docs mudarem)
+- `cargo test --no-default-features` em `proxbox-reconcile-rs` (quando Rust mudar)
 
 ## Checks de contrato Proxmox gerado
 

--- a/docs/pt-BR/getting-started/installation.md
+++ b/docs/pt-BR/getting-started/installation.md
@@ -202,6 +202,34 @@ Ou com `uv`:
 uv add proxbox-api
 ```
 
+### Engine Rust opcional de reconciliacao
+
+A reconciliacao de VMs usa Python por padrao. Um pacote nativo opcional,
+`proxbox-reconcile-rs`, pode ser instalado para validacao em compare mode ou testes explicitos do
+engine Rust depois que os wheels forem publicados.
+
+Quando o pacote opcional estiver publicado, instale com:
+
+```bash
+pip install proxbox-api[rust]
+```
+
+Ate a publicacao do pacote nativo, instale a partir do checkout local:
+
+```bash
+uv sync --extra test --group dev
+uv pip install -e proxbox-reconcile-rs
+```
+
+Habilite primeiro o compare mode:
+
+```bash
+PROXBOX_RECONCILIATION_ENGINE=compare uv run fastapi run proxbox_api.main:app
+```
+
+O padrao de producao continua sendo Python. Para rollback imediato, remova
+`PROXBOX_RECONCILIATION_ENGINE` ou defina `python`.
+
 Inicie o servidor apos instalar:
 
 ```bash
@@ -227,6 +255,12 @@ Ou use `uv`:
 
 ```bash
 uv sync
+```
+
+Instale o pacote Rust opcional para testes locais de paridade:
+
+```bash
+uv pip install -e proxbox-reconcile-rs
 ```
 
 Execute a API:

--- a/docs/pt-BR/sync/reconciliation-architecture.md
+++ b/docs/pt-BR/sync/reconciliation-architecture.md
@@ -47,11 +47,15 @@ A preparacao roda com concorrencia limitada usando `asyncio.gather` + semaforo.
 
 O sync le todas as VMs do NetBox em paginas (`limit/offset`) e monta um indice em memoria com chave:
 
-- `(cluster_id, proxmox_vm_id)`
+- `(cluster_id, proxmox_vm_id, proxmox_vm_type)`
 
-### Fase 4: Reconciliacao com Pydantic
+O segmento de tipo evita colisao entre uma VM QEMU 100 e um CT LXC 100 no mesmo cluster.
+Registros legados sem `custom_fields.proxmox_vm_type` so sao reaproveitados quando a identidade
+`(cluster_id, proxmox_vm_id)` e inequivoca.
 
-Para cada VM preparada:
+### Fase 4: Reconciliacao da Fila
+
+O engine padrao de reconciliacao e Python. Para cada VM preparada:
 
 1. Validar payload desired com `NetBoxVirtualMachineCreateBody`.
 2. Normalizar registro current do NetBox com o mesmo schema.
@@ -62,6 +66,36 @@ Classificacao:
 - `GET`: objeto existe e nao ha delta.
 - `CREATE`: objeto nao encontrado no indice.
 - `UPDATE`: objeto existe e ha delta.
+
+Existe uma implementacao Rust opcional atras de uma fronteira JSON pura:
+
+```text
+Input  : prepared_vms + netbox_snapshot + flags  (JSON bytes)
+Output : operation queue (CREATE | GET | UPDATE + patch_payload)  (JSON bytes)
+```
+
+A funcao Rust nao executa HTTP, async, banco de dados, retry ou dispatch. Essas responsabilidades
+continuam no Python. Quando o pacote nativo esta instalado, a ponte Python serializa a entrada com
+Pydantic v2, chama a extensao PyO3 com o GIL liberado, decodifica o resultado e adapta as operacoes
+de volta para as dataclasses usadas pelo dispatch.
+
+Selecao de engine:
+
+| Variavel | Valor | Comportamento |
+|----------|-------|----------------|
+| `PROXBOX_RECONCILIATION_ENGINE` | `python` | Padrao. Usa apenas a saida Python. |
+| `PROXBOX_RECONCILIATION_ENGINE` | `compare` | Roda Python e Rust quando Rust esta instalado, loga divergencias e retorna Python. |
+| `PROXBOX_RECONCILIATION_ENGINE` | `rust` | Retorna a saida Rust adaptada. |
+| `PROXBOX_RECONCILIATION_COMPARE_STRICT` | `true` | Falha em divergencia no compare mode. Uso previsto para CI. |
+
+Se o pacote Rust nao estiver instalado, o modo `python` funciona normalmente e o modo `compare`
+retorna a saida Python. O modo `rust` requer o pacote nativo e falha claramente quando ele nao esta
+disponivel.
+
+Divergencias em compare mode incrementam `proxbox_reconcile_mismatch_total`, exposto em:
+
+- `/cache/metrics`
+- `/cache/metrics/prometheus`
 
 ### Fase 5: Dispatch Sequencial para NetBox em Janelas de Batch
 
@@ -110,7 +144,7 @@ sequenceDiagram
     S->>N: Buscar paginas de VM no NetBox
     N-->>S: Snapshot NetBox em memoria
 
-    S->>S: Reconciliar com Pydantic
+    S->>S: Reconciliar com Python ou engine Rust opcional
     S->>S: Montar fila ordenada de operacoes
 
     loop Dispatch sequencial por batch
@@ -128,7 +162,7 @@ sequenceDiagram
 
 `CREATE`
 
-- Nao existe correspondencia por `(cluster_id, proxmox_vm_id)`.
+- Nao existe correspondencia por `(cluster_id, proxmox_vm_id, proxmox_vm_type)`.
 - Executa POST no NetBox durante o dispatch.
 
 `UPDATE`
@@ -140,5 +174,25 @@ sequenceDiagram
 
 - `PROXBOX_VM_SYNC_MAX_CONCURRENCY`: controla concorrencia de preparacao/fetch de VMs no Proxmox.
 - `PROXBOX_NETBOX_WRITE_CONCURRENCY`: define tamanho da janela de batch no dispatch.
+- `PROXBOX_RECONCILIATION_ENGINE`: seleciona `python`, `compare` ou `rust`.
+- `PROXBOX_RECONCILIATION_COMPARE_STRICT`: falha em drift no compare mode quando `true`.
 
 Observacao: tamanho de batch nao implica escrita paralela; as escritas continuam sequenciais para proteger o NetBox em ambiente de instancia unica.
+
+## Politica de Rollout do Rust
+
+Rust nao e o engine padrao. O rollout e conservador:
+
+1. Construir e testar wheels de `proxbox-reconcile-rs` no CI.
+2. Publicar `proxbox-reconcile-rs` apenas pelo workflow de release do repositorio.
+3. Manter `PROXBOX_RECONCILIATION_ENGINE=python` como padrao no `proxbox-api`.
+4. Rodar `PROXBOX_RECONCILIATION_ENGINE=compare` em staging por pelo menos duas semanas.
+5. Monitorar `proxbox_reconcile_mismatch_total` e logs de mismatch.
+6. Recomendar `PROXBOX_RECONCILIATION_ENGINE=rust` apenas depois de zero divergencias em syncs reais diversos.
+7. Considerar trocar o padrao apenas em uma release minor futura e somente se benchmarks de wall time do sync completo provarem ganho real.
+
+Rollback e imediato: remova `PROXBOX_RECONCILIATION_ENGINE` ou volte para `python`.
+
+A evidencia atual de benchmark nao justifica tornar Rust o padrao. O caminho Rust completo ficou
+mais lento que Python no benchmark sintetico, e a medicao real mostrou que reconciliacao nao era o
+custo dominante do sync.

--- a/docs/sync/reconciliation-architecture.md
+++ b/docs/sync/reconciliation-architecture.md
@@ -51,13 +51,16 @@ Preparation runs with bounded concurrency using `asyncio.gather` + semaphore.
 
 The sync reads all NetBox VMs in paginated batches (`limit/offset`) and builds an in-memory index keyed by:
 
-- `(cluster_id, proxmox_vm_id)`
+- `(cluster_id, proxmox_vm_id, proxmox_vm_type)`
 
 This avoids repeated NetBox list/filter calls during per-VM comparison.
+The VM type segment prevents QEMU VM 100 and LXC CT 100 in the same cluster from colliding.
+Legacy records that do not yet have `custom_fields.proxmox_vm_type` are matched only when the
+`(cluster_id, proxmox_vm_id)` identity is unambiguous.
 
-### Phase 4: Pydantic Reconciliation
+### Phase 4: Queue Reconciliation
 
-For each prepared VM:
+The default reconciliation engine is Python. For each prepared VM:
 
 1. Validate desired payload with `NetBoxVirtualMachineCreateBody`.
 2. Normalize current NetBox record with the same schema.
@@ -68,6 +71,35 @@ Classification result:
 - `GET`: Object exists and no delta.
 - `CREATE`: Object missing in snapshot index.
 - `UPDATE`: Object exists and delta is non-empty.
+
+An optional Rust implementation exists behind a pure JSON boundary:
+
+```text
+Input  : prepared_vms + netbox_snapshot + flags  (JSON bytes)
+Output : operation queue (CREATE | GET | UPDATE + patch_payload)  (JSON bytes)
+```
+
+The Rust function performs no HTTP, async work, database access, retry logic, or dispatch.
+Those concerns remain in Python. When the native package is installed, the Python bridge can
+serialize inputs with Pydantic v2, call the PyO3 extension with the GIL released, decode the
+result, and adapt operations back to the Python dataclasses used by dispatch.
+
+Engine selection is controlled by environment variables:
+
+| Variable | Value | Behavior |
+|----------|-------|----------|
+| `PROXBOX_RECONCILIATION_ENGINE` | `python` | Default. Use Python output only. |
+| `PROXBOX_RECONCILIATION_ENGINE` | `compare` | Run Python and Rust when Rust is installed, log mismatches, return Python output. |
+| `PROXBOX_RECONCILIATION_ENGINE` | `rust` | Return adapted Rust output. |
+| `PROXBOX_RECONCILIATION_COMPARE_STRICT` | `true` | Raise on compare-mode mismatch. Intended for CI. |
+
+If the Rust package is not installed, `python` mode works normally and `compare` mode returns
+Python output. `rust` mode requires the native package and fails clearly if it is unavailable.
+
+Compare-mode mismatches increment `proxbox_reconcile_mismatch_total`, which is exposed in:
+
+- `/cache/metrics`
+- `/cache/metrics/prometheus`
 
 ### Phase 5: Sequential NetBox Dispatch in Batch Windows
 
@@ -118,7 +150,7 @@ sequenceDiagram
     S->>N: Fetch NetBox VM pages
     N-->>S: NetBox in-memory snapshot
 
-    S->>S: Reconcile with Pydantic
+    S->>S: Reconcile with Python or optional Rust engine
     S->>S: Build ordered operations queue
 
     loop Sequential batch dispatch
@@ -136,7 +168,7 @@ sequenceDiagram
 
 `CREATE`
 
-- Means no matching `(cluster_id, proxmox_vm_id)` was found.
+- Means no matching `(cluster_id, proxmox_vm_id, proxmox_vm_type)` was found.
 - NetBox POST is executed once during dispatch.
 
 `UPDATE`
@@ -148,8 +180,28 @@ sequenceDiagram
 
 - `PROXBOX_VM_SYNC_MAX_CONCURRENCY`: controls concurrent VM preparation/fetch from Proxmox.
 - `PROXBOX_NETBOX_WRITE_CONCURRENCY`: defines dispatch batch window size.
+- `PROXBOX_RECONCILIATION_ENGINE`: selects `python`, `compare`, or `rust`.
+- `PROXBOX_RECONCILIATION_COMPARE_STRICT`: raises on compare-mode drift when set to `true`.
 
 Note: batch window size does not imply parallel writes; writes remain sequential to protect NetBox under single-instance operation.
+
+## Rust Rollout Policy
+
+Rust is not the default engine. Rollout is intentionally conservative:
+
+1. Build and test `proxbox-reconcile-rs` wheels in CI.
+2. Publish `proxbox-reconcile-rs` only through the repository release workflow.
+3. Keep `PROXBOX_RECONCILIATION_ENGINE=python` as the default in `proxbox-api`.
+4. Run `PROXBOX_RECONCILIATION_ENGINE=compare` in staging for at least two weeks.
+5. Watch `proxbox_reconcile_mismatch_total` and reconciliation mismatch logs.
+6. Recommend `PROXBOX_RECONCILIATION_ENGINE=rust` only after zero mismatches across diverse real syncs.
+7. Consider a default-engine change only in a later minor release and only after full sync wall-time benchmarks show a real win.
+
+Rollback is immediate: unset `PROXBOX_RECONCILIATION_ENGINE` or set it back to `python`.
+
+Current benchmark evidence does not justify making Rust the default. The full Rust path is slower
+than Python in the synthetic benchmark harness, and live measurement showed reconciliation was not
+the dominant sync cost.
 
 ## Benefits
 

--- a/tests/reconciliation/fixtures/create_get_update.json
+++ b/tests/reconciliation/fixtures/create_get_update.json
@@ -1,0 +1,106 @@
+{
+  "prepared_vms": [
+    {
+      "cluster_name": "cluster-a",
+      "resource": {"name": "qemu-100", "vmid": 100, "type": "qemu"},
+      "vm_config": {},
+      "desired_payload": {
+        "name": "qemu-100",
+        "status": "active",
+        "cluster": 1,
+        "device": 10,
+        "role": 20,
+        "vcpus": 2,
+        "memory": 2048,
+        "disk": 30,
+        "tags": [99],
+        "custom_fields": {"proxmox_vm_id": 100, "proxmox_vm_type": "qemu"},
+        "description": "Synced from Proxmox node pve01"
+      },
+      "lookup": {"cf_proxmox_vm_id": 100, "cluster_id": 1},
+      "vm_type": "qemu"
+    },
+    {
+      "cluster_name": "cluster-a",
+      "resource": {"name": "qemu-101", "vmid": 101, "type": "qemu"},
+      "vm_config": {},
+      "desired_payload": {
+        "name": "qemu-101",
+        "status": "active",
+        "cluster": 1,
+        "device": 10,
+        "role": 20,
+        "vcpus": 2,
+        "memory": 2048,
+        "disk": 30,
+        "tags": [99],
+        "custom_fields": {"proxmox_vm_id": 101, "proxmox_vm_type": "qemu"},
+        "description": "Synced from Proxmox node pve01"
+      },
+      "lookup": {"cf_proxmox_vm_id": 101, "cluster_id": 1},
+      "vm_type": "qemu"
+    },
+    {
+      "cluster_name": "cluster-a",
+      "resource": {"name": "qemu-102", "vmid": 102, "type": "qemu"},
+      "vm_config": {},
+      "desired_payload": {
+        "name": "qemu-102",
+        "status": "active",
+        "cluster": 1,
+        "device": 10,
+        "role": 20,
+        "vcpus": 2,
+        "memory": 2048,
+        "disk": 30,
+        "tags": [99],
+        "custom_fields": {"proxmox_vm_id": 102, "proxmox_vm_type": "qemu"},
+        "description": "Synced from Proxmox node pve01"
+      },
+      "lookup": {"cf_proxmox_vm_id": 102, "cluster_id": 1},
+      "vm_type": "qemu"
+    }
+  ],
+  "netbox_snapshot": [
+    {
+      "id": 2101,
+      "name": "qemu-101",
+      "status": "active",
+      "cluster": {"id": 1},
+      "device": {"id": 10},
+      "role": {"id": 20},
+      "vcpus": 2,
+      "memory": 2048,
+      "disk": 30,
+      "tags": [{"id": 99}],
+      "custom_fields": {"proxmox_vm_id": 101, "proxmox_vm_type": "qemu"},
+      "description": "Synced from Proxmox node pve01"
+    },
+    {
+      "id": 2102,
+      "name": "qemu-102",
+      "status": "active",
+      "cluster": {"id": 1},
+      "device": {"id": 10},
+      "role": {"id": 20},
+      "vcpus": 2,
+      "memory": 1024,
+      "disk": 30,
+      "tags": [{"id": 99}],
+      "custom_fields": {"proxmox_vm_id": 102, "proxmox_vm_type": "qemu"},
+      "description": "Synced from Proxmox node pve01"
+    }
+  ],
+  "flags": {
+    "overwrite_vm_role": true,
+    "overwrite_vm_type": true,
+    "overwrite_vm_tags": true,
+    "overwrite_vm_description": true,
+    "overwrite_vm_custom_fields": true,
+    "supports_virtual_machine_type_field": true
+  },
+  "expected": {
+    "methods": ["CREATE", "GET", "UPDATE"],
+    "patch_payloads": [{}, {}, {"memory": 2048}]
+  }
+}

--- a/tests/reconciliation/fixtures/merge_tags.json
+++ b/tests/reconciliation/fixtures/merge_tags.json
@@ -1,0 +1,49 @@
+{
+  "prepared_vms": [
+    {
+      "cluster_name": "cluster-a",
+      "resource": {"name": "qemu-104", "vmid": 104, "type": "qemu"},
+      "vm_config": {},
+      "desired_payload": {
+        "name": "qemu-104",
+        "status": "active",
+        "cluster": 1,
+        "device": 10,
+        "role": 20,
+        "vcpus": 2,
+        "memory": 2048,
+        "disk": 30,
+        "tags": [99],
+        "custom_fields": {"proxmox_vm_id": 104, "proxmox_vm_type": "qemu"},
+        "description": "Synced from Proxmox node pve01"
+      },
+      "lookup": {"cf_proxmox_vm_id": 104, "cluster_id": 1},
+      "vm_type": "qemu"
+    }
+  ],
+  "netbox_snapshot": [
+    {
+      "id": 2104,
+      "name": "qemu-104",
+      "status": "active",
+      "cluster": {"id": 1},
+      "device": {"id": 10},
+      "role": {"id": 20},
+      "vcpus": 2,
+      "memory": 2048,
+      "disk": 30,
+      "tags": [{"id": 77}],
+      "custom_fields": {"proxmox_vm_id": 104, "proxmox_vm_type": "qemu"},
+      "description": "Synced from Proxmox node pve01"
+    }
+  ],
+  "flags": {
+    "overwrite_vm_role": true,
+    "overwrite_vm_type": true,
+    "overwrite_vm_tags": true,
+    "overwrite_vm_description": true,
+    "overwrite_vm_custom_fields": true,
+    "supports_virtual_machine_type_field": true
+  },
+  "expected": {"methods": ["UPDATE"], "patch_payloads": [{"tags": [77, 99]}]}
+}

--- a/tests/reconciliation/fixtures/missing_cluster.json
+++ b/tests/reconciliation/fixtures/missing_cluster.json
@@ -1,0 +1,49 @@
+{
+  "prepared_vms": [
+    {
+      "cluster_name": "cluster-a",
+      "resource": {"name": "qemu-106", "vmid": 106, "type": "qemu"},
+      "vm_config": {},
+      "desired_payload": {
+        "name": "qemu-106",
+        "status": "active",
+        "cluster": null,
+        "device": 10,
+        "role": 20,
+        "vcpus": 2,
+        "memory": 2048,
+        "disk": 30,
+        "tags": [99],
+        "custom_fields": {"proxmox_vm_id": 106, "proxmox_vm_type": "qemu"},
+        "description": "Synced from Proxmox node pve01"
+      },
+      "lookup": {"cf_proxmox_vm_id": 106, "cluster_id": 1},
+      "vm_type": "qemu"
+    }
+  ],
+  "netbox_snapshot": [
+    {
+      "id": 2106,
+      "name": "qemu-106",
+      "status": "active",
+      "cluster": {"id": 1},
+      "device": {"id": 10},
+      "role": {"id": 20},
+      "vcpus": 2,
+      "memory": 2048,
+      "disk": 30,
+      "tags": [{"id": 99}],
+      "custom_fields": {"proxmox_vm_id": 106, "proxmox_vm_type": "qemu"},
+      "description": "Synced from Proxmox node pve01"
+    }
+  ],
+  "flags": {
+    "overwrite_vm_role": true,
+    "overwrite_vm_type": true,
+    "overwrite_vm_tags": true,
+    "overwrite_vm_description": true,
+    "overwrite_vm_custom_fields": true,
+    "supports_virtual_machine_type_field": true
+  },
+  "expected": {"methods": ["CREATE"], "patch_payloads": [{}]}
+}

--- a/tests/reconciliation/fixtures/missing_vmid.json
+++ b/tests/reconciliation/fixtures/missing_vmid.json
@@ -1,0 +1,49 @@
+{
+  "prepared_vms": [
+    {
+      "cluster_name": "cluster-a",
+      "resource": {"name": "qemu-107", "vmid": 107, "type": "qemu"},
+      "vm_config": {},
+      "desired_payload": {
+        "name": "qemu-107",
+        "status": "active",
+        "cluster": 1,
+        "device": 10,
+        "role": 20,
+        "vcpus": 2,
+        "memory": 2048,
+        "disk": 30,
+        "tags": [99],
+        "custom_fields": {"proxmox_vm_id": 107, "proxmox_vm_type": "qemu"},
+        "description": "Synced from Proxmox node pve01"
+      },
+      "lookup": {"cf_proxmox_vm_id": 107, "cluster_id": 1},
+      "vm_type": "qemu"
+    }
+  ],
+  "netbox_snapshot": [
+    {
+      "id": 2107,
+      "name": "qemu-107",
+      "status": "active",
+      "cluster": {"id": 1},
+      "device": {"id": 10},
+      "role": {"id": 20},
+      "vcpus": 2,
+      "memory": 2048,
+      "disk": 30,
+      "tags": [{"id": 99}],
+      "custom_fields": {"proxmox_vm_type": "qemu"},
+      "description": "Synced from Proxmox node pve01"
+    }
+  ],
+  "flags": {
+    "overwrite_vm_role": true,
+    "overwrite_vm_type": true,
+    "overwrite_vm_tags": true,
+    "overwrite_vm_description": true,
+    "overwrite_vm_custom_fields": true,
+    "supports_virtual_machine_type_field": true
+  },
+  "expected": {"methods": ["CREATE"], "patch_payloads": [{}]}
+}

--- a/tests/reconciliation/fixtures/null_vs_missing.json
+++ b/tests/reconciliation/fixtures/null_vs_missing.json
@@ -1,0 +1,52 @@
+{
+  "prepared_vms": [
+    {
+      "cluster_name": "cluster-a",
+      "resource": {"name": "qemu-109", "vmid": 109, "type": "qemu"},
+      "vm_config": {},
+      "desired_payload": {
+        "name": "qemu-109",
+        "status": "active",
+        "cluster": 1,
+        "device": 10,
+        "role": 20,
+        "vcpus": 2,
+        "memory": 2048,
+        "disk": 30,
+        "tags": [99],
+        "custom_fields": {"proxmox_vm_id": 109, "foo": null},
+        "description": "Synced from Proxmox node pve01"
+      },
+      "lookup": {"cf_proxmox_vm_id": 109, "cluster_id": 1},
+      "vm_type": "qemu"
+    }
+  ],
+  "netbox_snapshot": [
+    {
+      "id": 2109,
+      "name": "qemu-109",
+      "status": "active",
+      "cluster": {"id": 1},
+      "device": {"id": 10},
+      "role": {"id": 20},
+      "vcpus": 2,
+      "memory": 2048,
+      "disk": 30,
+      "tags": [{"id": 99}],
+      "custom_fields": {"proxmox_vm_id": 109},
+      "description": "Synced from Proxmox node pve01"
+    }
+  ],
+  "flags": {
+    "overwrite_vm_role": true,
+    "overwrite_vm_type": true,
+    "overwrite_vm_tags": true,
+    "overwrite_vm_description": true,
+    "overwrite_vm_custom_fields": true,
+    "supports_virtual_machine_type_field": true
+  },
+  "expected": {
+    "methods": ["UPDATE"],
+    "patch_payloads": [{"custom_fields": {"proxmox_vm_id": 109, "foo": null}}]
+  }
+}

--- a/tests/reconciliation/fixtures/overwrite_role_false.json
+++ b/tests/reconciliation/fixtures/overwrite_role_false.json
@@ -1,0 +1,49 @@
+{
+  "prepared_vms": [
+    {
+      "cluster_name": "cluster-a",
+      "resource": {"name": "qemu-103", "vmid": 103, "type": "qemu"},
+      "vm_config": {},
+      "desired_payload": {
+        "name": "qemu-103",
+        "status": "active",
+        "cluster": 1,
+        "device": 10,
+        "role": 21,
+        "vcpus": 2,
+        "memory": 2048,
+        "disk": 30,
+        "tags": [99],
+        "custom_fields": {"proxmox_vm_id": 103, "proxmox_vm_type": "qemu"},
+        "description": "Synced from Proxmox node pve01"
+      },
+      "lookup": {"cf_proxmox_vm_id": 103, "cluster_id": 1},
+      "vm_type": "qemu"
+    }
+  ],
+  "netbox_snapshot": [
+    {
+      "id": 2103,
+      "name": "qemu-103",
+      "status": "active",
+      "cluster": {"id": 1},
+      "device": {"id": 10},
+      "role": {"id": 20},
+      "vcpus": 2,
+      "memory": 2048,
+      "disk": 30,
+      "tags": [{"id": 99}],
+      "custom_fields": {"proxmox_vm_id": 103, "proxmox_vm_type": "qemu"},
+      "description": "Synced from Proxmox node pve01"
+    }
+  ],
+  "flags": {
+    "overwrite_vm_role": false,
+    "overwrite_vm_type": true,
+    "overwrite_vm_tags": true,
+    "overwrite_vm_description": true,
+    "overwrite_vm_custom_fields": true,
+    "supports_virtual_machine_type_field": true
+  },
+  "expected": {"methods": ["GET"], "patch_payloads": [{}]}
+}

--- a/tests/reconciliation/fixtures/preserve_tags.json
+++ b/tests/reconciliation/fixtures/preserve_tags.json
@@ -1,0 +1,49 @@
+{
+  "prepared_vms": [
+    {
+      "cluster_name": "cluster-a",
+      "resource": {"name": "qemu-105", "vmid": 105, "type": "qemu"},
+      "vm_config": {},
+      "desired_payload": {
+        "name": "qemu-105",
+        "status": "active",
+        "cluster": 1,
+        "device": 10,
+        "role": 20,
+        "vcpus": 2,
+        "memory": 2048,
+        "disk": 30,
+        "tags": [99],
+        "custom_fields": {"proxmox_vm_id": 105, "proxmox_vm_type": "qemu"},
+        "description": "Synced from Proxmox node pve01"
+      },
+      "lookup": {"cf_proxmox_vm_id": 105, "cluster_id": 1},
+      "vm_type": "qemu"
+    }
+  ],
+  "netbox_snapshot": [
+    {
+      "id": 2105,
+      "name": "qemu-105",
+      "status": "active",
+      "cluster": {"id": 1},
+      "device": {"id": 10},
+      "role": {"id": 20},
+      "vcpus": 2,
+      "memory": 2048,
+      "disk": 30,
+      "tags": [{"id": 77}],
+      "custom_fields": {"proxmox_vm_id": 105, "proxmox_vm_type": "qemu"},
+      "description": "Synced from Proxmox node pve01"
+    }
+  ],
+  "flags": {
+    "overwrite_vm_role": true,
+    "overwrite_vm_type": true,
+    "overwrite_vm_tags": false,
+    "overwrite_vm_description": true,
+    "overwrite_vm_custom_fields": true,
+    "supports_virtual_machine_type_field": true
+  },
+  "expected": {"methods": ["GET"], "patch_payloads": [{}]}
+}

--- a/tests/reconciliation/fixtures/qemu_lxc_id_collision.json
+++ b/tests/reconciliation/fixtures/qemu_lxc_id_collision.json
@@ -1,0 +1,87 @@
+{
+  "prepared_vms": [
+    {
+      "cluster_name": "cluster-a",
+      "resource": {"name": "qemu-100", "vmid": 100, "type": "qemu"},
+      "vm_config": {},
+      "desired_payload": {
+        "name": "qemu-100",
+        "status": "active",
+        "cluster": 1,
+        "device": 10,
+        "role": 20,
+        "vcpus": 2,
+        "memory": 2048,
+        "disk": 30,
+        "tags": [99],
+        "custom_fields": {"proxmox_vm_id": 100, "proxmox_vm_type": "qemu"},
+        "description": "Synced from Proxmox node pve01"
+      },
+      "lookup": {"cf_proxmox_vm_id": 100, "cluster_id": 1},
+      "vm_type": "qemu"
+    },
+    {
+      "cluster_name": "cluster-a",
+      "resource": {"name": "lxc-100", "vmid": 100, "type": "lxc"},
+      "vm_config": {},
+      "desired_payload": {
+        "name": "lxc-100",
+        "status": "active",
+        "cluster": 1,
+        "device": 10,
+        "role": 20,
+        "vcpus": 2,
+        "memory": 2048,
+        "disk": 30,
+        "tags": [99],
+        "custom_fields": {"proxmox_vm_id": 100, "proxmox_vm_type": "lxc"},
+        "description": "Synced from Proxmox node pve01"
+      },
+      "lookup": {"cf_proxmox_vm_id": 100, "cluster_id": 1},
+      "vm_type": "lxc"
+    }
+  ],
+  "netbox_snapshot": [
+    {
+      "id": 3001,
+      "name": "qemu-100",
+      "status": "active",
+      "cluster": {"id": 1},
+      "device": {"id": 10},
+      "role": {"id": 20},
+      "vcpus": 2,
+      "memory": 2048,
+      "disk": 30,
+      "tags": [{"id": 99}],
+      "custom_fields": {"proxmox_vm_id": 100, "proxmox_vm_type": "qemu"},
+      "description": "Synced from Proxmox node pve01"
+    },
+    {
+      "id": 3002,
+      "name": "lxc-100",
+      "status": "active",
+      "cluster": {"id": 1},
+      "device": {"id": 10},
+      "role": {"id": 20},
+      "vcpus": 2,
+      "memory": 2048,
+      "disk": 30,
+      "tags": [{"id": 99}],
+      "custom_fields": {"proxmox_vm_id": 100, "proxmox_vm_type": "lxc"},
+      "description": "Synced from Proxmox node pve01"
+    }
+  ],
+  "flags": {
+    "overwrite_vm_role": true,
+    "overwrite_vm_type": true,
+    "overwrite_vm_tags": true,
+    "overwrite_vm_description": true,
+    "overwrite_vm_custom_fields": true,
+    "supports_virtual_machine_type_field": true
+  },
+  "expected": {
+    "methods": ["GET", "GET"],
+    "patch_payloads": [{}, {}],
+    "existing_ids": [3001, 3002]
+  }
+}

--- a/tests/reconciliation/fixtures/relation_int_vs_object.json
+++ b/tests/reconciliation/fixtures/relation_int_vs_object.json
@@ -1,0 +1,49 @@
+{
+  "prepared_vms": [
+    {
+      "cluster_name": "cluster-a",
+      "resource": {"name": "qemu-110", "vmid": 110, "type": "qemu"},
+      "vm_config": {},
+      "desired_payload": {
+        "name": "qemu-110",
+        "status": "active",
+        "cluster": 1,
+        "device": {"id": 10},
+        "role": {"id": 20},
+        "vcpus": 2,
+        "memory": 2048,
+        "disk": 30,
+        "tags": [3, 1, 2],
+        "custom_fields": {"proxmox_vm_id": 110, "proxmox_vm_type": "qemu"},
+        "description": "Synced from Proxmox node pve01"
+      },
+      "lookup": {"cf_proxmox_vm_id": 110, "cluster_id": 1},
+      "vm_type": "qemu"
+    }
+  ],
+  "netbox_snapshot": [
+    {
+      "id": 2110,
+      "name": "qemu-110",
+      "status": "active",
+      "cluster": {"id": 1},
+      "device": 10,
+      "role": 20,
+      "vcpus": 2,
+      "memory": 2048,
+      "disk": 30,
+      "tags": [{"id": 1}, {"id": 2}, {"id": 3}],
+      "custom_fields": {"proxmox_vm_id": 110, "proxmox_vm_type": "qemu"},
+      "description": "Synced from Proxmox node pve01"
+    }
+  ],
+  "flags": {
+    "overwrite_vm_role": true,
+    "overwrite_vm_type": true,
+    "overwrite_vm_tags": true,
+    "overwrite_vm_description": true,
+    "overwrite_vm_custom_fields": true,
+    "supports_virtual_machine_type_field": true
+  },
+  "expected": {"methods": ["GET"], "patch_payloads": [{}]}
+}

--- a/tests/reconciliation/fixtures/type_coercion.json
+++ b/tests/reconciliation/fixtures/type_coercion.json
@@ -1,0 +1,49 @@
+{
+  "prepared_vms": [
+    {
+      "cluster_name": "cluster-a",
+      "resource": {"name": "qemu-108", "vmid": 108, "type": "qemu"},
+      "vm_config": {},
+      "desired_payload": {
+        "name": "qemu-108",
+        "status": "active",
+        "cluster": 1,
+        "device": 10,
+        "role": 20,
+        "vcpus": 2,
+        "memory": 2048,
+        "disk": 30,
+        "tags": [99],
+        "custom_fields": {"proxmox_vm_id": 108, "proxmox_vm_type": "qemu"},
+        "description": "Synced from Proxmox node pve01"
+      },
+      "lookup": {"cf_proxmox_vm_id": 108, "cluster_id": 1},
+      "vm_type": "qemu"
+    }
+  ],
+  "netbox_snapshot": [
+    {
+      "id": 2108,
+      "name": "qemu-108",
+      "status": "active",
+      "cluster": {"id": 1},
+      "device": {"id": 10},
+      "role": {"id": 20},
+      "vcpus": 2.0,
+      "memory": 2048.0,
+      "disk": 30.0,
+      "tags": [{"id": 99}],
+      "custom_fields": {"proxmox_vm_id": 108, "proxmox_vm_type": "qemu"},
+      "description": "Synced from Proxmox node pve01"
+    }
+  ],
+  "flags": {
+    "overwrite_vm_role": true,
+    "overwrite_vm_type": true,
+    "overwrite_vm_tags": true,
+    "overwrite_vm_description": true,
+    "overwrite_vm_custom_fields": true,
+    "supports_virtual_machine_type_field": true
+  },
+  "expected": {"methods": ["GET"], "patch_payloads": [{}]}
+}

--- a/tests/reconciliation/test_vm_queue_parity.py
+++ b/tests/reconciliation/test_vm_queue_parity.py
@@ -1,0 +1,86 @@
+"""Fixture-driven Python/Rust VM queue parity tests."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from proxbox_api.proxmox_to_netbox.models import ProxmoxVmConfigInput
+from proxbox_api.services.sync.reconciliation.rust_bridge import (
+    build_vm_operation_queue_rust,
+    rust_available,
+)
+from proxbox_api.services.sync.reconciliation.types import PreparedVMState
+from proxbox_api.services.sync.reconciliation.vm_queue import (
+    _adapt_to_dataclasses,
+    _normalize_ops,
+    build_vm_operation_queue_python,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _fixture_names() -> list[str]:
+    return sorted(path.stem for path in FIXTURES.glob("*.json"))
+
+
+def _load_fixture(name: str) -> dict[str, Any]:
+    return json.loads((FIXTURES / f"{name}.json").read_text())
+
+
+def _prepared_state_from_fixture(data: dict[str, Any]) -> PreparedVMState:
+    return PreparedVMState(
+        cluster_name=data["cluster_name"],
+        resource=data["resource"],
+        vm_config=data.get("vm_config") or {},
+        vm_config_obj=ProxmoxVmConfigInput.model_validate(data.get("vm_config") or {}),
+        desired_payload=data["desired_payload"],
+        lookup=data.get("lookup") or {},
+        now=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        vm_type=data["vm_type"],
+    )
+
+
+def _python_ops(data: dict[str, Any]):
+    prepared_vms = [_prepared_state_from_fixture(item) for item in data["prepared_vms"]]
+    return prepared_vms, build_vm_operation_queue_python(
+        prepared_vms,
+        data["netbox_snapshot"],
+        **data["flags"],
+    )
+
+
+@pytest.mark.parametrize("fixture", _fixture_names())
+def test_fixture_python_contract(fixture: str) -> None:
+    data = _load_fixture(fixture)
+    _prepared_vms, ops = _python_ops(data)
+    expected = data["expected"]
+
+    assert [op.method for op in ops] == expected["methods"]
+    assert [op.patch_payload for op in ops] == expected["patch_payloads"]
+    if "existing_ids" in expected:
+        assert [
+            op.existing_record["id"] for op in ops if op.existing_record is not None
+        ] == expected["existing_ids"]
+
+
+@pytest.mark.parametrize("fixture", _fixture_names())
+def test_rust_matches_python(fixture: str) -> None:
+    if not rust_available():
+        pytest.skip("proxbox-reconcile-rs is not installed")
+
+    data = _load_fixture(fixture)
+    prepared_vms, py_ops = _python_ops(data)
+
+    raw_rust = build_vm_operation_queue_rust(
+        prepared_vms=prepared_vms,
+        netbox_snapshot=data["netbox_snapshot"],
+        flags=data["flags"],
+    )
+    rust_ops = _adapt_to_dataclasses(raw_rust, prepared_vms)
+
+    assert _normalize_ops(rust_ops) == _normalize_ops(py_ops)


### PR DESCRIPTION
Depends on #181.

Closes #173.

## Summary

- Add ten fixture-driven VM reconciliation scenarios covering CREATE/GET/UPDATE, overwrite gates, tag merge/preserve behavior, missing identity fields, QEMU/LXC VMID collisions, numeric coercion, null-vs-missing custom fields, and relation int/object equivalence.
- Add `test_vm_queue_parity.py` to assert each fixture's Python contract and compare normalized Rust output against Python when `proxbox-reconcile-rs` is installed.
- Add a synthetic dataset generator and benchmark harness that reports Python diff, Pydantic encode, Rust native, JSON decode, adapter, full Rust path, and speedup.

## Verification

- `uv sync --frozen --extra test --group dev`
- `uv run pytest tests/reconciliation -q` without native package installed: 38 passed, 10 skipped.
- `uv pip install -e proxbox-reconcile-rs`
- `uv run pytest tests/reconciliation -q` with native package installed: 48 passed.
- `PROXBOX_RECONCILIATION_ENGINE=compare PROXBOX_RECONCILIATION_COMPARE_STRICT=true uv run pytest tests/reconciliation -q`: 48 passed.
- `uv run python benchmarks/reconciliation/bench_vm_queue.py --sizes 100 1000 10000`
- `uv run python benchmarks/reconciliation/bench_vm_queue.py --sizes 10000 --pathological`
- `uv run python -m compileall proxbox_api tests benchmarks`
- `uv run ruff check .`
- `uv run ruff format --check .`

## Benchmark Decision

The benchmark results do not justify making Rust default. Full Rust path was slower than Python in the synthetic datasets, so Python should remain default and Rust should remain optional/experimental until later optimization changes the full-path result.
