### PR TITLE
Add Rust reconciliation CI and rollout docs

### DIFF
--- a/.github/workflows/rust-reconcile.yml
+++ b/.github/workflows/rust-reconcile.yml
@@ -1,0 +1,84 @@
+name: rust-reconcile
+
+on:
+  push:
+    branches: [main, testing, "v*"]
+  pull_request:
+    branches: [main, testing, "v*"]
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+env:
+  PROXBOX_ENCRYPTION_KEY: proxbox-ci-only-encryption-key-not-a-secret
+
+jobs:
+  test:
+    name: Test (${{ matrix.os }}, Python ${{ matrix.python }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ["3.12", "3.13"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python }}
+
+      - name: Sync proxbox-api dependencies
+        run: uv sync --frozen --extra test --group dev
+
+      - name: Rust unit tests
+        run: cargo test --no-default-features
+        working-directory: proxbox-reconcile-rs
+
+      - name: Install local Rust extension
+        run: uv pip install -e proxbox-reconcile-rs
+
+      - name: Strict Rust/Python parity tests
+        run: uv run pytest tests/reconciliation -q
+        env:
+          PROXBOX_RECONCILIATION_ENGINE: compare
+          PROXBOX_RECONCILIATION_COMPARE_STRICT: "true"
+          XDG_DATA_HOME: ${{ runner.temp }}/xdg-data
+
+  build-wheels:
+    name: Build wheels (${{ matrix.os }}, Python ${{ matrix.python }})
+    runs-on: ${{ matrix.os }}
+    needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ["3.12", "3.13"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Build wheel artifact
+        uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          args: --release --out dist --manifest-path proxbox-reconcile-rs/Cargo.toml
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: proxbox-reconcile-rs-${{ matrix.os }}-py${{ matrix.python }}
+          path: dist/*

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ uv run mkdocs serve   # after syncing with --extra docs
 
 Project documentation is available under `docs/` and built with MkDocs Material.
 
+The VM reconciliation engine is documented in
+[`docs/sync/reconciliation-architecture.md`](docs/sync/reconciliation-architecture.md).
+Python is the default engine; the optional Rust engine is for compare-mode validation and explicit
+opt-in testing.
+
 ### Local docs build
 
 ```bash

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -34,6 +34,55 @@ For the current route and docs contract surface:
 pytest tests/test_generated_proxmox_routes.py tests/test_proxmox_codegen_docs.py tests/test_api_routes.py tests/test_stub_routes.py tests/test_admin_logs.py
 ```
 
+## Rust reconciliation tests
+
+The optional Rust reconciliation package lives in `proxbox-reconcile-rs/`.
+Python remains the default engine, so the normal test suite must pass without the native package.
+
+Run the Python fixture contracts and skip Rust parity when the native package is absent:
+
+```bash
+uv run pytest tests/reconciliation
+```
+
+Run Rust unit tests without the PyO3 extension-module link mode:
+
+```bash
+cd proxbox-reconcile-rs
+cargo test --no-default-features
+```
+
+Install the local native package into the root `uv` environment:
+
+```bash
+uv pip install -e proxbox-reconcile-rs
+```
+
+Run strict compare-mode parity:
+
+```bash
+PROXBOX_RECONCILIATION_ENGINE=compare \
+PROXBOX_RECONCILIATION_COMPARE_STRICT=true \
+uv run pytest tests/reconciliation
+```
+
+Run explicit Rust-engine tests:
+
+```bash
+PROXBOX_RECONCILIATION_ENGINE=rust uv run pytest tests/reconciliation
+```
+
+Run the synthetic benchmark harness:
+
+```bash
+uv run python benchmarks/reconciliation/bench_vm_queue.py --sizes 100 1000 10000
+uv run python benchmarks/reconciliation/bench_vm_queue.py --sizes 10000 --pathological
+```
+
+If compare mode reports mismatches, keep `PROXBOX_RECONCILIATION_ENGINE=python` in production
+and inspect `proxbox_reconcile_mismatch_total` through `/cache/metrics` or
+`/cache/metrics/prometheus`.
+
 For the v0.0.11 surface specifically (HA routes, operational verbs, the
 `allow_writes` gate, and supporting helpers):
 
@@ -218,6 +267,7 @@ python -m compileall proxbox_api
 - `pytest`
 - `python -m compileall proxbox_api`
 - `mkdocs build --strict` (when docs changed)
+- `cargo test --no-default-features` in `proxbox-reconcile-rs` (when Rust changes)
 
 ## Generated Proxmox contract checks
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -205,6 +205,34 @@ Or with `uv`:
 uv add proxbox-api
 ```
 
+### Optional Rust reconciliation engine
+
+VM reconciliation uses the Python engine by default. An optional native package,
+`proxbox-reconcile-rs`, can be installed for compare-mode validation or explicit Rust-engine
+testing after wheels are published.
+
+Once the optional package is published, install with:
+
+```bash
+pip install proxbox-api[rust]
+```
+
+Until the native package is published, install it from a local checkout:
+
+```bash
+uv sync --extra test --group dev
+uv pip install -e proxbox-reconcile-rs
+```
+
+Enable compare mode first:
+
+```bash
+PROXBOX_RECONCILIATION_ENGINE=compare uv run fastapi run proxbox_api.main:app
+```
+
+The production default remains Python. To roll back immediately, unset
+`PROXBOX_RECONCILIATION_ENGINE` or set it to `python`.
+
 Start the server:
 
 ```bash
@@ -230,6 +258,12 @@ Or use `uv`:
 
 ```bash
 uv sync
+```
+
+Install the optional Rust reconciliation package for local parity testing:
+
+```bash
+uv pip install -e proxbox-reconcile-rs
 ```
 
 Run API:

--- a/docs/pt-BR/development/testing.md
+++ b/docs/pt-BR/development/testing.md
@@ -34,6 +34,55 @@ Para a superficie atual de rotas e contratos de docs:
 pytest tests/test_generated_proxmox_routes.py tests/test_proxmox_codegen_docs.py tests/test_api_routes.py tests/test_stub_routes.py tests/test_admin_logs.py
 ```
 
+## Testes da reconciliacao Rust
+
+O pacote Rust opcional fica em `proxbox-reconcile-rs/`. Python continua sendo o engine padrao,
+entao a suite normal deve passar sem o pacote nativo.
+
+Rode os contratos Python das fixtures; a paridade Rust sera pulada se o pacote nativo nao estiver instalado:
+
+```bash
+uv run pytest tests/reconciliation
+```
+
+Rode testes unitarios Rust sem o modo de link `extension-module` do PyO3:
+
+```bash
+cd proxbox-reconcile-rs
+cargo test --no-default-features
+```
+
+Instale o pacote nativo local no ambiente `uv` raiz:
+
+```bash
+uv pip install -e proxbox-reconcile-rs
+```
+
+Rode paridade estrita em compare mode:
+
+```bash
+PROXBOX_RECONCILIATION_ENGINE=compare \
+PROXBOX_RECONCILIATION_COMPARE_STRICT=true \
+uv run pytest tests/reconciliation
+```
+
+Rode testes usando explicitamente o engine Rust:
+
+```bash
+PROXBOX_RECONCILIATION_ENGINE=rust uv run pytest tests/reconciliation
+```
+
+Rode o benchmark sintetico:
+
+```bash
+uv run python benchmarks/reconciliation/bench_vm_queue.py --sizes 100 1000 10000
+uv run python benchmarks/reconciliation/bench_vm_queue.py --sizes 10000 --pathological
+```
+
+Se o compare mode reportar divergencias, mantenha `PROXBOX_RECONCILIATION_ENGINE=python` em
+producao e inspecione `proxbox_reconcile_mismatch_total` em `/cache/metrics` ou
+`/cache/metrics/prometheus`.
+
 Para os modulos novos da v0.0.11 (HA, verbos operacionais, sync-active, parsing de metadata e resolucao de colisao de nomes):
 
 ```bash
@@ -215,6 +264,7 @@ python -m compileall proxbox_api
 - `pytest`
 - `python -m compileall proxbox_api`
 - `mkdocs build --strict` (quando docs mudarem)
+- `cargo test --no-default-features` em `proxbox-reconcile-rs` (quando Rust mudar)
 
 ## Checks de contrato Proxmox gerado
 

--- a/docs/pt-BR/getting-started/installation.md
+++ b/docs/pt-BR/getting-started/installation.md
@@ -202,6 +202,34 @@ Ou com `uv`:
 uv add proxbox-api
 ```
 
+### Engine Rust opcional de reconciliacao
+
+A reconciliacao de VMs usa Python por padrao. Um pacote nativo opcional,
+`proxbox-reconcile-rs`, pode ser instalado para validacao em compare mode ou testes explicitos do
+engine Rust depois que os wheels forem publicados.
+
+Quando o pacote opcional estiver publicado, instale com:
+
+```bash
+pip install proxbox-api[rust]
+```
+
+Ate a publicacao do pacote nativo, instale a partir do checkout local:
+
+```bash
+uv sync --extra test --group dev
+uv pip install -e proxbox-reconcile-rs
+```
+
+Habilite primeiro o compare mode:
+
+```bash
+PROXBOX_RECONCILIATION_ENGINE=compare uv run fastapi run proxbox_api.main:app
+```
+
+O padrao de producao continua sendo Python. Para rollback imediato, remova
+`PROXBOX_RECONCILIATION_ENGINE` ou defina `python`.
+
 Inicie o servidor apos instalar:
 
 ```bash
@@ -227,6 +255,12 @@ Ou use `uv`:
 
 ```bash
 uv sync
+```
+
+Instale o pacote Rust opcional para testes locais de paridade:
+
+```bash
+uv pip install -e proxbox-reconcile-rs
 ```
 
 Execute a API:

--- a/docs/pt-BR/sync/reconciliation-architecture.md
+++ b/docs/pt-BR/sync/reconciliation-architecture.md
@@ -47,11 +47,15 @@ A preparacao roda com concorrencia limitada usando `asyncio.gather` + semaforo.
 
 O sync le todas as VMs do NetBox em paginas (`limit/offset`) e monta um indice em memoria com chave:
 
-- `(cluster_id, proxmox_vm_id)`
+- `(cluster_id, proxmox_vm_id, proxmox_vm_type)`
 
-### Fase 4: Reconciliacao com Pydantic
+O segmento de tipo evita colisao entre uma VM QEMU 100 e um CT LXC 100 no mesmo cluster.
+Registros legados sem `custom_fields.proxmox_vm_type` so sao reaproveitados quando a identidade
+`(cluster_id, proxmox_vm_id)` e inequivoca.
 
-Para cada VM preparada:
+### Fase 4: Reconciliacao da Fila
+
+O engine padrao de reconciliacao e Python. Para cada VM preparada:
 
 1. Validar payload desired com `NetBoxVirtualMachineCreateBody`.
 2. Normalizar registro current do NetBox com o mesmo schema.
@@ -62,6 +66,36 @@ Classificacao:
 - `GET`: objeto existe e nao ha delta.
 - `CREATE`: objeto nao encontrado no indice.
 - `UPDATE`: objeto existe e ha delta.
+
+Existe uma implementacao Rust opcional atras de uma fronteira JSON pura:
+
+```text
+Input  : prepared_vms + netbox_snapshot + flags  (JSON bytes)
+Output : operation queue (CREATE | GET | UPDATE + patch_payload)  (JSON bytes)
+```
+
+A funcao Rust nao executa HTTP, async, banco de dados, retry ou dispatch. Essas responsabilidades
+continuam no Python. Quando o pacote nativo esta instalado, a ponte Python serializa a entrada com
+Pydantic v2, chama a extensao PyO3 com o GIL liberado, decodifica o resultado e adapta as operacoes
+de volta para as dataclasses usadas pelo dispatch.
+
+Selecao de engine:
+
+| Variavel | Valor | Comportamento |
+|----------|-------|----------------|
+| `PROXBOX_RECONCILIATION_ENGINE` | `python` | Padrao. Usa apenas a saida Python. |
+| `PROXBOX_RECONCILIATION_ENGINE` | `compare` | Roda Python e Rust quando Rust esta instalado, loga divergencias e retorna Python. |
+| `PROXBOX_RECONCILIATION_ENGINE` | `rust` | Retorna a saida Rust adaptada. |
+| `PROXBOX_RECONCILIATION_COMPARE_STRICT` | `true` | Falha em divergencia no compare mode. Uso previsto para CI. |
+
+Se o pacote Rust nao estiver instalado, o modo `python` funciona normalmente e o modo `compare`
+retorna a saida Python. O modo `rust` requer o pacote nativo e falha claramente quando ele nao esta
+disponivel.
+
+Divergencias em compare mode incrementam `proxbox_reconcile_mismatch_total`, exposto em:
+
+- `/cache/metrics`
+- `/cache/metrics/prometheus`
 
 ### Fase 5: Dispatch Sequencial para NetBox em Janelas de Batch
 
@@ -110,7 +144,7 @@ sequenceDiagram
     S->>N: Buscar paginas de VM no NetBox
     N-->>S: Snapshot NetBox em memoria
 
-    S->>S: Reconciliar com Pydantic
+    S->>S: Reconciliar com Python ou engine Rust opcional
     S->>S: Montar fila ordenada de operacoes
 
     loop Dispatch sequencial por batch
@@ -128,7 +162,7 @@ sequenceDiagram
 
 `CREATE`
 
-- Nao existe correspondencia por `(cluster_id, proxmox_vm_id)`.
+- Nao existe correspondencia por `(cluster_id, proxmox_vm_id, proxmox_vm_type)`.
 - Executa POST no NetBox durante o dispatch.
 
 `UPDATE`
@@ -140,5 +174,25 @@ sequenceDiagram
 
 - `PROXBOX_VM_SYNC_MAX_CONCURRENCY`: controla concorrencia de preparacao/fetch de VMs no Proxmox.
 - `PROXBOX_NETBOX_WRITE_CONCURRENCY`: define tamanho da janela de batch no dispatch.
+- `PROXBOX_RECONCILIATION_ENGINE`: seleciona `python`, `compare` ou `rust`.
+- `PROXBOX_RECONCILIATION_COMPARE_STRICT`: falha em drift no compare mode quando `true`.
 
 Observacao: tamanho de batch nao implica escrita paralela; as escritas continuam sequenciais para proteger o NetBox em ambiente de instancia unica.
+
+## Politica de Rollout do Rust
+
+Rust nao e o engine padrao. O rollout e conservador:
+
+1. Construir e testar wheels de `proxbox-reconcile-rs` no CI.
+2. Publicar `proxbox-reconcile-rs` apenas pelo workflow de release do repositorio.
+3. Manter `PROXBOX_RECONCILIATION_ENGINE=python` como padrao no `proxbox-api`.
+4. Rodar `PROXBOX_RECONCILIATION_ENGINE=compare` em staging por pelo menos duas semanas.
+5. Monitorar `proxbox_reconcile_mismatch_total` e logs de mismatch.
+6. Recomendar `PROXBOX_RECONCILIATION_ENGINE=rust` apenas depois de zero divergencias em syncs reais diversos.
+7. Considerar trocar o padrao apenas em uma release minor futura e somente se benchmarks de wall time do sync completo provarem ganho real.
+
+Rollback e imediato: remova `PROXBOX_RECONCILIATION_ENGINE` ou volte para `python`.
+
+A evidencia atual de benchmark nao justifica tornar Rust o padrao. O caminho Rust completo ficou
+mais lento que Python no benchmark sintetico, e a medicao real mostrou que reconciliacao nao era o
+custo dominante do sync.

--- a/docs/sync/reconciliation-architecture.md
+++ b/docs/sync/reconciliation-architecture.md
@@ -51,13 +51,16 @@ Preparation runs with bounded concurrency using `asyncio.gather` + semaphore.
 
 The sync reads all NetBox VMs in paginated batches (`limit/offset`) and builds an in-memory index keyed by:
 
-- `(cluster_id, proxmox_vm_id)`
+- `(cluster_id, proxmox_vm_id, proxmox_vm_type)`
 
 This avoids repeated NetBox list/filter calls during per-VM comparison.
+The VM type segment prevents QEMU VM 100 and LXC CT 100 in the same cluster from colliding.
+Legacy records that do not yet have `custom_fields.proxmox_vm_type` are matched only when the
+`(cluster_id, proxmox_vm_id)` identity is unambiguous.
 
-### Phase 4: Pydantic Reconciliation
+### Phase 4: Queue Reconciliation
 
-For each prepared VM:
+The default reconciliation engine is Python. For each prepared VM:
 
 1. Validate desired payload with `NetBoxVirtualMachineCreateBody`.
 2. Normalize current NetBox record with the same schema.
@@ -68,6 +71,35 @@ Classification result:
 - `GET`: Object exists and no delta.
 - `CREATE`: Object missing in snapshot index.
 - `UPDATE`: Object exists and delta is non-empty.
+
+An optional Rust implementation exists behind a pure JSON boundary:
+
+```text
+Input  : prepared_vms + netbox_snapshot + flags  (JSON bytes)
+Output : operation queue (CREATE | GET | UPDATE + patch_payload)  (JSON bytes)
+```
+
+The Rust function performs no HTTP, async work, database access, retry logic, or dispatch.
+Those concerns remain in Python. When the native package is installed, the Python bridge can
+serialize inputs with Pydantic v2, call the PyO3 extension with the GIL released, decode the
+result, and adapt operations back to the Python dataclasses used by dispatch.
+
+Engine selection is controlled by environment variables:
+
+| Variable | Value | Behavior |
+|----------|-------|----------|
+| `PROXBOX_RECONCILIATION_ENGINE` | `python` | Default. Use Python output only. |
+| `PROXBOX_RECONCILIATION_ENGINE` | `compare` | Run Python and Rust when Rust is installed, log mismatches, return Python output. |
+| `PROXBOX_RECONCILIATION_ENGINE` | `rust` | Return adapted Rust output. |
+| `PROXBOX_RECONCILIATION_COMPARE_STRICT` | `true` | Raise on compare-mode mismatch. Intended for CI. |
+
+If the Rust package is not installed, `python` mode works normally and `compare` mode returns
+Python output. `rust` mode requires the native package and fails clearly if it is unavailable.
+
+Compare-mode mismatches increment `proxbox_reconcile_mismatch_total`, which is exposed in:
+
+- `/cache/metrics`
+- `/cache/metrics/prometheus`
 
 ### Phase 5: Sequential NetBox Dispatch in Batch Windows
 
@@ -118,7 +150,7 @@ sequenceDiagram
     S->>N: Fetch NetBox VM pages
     N-->>S: NetBox in-memory snapshot
 
-    S->>S: Reconcile with Pydantic
+    S->>S: Reconcile with Python or optional Rust engine
     S->>S: Build ordered operations queue
 
     loop Sequential batch dispatch
@@ -136,7 +168,7 @@ sequenceDiagram
 
 `CREATE`
 
-- Means no matching `(cluster_id, proxmox_vm_id)` was found.
+- Means no matching `(cluster_id, proxmox_vm_id, proxmox_vm_type)` was found.
 - NetBox POST is executed once during dispatch.
 
 `UPDATE`
@@ -148,8 +180,28 @@ sequenceDiagram
 
 - `PROXBOX_VM_SYNC_MAX_CONCURRENCY`: controls concurrent VM preparation/fetch from Proxmox.
 - `PROXBOX_NETBOX_WRITE_CONCURRENCY`: defines dispatch batch window size.
+- `PROXBOX_RECONCILIATION_ENGINE`: selects `python`, `compare`, or `rust`.
+- `PROXBOX_RECONCILIATION_COMPARE_STRICT`: raises on compare-mode drift when set to `true`.
 
 Note: batch window size does not imply parallel writes; writes remain sequential to protect NetBox under single-instance operation.
+
+## Rust Rollout Policy
+
+Rust is not the default engine. Rollout is intentionally conservative:
+
+1. Build and test `proxbox-reconcile-rs` wheels in CI.
+2. Publish `proxbox-reconcile-rs` only through the repository release workflow.
+3. Keep `PROXBOX_RECONCILIATION_ENGINE=python` as the default in `proxbox-api`.
+4. Run `PROXBOX_RECONCILIATION_ENGINE=compare` in staging for at least two weeks.
+5. Watch `proxbox_reconcile_mismatch_total` and reconciliation mismatch logs.
+6. Recommend `PROXBOX_RECONCILIATION_ENGINE=rust` only after zero mismatches across diverse real syncs.
+7. Consider a default-engine change only in a later minor release and only after full sync wall-time benchmarks show a real win.
+
+Rollback is immediate: unset `PROXBOX_RECONCILIATION_ENGINE` or set it back to `python`.
+
+Current benchmark evidence does not justify making Rust the default. The full Rust path is slower
+than Python in the synthetic benchmark harness, and live measurement showed reconciliation was not
+the dominant sync cost.
 
 ## Benefits
 


### PR DESCRIPTION
Depends on #182.

Closes #174.

## Summary

- Add a `rust-reconcile` GitHub Actions workflow for Rust unit tests, native extension install, strict Rust/Python parity tests, and wheel artifact builds across Linux, macOS, and Windows for Python 3.12/3.13.
- Document the optional Rust engine, compare mode, strict mode, mismatch metric, rollback to Python, and conservative rollout policy.
- Add installation and local development guidance for `proxbox-reconcile-rs` without adding the `[rust]` extra before the package is published.
- Update English and Brazilian Portuguese docs, plus a README pointer to the reconciliation architecture page.

## Verification

- `uv sync --frozen --extra docs --extra test --group dev`
- `uv run mkdocs build --strict`
- `uv run python -c "import yaml; yaml.safe_load(open('.github/workflows/rust-reconcile.yml'))"`
- `uv pip install -e proxbox-reconcile-rs`
- `cd proxbox-reconcile-rs && cargo test --no-default-features`
- `uv run pytest tests/reconciliation -q`
- `PROXBOX_RECONCILIATION_ENGINE=compare PROXBOX_RECONCILIATION_COMPARE_STRICT=true uv run pytest tests/reconciliation -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python -m compileall proxbox_api tests benchmarks`
- `uv run --with maturin maturin build --release --out /tmp/proxbox-reconcile-dist --manifest-path proxbox-reconcile-rs/Cargo.toml`

## Rollout Decision

Python remains the default. The docs explicitly keep Rust behind optional install, compare-mode staging, mismatch metrics, and future benchmark evidence before any default change.
