### PR TITLE
Document Rust reconciliation engine in agent guides

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -21,6 +21,7 @@ GitHub Actions CI/CD workflows for `proxbox-api`. All workflows live under `.git
 | `docs.yml` | Push to `main` | Builds MkDocs site and deploys to GitHub Pages |
 | `docker-hub-publish.yml` | Called by `publish-testpypi.yml` on Release, or manual dispatch | Builds and pushes three Alpine-based Docker images to Docker Hub: raw (uvicorn), nginx (nginx+mkcert+uvicorn), granian (granian+mkcert) |
 | `publish-testpypi.yml` | Version tag push, GitHub Release published, or manual dispatch | Validates release metadata, builds dist, then runs either the TestPyPI lane or the PyPI lane. `rcN` tag pushes publish to TestPyPI for release-candidate validation; non-rc tag pushes (`vX.Y.Z`, `vX.Y.Z.postN`), GitHub releases, and `publish_target=pypi` dispatches publish to PyPI. PyPI success then publishes Docker images and runs post-publish E2E. |
+| `rust-reconcile.yml` | Push / PR to `main`, `testing`, or `v*`; manual dispatch | Runs Rust unit tests for `proxbox-reconcile-rs`, installs the local native extension, runs strict Rust/Python reconciliation parity tests, and builds wheel artifacts across Linux/macOS/Windows for Python 3.12 and 3.13. |
 | `nightly-schema-refresh.yml` | Scheduled (nightly) | Runs `scripts/refresh_schemas.py` and opens a PR if schemas changed |
 | `release-docker-verify.yml` | Release published | Post-release smoke test of all three published Docker images |
 
@@ -41,6 +42,10 @@ ci.yml (push/PR — dev mode E2E only)
     - NetBox image handling: each E2E job pulls the public image first and only downloads the source-built artifact when the registry pull fails.
     - NetBox readiness waits up to 20 minutes for migrations/search indexing, then checks `/api/status/` before creating tokens.
     - Docker-backed Proxmox E2E uses pytest marker `mock_http`; the separate in-process MockBackend pass uses `mock_backend`.
+
+rust-reconcile.yml
+├── test         (cargo test --no-default-features, local native install, strict parity)
+└── build-wheels (needs: test; maturin wheel artifacts for Linux/macOS/Windows)
 
 ci.yml (release event — both dev + pypi modes)
 └── e2e-docker matrix runs both netbox_proxbox_mode=dev and netbox_proxbox_mode=pypi
@@ -85,3 +90,5 @@ All tags also have `sha-<commit>` variants (e.g., `sha-abc1234`, `sha-abc1234-ng
 - Package uploads intentionally do not use `twine --skip-existing`; if an artifact version was consumed, bump to the next `.postN` or `rcN` and publish that immutable version.
 - Do not add secrets to workflow files — use repository secrets (`PYPI_TOKEN`, `DOCKERHUB_TOKEN`, etc.).
 - Keep `docs/development/ci-e2e-workflows.md`, `docs/pt-BR/development/ci-e2e-workflows.md`, and `docs/development/release-publishing.md` aligned with CI workflow changes.
+- Keep `rust-reconcile.yml` aligned with `proxbox-reconcile-rs/Cargo.toml`,
+  `proxbox-reconcile-rs/pyproject.toml`, and `tests/reconciliation/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,18 @@ uv run ty check proxbox_api/types proxbox_api/utils/retry.py proxbox_api/schemas
 rtk pytest tests
 ```
 
+If you edit VM reconciliation or the Rust bridge (`proxbox_api/services/sync/reconciliation/`,
+`tests/reconciliation/`, `benchmarks/reconciliation/`, `proxbox-reconcile-rs/`,
+or `.github/workflows/rust-reconcile.yml`), also run:
+
+```bash
+cargo test --no-default-features --manifest-path proxbox-reconcile-rs/Cargo.toml
+uv pip install -e proxbox-reconcile-rs
+PROXBOX_RECONCILIATION_ENGINE=compare \
+  PROXBOX_RECONCILIATION_COMPARE_STRICT=true \
+  uv run pytest tests/reconciliation -q
+```
+
 If you edit `proxmox-sdk/`, also run:
 
 ```bash
@@ -81,6 +93,8 @@ and resolution-order details.
 
 ### Top-level packages
 - `proxbox_api/CLAUDE.md`
+- `proxbox-reconcile-rs/CLAUDE.md`
+- `proxbox-reconcile-rs/AGENTS.md`
 - `proxmox-sdk/CLAUDE.md`
 - `nextjs-ui/CLAUDE.md`
 - `nextjs-ui/AGENTS.md`
@@ -110,6 +124,7 @@ and resolution-order details.
 - `proxbox_api/routes/virtualization/virtual_machines/CLAUDE.md`
 - `proxbox_api/services/CLAUDE.md`
 - `proxbox_api/services/sync/CLAUDE.md`
+- `proxbox_api/services/sync/reconciliation/CLAUDE.md`
 - `proxbox_api/services/sync/individual/CLAUDE.md`
 - `proxbox_api/session/CLAUDE.md`
 - `proxbox_api/schemas/CLAUDE.md`
@@ -180,10 +195,12 @@ Read the nearest scoped guide for the code you are changing.
 - [proxbox_api/schemas/virtualization/CLAUDE.md](proxbox_api/schemas/virtualization/CLAUDE.md)
 - [proxbox_api/services/CLAUDE.md](proxbox_api/services/CLAUDE.md)
 - [proxbox_api/services/sync/CLAUDE.md](proxbox_api/services/sync/CLAUDE.md)
+- [proxbox_api/services/sync/reconciliation/CLAUDE.md](proxbox_api/services/sync/reconciliation/CLAUDE.md)
 - [proxbox_api/services/sync/individual/CLAUDE.md](proxbox_api/services/sync/individual/CLAUDE.md)
 - [proxbox_api/session/CLAUDE.md](proxbox_api/session/CLAUDE.md)
 - [proxbox_api/types/CLAUDE.md](proxbox_api/types/CLAUDE.md)
 - [proxbox_api/utils/CLAUDE.md](proxbox_api/utils/CLAUDE.md)
+- [proxbox-reconcile-rs/CLAUDE.md](proxbox-reconcile-rs/CLAUDE.md)
 - [proxmox-mock/CLAUDE.md](proxmox-mock/CLAUDE.md)
 - [scripts/CLAUDE.md](scripts/CLAUDE.md)
 - [tasks/CLAUDE.md](tasks/CLAUDE.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ Open the nearest scoped guide for the code you are changing.
 ### Top-level packages
 
 - `proxbox_api/CLAUDE.md` — Core FastAPI package overview
+- `proxbox-reconcile-rs/CLAUDE.md` — Optional Rust VM reconciliation engine
 - `proxmox-sdk/CLAUDE.md` — Proxmox OpenAPI package (mock + real API modes)
 - `nextjs-ui/CLAUDE.md` — Next.js frontend for endpoint management
 - `nextjs-ui/AGENTS.md` — Frontend agent quick-reference
@@ -64,6 +65,7 @@ Open the nearest scoped guide for the code you are changing.
 - `proxbox_api/routes/virtualization/virtual_machines/CLAUDE.md` — VM sync routes
 - `proxbox_api/services/CLAUDE.md` — Service layer index
 - `proxbox_api/services/sync/CLAUDE.md` — Sync workflow services
+- `proxbox_api/services/sync/reconciliation/CLAUDE.md` — VM reconciliation seam and engine modes
 - `proxbox_api/services/sync/individual/CLAUDE.md` — Individual object sync services
 - `proxbox_api/session/CLAUDE.md` — Session and client factories
 - `proxbox_api/schemas/CLAUDE.md` — Pydantic schema index
@@ -92,9 +94,11 @@ Open the nearest scoped guide for the code you are changing.
 ## Repo Structure
 
 - `proxbox_api/`: FastAPI package, session factories, schemas, routes, sync services, code generation, and shared utilities.
+- `proxbox-reconcile-rs/`: optional PyO3/maturin Rust package for VM operation-queue reconciliation parity testing and opt-in execution.
 - `proxmox-sdk/`: Schema-driven Proxmox API package used for both mock endpoints and real API access.
 - `nextjs-ui/`: Next.js frontend used to manage one NetBox endpoint and multiple Proxmox endpoints.
 - `tests/`: Unit, integration, and end-to-end tests for the backend package.
+- `benchmarks/`: local benchmark helpers, including VM reconciliation queue datasets and timers.
 - `docs/`: MkDocs documentation, including English and Brazilian Portuguese content.
 - `scripts/`: Utility scripts, including schema refresh helpers.
 - `automation/`: Placeholder for future automation workflows.
@@ -120,8 +124,10 @@ Open the nearest scoped guide for the code you are changing.
 1. `proxbox_api.app.factory.create_app()` initializes database state, builds the default NetBox session, and records bootstrap status.
 2. The app registers generated Proxmox proxy routes during lifespan startup and wires shared middleware, routers, and exception handlers.
 3. Requests resolve NetBox and Proxmox sessions through dependency providers.
-4. Route handlers delegate heavy work to service modules and schemas.
-5. Sync runs emit journal entries, structured logs, and optional WebSocket or SSE progress messages.
+4. VM sync routes prepare Proxmox/NetBox state, then delegate deterministic VM
+   operation-queue reconciliation to `proxbox_api.services.sync.reconciliation`.
+5. Route handlers delegate remaining heavy work to service modules and schemas.
+6. Sync runs emit journal entries, structured logs, and optional WebSocket or SSE progress messages.
 
 ### Error and data rules
 
@@ -186,6 +192,13 @@ the `netbox-proxbox` side, do all five — the existing fields in
 - `PROXBOX_ENCRYPTION_KEY_FILE`: optional override for the local key file path used when neither the env var nor the plugin settings provide a key. Defaults to `<repo_root>/data/encryption.key`.
 - `PROXBOX_ALLOW_PLAINTEXT_CREDENTIALS`: legacy opt-in flag for plaintext credential storage. No longer required for startup; kept for compatibility with operators who scripted it.
 - `PROXBOX_LOG_LEVEL`: console log verbosity (default `INFO`). Valid values: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` (case-insensitive). Controls only the console handler; the in-memory buffer always receives DEBUG+ and the rotating file handler always writes WARNING+. Setting `DEBUG` also enables full `netbox_sdk.client` per-request tracing which is suppressed at all other levels to prevent INFO-level flooding.
+- `PROXBOX_RECONCILIATION_ENGINE`: VM operation-queue engine. Valid values:
+  `python` (default), `compare`, and `rust`. `compare` runs Python and Rust,
+  logs/increments mismatch metrics, and returns Python output. `rust` requires
+  the optional `proxbox-reconcile-rs` native package to be installed.
+- `PROXBOX_RECONCILIATION_COMPARE_STRICT`: when `true`, compare mode raises on
+  Rust/Python mismatch. Use this in CI/parity tests, not normal production
+  syncs.
 
 ### Plugin-managed (env override optional, defaults shown)
 
@@ -224,6 +237,18 @@ uv run python -c "import proxbox_api.main"
 uv run python -c "from proxbox_api.proxmox_to_netbox.proxmox_schema import load_proxmox_generated_openapi; assert load_proxmox_generated_openapi().get('paths')"
 uv run ty check proxbox_api/types proxbox_api/utils/retry.py proxbox_api/schemas/sync.py
 uv run pytest tests
+```
+
+If you touch `proxbox_api/services/sync/reconciliation/`, `tests/reconciliation/`,
+`benchmarks/reconciliation/`, `proxbox-reconcile-rs/`, or `.github/workflows/rust-reconcile.yml`,
+also run the focused Rust/parity checks:
+
+```bash
+cargo test --no-default-features --manifest-path proxbox-reconcile-rs/Cargo.toml
+uv pip install -e proxbox-reconcile-rs
+PROXBOX_RECONCILIATION_ENGINE=compare \
+  PROXBOX_RECONCILIATION_COMPARE_STRICT=true \
+  uv run pytest tests/reconciliation -q
 ```
 
 If you touch `nextjs-ui/`, also run:
@@ -280,11 +305,36 @@ See `proxbox_api/types/CLAUDE.md` for complete typing guidelines.
 
 ## Rust-Python FFI Reference
 
-The `proxbox-api` backend is pure Python today. When performance-critical paths
-(sync transforms in `proxmox_to_netbox/`, codegen pipeline in
-`proxmox_codegen/`, bulk data serialization in `services/sync/`, or generated
-Proxmox proxy routes) justify native Rust extensions, use PyO3 as the binding
-framework:
+The backend now has one optional native extension:
+`proxbox-reconcile-rs`, a PyO3/maturin Rust package for the deterministic VM
+operation-queue builder used by full VM sync. Python remains the default engine
+because live `netbox.nmulti.cloud` timing and synthetic benchmarks showed the
+full Rust path was not faster after JSON/adaptation overhead.
+
+The runtime seam is:
+
+```
+prepared_vms + netbox_snapshot + flags
+  -> proxbox_api.services.sync.reconciliation.build_vm_operation_queue()
+  -> Python engine, compare mode, or optional Rust engine
+  -> CREATE | GET | UPDATE operations with patch_payload
+```
+
+Keep FastAPI routes, NetBox/Proxmox clients, SQLite, auth, retries, streaming,
+and dispatch execution in Python. Only pure, synchronous, CPU-bound queue
+construction belongs behind the Rust bridge.
+
+Engine modes:
+
+- `PROXBOX_RECONCILIATION_ENGINE=python`: default and production-safe path.
+- `PROXBOX_RECONCILIATION_ENGINE=compare`: run both engines, return Python,
+  and report mismatches through logs and `proxbox_reconcile_mismatch_total`.
+- `PROXBOX_RECONCILIATION_ENGINE=rust`: return Rust output; requires the
+  native package and should only be used after compare mode is clean.
+- `PROXBOX_RECONCILIATION_COMPARE_STRICT=true`: raise on mismatch in compare
+  mode, intended for CI and local parity debugging.
+
+When adding future native Rust extensions, use PyO3 as the binding framework:
 
 - Architecture reference: `/root/personal-context/PYO3.md`
 - Per-directory guidance: `/root/personal-context/pyo3/CLAUDE.md`
@@ -292,10 +342,23 @@ framework:
 - Build backend: maturin (preferred) or setuptools-rust
 - Version: PyO3 v0.28.3, minimum Rust 1.83
 
+Current Rust package:
+
+- `proxbox-reconcile-rs/`: Rust VM reconciliation crate.
+- `proxbox_api/services/sync/reconciliation/rust_bridge.py`: Pydantic v2
+  JSON-byte adapter and optional native import.
+- `proxbox_api/services/sync/reconciliation/vm_queue.py`: engine-neutral
+  wrapper, Python fallback, compare mode, strict mode, mismatch diffing, and
+  dataclass adaptation.
+- `tests/reconciliation/`: Python contract, bridge, engine-mode, and
+  Rust/Python parity fixtures.
+- `.github/workflows/rust-reconcile.yml`: Rust unit tests, strict parity matrix,
+  and wheel build matrix.
+
 Candidate hotpaths for future Rust acceleration:
 - `proxbox_api/proxmox_to_netbox/` — object mapping and field transformation
 - `proxbox_api/proxmox_codegen/` — OpenAPI schema crawling and code generation
-- `proxbox_api/services/sync/` — bulk reconciliation and diffing
+- `proxbox_api/services/sync/` — additional bulk reconciliation and diffing
 - `proxbox_api/generated/` — generated Pydantic model validation
 
 ## Extension Rules

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -23,12 +23,14 @@ docs/
 ├── architecture/               # System overview and design patterns
 ├── api/                        # HTTP and WebSocket API reference
 ├── sync/                       # Sync workflow documentation
+│   └── reconciliation-architecture.md
 └── pt-BR/                      # Brazilian Portuguese translations
     ├── api/
     ├── architecture/
     ├── development/
     ├── getting-started/
     └── sync/
+        └── reconciliation-architecture.md
 ```
 
 ## Building and Serving Docs
@@ -49,4 +51,7 @@ uv run mkdocs build
 - Keep English (`docs/`) and Portuguese (`docs/pt-BR/`) files in sync when updating content.
 - API reference in `docs/api/` should match the actual route signatures in `proxbox_api/routes/`.
 - Architecture diagrams belong in `docs/architecture/`.
+- Reconciliation engine docs live under `docs/sync/reconciliation-architecture.md`
+  and `docs/pt-BR/sync/reconciliation-architecture.md`; keep them aligned
+  with `proxbox_api/services/sync/reconciliation/` and `proxbox-reconcile-rs/`.
 - Do not store generated artifacts or runtime data in `docs/`.

--- a/proxbox-reconcile-rs/AGENTS.md
+++ b/proxbox-reconcile-rs/AGENTS.md
@@ -1,0 +1,22 @@
+# proxbox-reconcile-rs Agent Guide
+
+Read `CLAUDE.md` first for the full architecture and rollout rules.
+
+## Quick Rules
+
+- This crate is optional; Python remains the default reconciliation engine.
+- Keep the crate pure: no HTTP, async runtime, SQLite, auth, retries, dispatch,
+  or streaming.
+- Preserve parity with `build_vm_operation_queue_python()`.
+- Keep QEMU/LXC identity keys typed with `vm_type`.
+- Run Rust tests and strict Python/Rust parity tests before pushing changes.
+
+## Required Checks
+
+```bash
+cargo test --no-default-features --manifest-path proxbox-reconcile-rs/Cargo.toml
+uv pip install -e proxbox-reconcile-rs
+PROXBOX_RECONCILIATION_ENGINE=compare \
+  PROXBOX_RECONCILIATION_COMPARE_STRICT=true \
+  uv run pytest tests/reconciliation -q
+```

--- a/proxbox-reconcile-rs/CLAUDE.md
+++ b/proxbox-reconcile-rs/CLAUDE.md
@@ -1,0 +1,93 @@
+# proxbox-reconcile-rs Directory Guide
+
+## Workspace Context
+
+This file lives at `/root/personal-context/nmulticloud-context/proxbox-api/proxbox-reconcile-rs/CLAUDE.md` inside the `personal-context` workspace.
+Workspace guidance: `/root/personal-context/CLAUDE.md`.
+Per-repo deep-dive: `/root/personal-context/claude-reference/proxbox-api.md`.
+Submodule layout and cross-repo links: `/root/personal-context/claude-reference/dependency-map.md`.
+
+---
+
+## Purpose
+
+Optional PyO3/maturin Rust package for the deterministic VM operation-queue
+reconciliation seam in `proxbox-api`.
+
+This package is intentionally separate from the FastAPI backend. It has no
+HTTP clients, async runtime, SQLite access, auth, retry logic, dispatch
+execution, or streaming. It receives JSON bytes, computes the queue, and
+returns JSON bytes.
+
+## Boundary
+
+Input:
+
+```text
+prepared_vms + netbox_snapshot + flags
+```
+
+Output:
+
+```text
+CREATE | GET | UPDATE operations with patch_payload
+```
+
+The Python bridge lives in
+`proxbox_api/services/sync/reconciliation/rust_bridge.py`. The engine-neutral
+wrapper and Python fallback live in
+`proxbox_api/services/sync/reconciliation/vm_queue.py`.
+
+## Runtime Rules
+
+- Python remains the default engine: `PROXBOX_RECONCILIATION_ENGINE=python`.
+- `compare` mode runs Python and Rust, returns Python, and records mismatches.
+- `rust` mode requires this package to be installed and should only be enabled
+  after compare mode is clean in the target environment.
+- The PyO3 entry point must copy Python-owned bytes into `Vec<u8>` before
+  releasing the GIL.
+- Keep the Rust implementation deterministic. Preserve VM order and use stable
+  map behavior where output order matters.
+- Include `vm_type` in all VM identity keys to avoid QEMU/LXC VMID collisions.
+- Match Python's loose number semantics for integer/float JSON comparisons.
+- Keep tag comparison order-independent and preserve the documented
+  custom-field null/missing semantics.
+
+## Files
+
+- `Cargo.toml`: crate metadata, PyO3, serde, serde_json, thiserror, indexmap.
+- `pyproject.toml`: maturin build backend and native module path.
+- `src/lib.rs`: PyO3 module and GIL-release wrapper.
+- `src/vm.rs`: queue input/output structs and VM operation builder.
+- `src/normalize.rs`: relation, tag, custom-field, and current-record normalization.
+- `src/diff.rs`: loose JSON diffing and overwrite-rule application.
+- `python/proxbox_reconcile_rs/__init__.py`: Python package re-export surface.
+- `tests/`: import smoke coverage for the built extension.
+
+## Checks
+
+Run these when changing this package or its Python bridge:
+
+```bash
+cargo test --no-default-features --manifest-path proxbox-reconcile-rs/Cargo.toml
+uv pip install -e proxbox-reconcile-rs
+PROXBOX_RECONCILIATION_ENGINE=compare \
+  PROXBOX_RECONCILIATION_COMPARE_STRICT=true \
+  uv run pytest tests/reconciliation -q
+```
+
+For a wheel smoke test:
+
+```bash
+uv run --with maturin maturin build --release \
+  --out /tmp/proxbox-reconcile-dist \
+  --manifest-path proxbox-reconcile-rs/Cargo.toml
+```
+
+## Rollout Guidance
+
+Do not make Rust the default based on microbenchmarks alone. The initial live
+measurement showed VM reconciliation was a tiny share of real sync wall time,
+and full synthetic Rust-path benchmarks were slower after serialization and
+adaptation overhead. Keep Python default unless future real-sync evidence shows
+the full Rust path is faster and parity has stayed clean.

--- a/proxbox-reconcile-rs/README.md
+++ b/proxbox-reconcile-rs/README.md
@@ -2,8 +2,9 @@
 
 Optional native reconciliation engine for `proxbox-api`.
 
-This package is intentionally independent from the Python API package and is not
-wired into production reconciliation yet.
+This package is intentionally independent from the Python API package. The
+Python backend can use it through `PROXBOX_RECONCILIATION_ENGINE=compare` or
+`PROXBOX_RECONCILIATION_ENGINE=rust`, but Python remains the default engine.
 
 ## Local Development
 

--- a/proxbox_api/CLAUDE.md
+++ b/proxbox_api/CLAUDE.md
@@ -17,7 +17,7 @@ Core FastAPI package for `proxbox-api`. This package owns application compositio
 
 - `app/` — application factory, bootstrap, CORS, exception handlers, cache routes, root metadata, full-update orchestration, and WebSocket handlers. See `app/CLAUDE.md`.
 - `routes/` — FastAPI route packages for admin, NetBox, Proxmox, DCIM, virtualization, Proxbox plugin access, and sync helpers. See `routes/CLAUDE.md`.
-- `services/` — synchronization workflows and reusable helper logic, including the typed Proxmox helper layer. See `services/CLAUDE.md`.
+- `services/` — synchronization workflows and reusable helper logic, including the typed Proxmox helper layer and VM reconciliation seam. See `services/CLAUDE.md`.
 - `session/` — NetBox and Proxmox session factories, providers, and dependency aliases. See `session/CLAUDE.md`.
 - `schemas/` — Pydantic request and response models for external and internal contracts. See `schemas/CLAUDE.md`.
 - `enum/` — Proxmox and NetBox choice values used by schemas and routes. See `enum/CLAUDE.md`.
@@ -40,7 +40,10 @@ Core FastAPI package for `proxbox-api`. This package owns application compositio
 - `auth.py` implements bcrypt-hashed API key validation, IP-based brute-force lockout, and the `check_auth_header_with_session` helper used by `APIKeyAuthMiddleware`.
 - `database.py` persists NetBox and Proxmox endpoint records, API keys, and auth lockout state in SQLite.
 - `session/netbox.py` and `session/proxmox.py` own client construction and dependency wiring. Route handlers should use these dependencies instead of creating clients inline.
-- `services/sync/` and `routes/virtualization/virtual_machines/` handle the main Proxmox-to-NetBox sync flow, including per-object journal tracking and stream progress.
+- `services/sync/`, `services/sync/reconciliation/`, and
+  `routes/virtualization/virtual_machines/` handle the main Proxmox-to-NetBox
+  sync flow, including VM operation-queue classification, per-object journal
+  tracking, and stream progress.
 - `proxmox_to_netbox/` is the normalization boundary. Parsing and conversion must happen in schemas and mappers, not in route handlers.
 
 ## Key Data Flow
@@ -48,8 +51,11 @@ Core FastAPI package for `proxbox-api`. This package owns application compositio
 1. Startup bootstraps the local database and default NetBox session unless bootstrap is skipped.
 2. Routes resolve NetBox or Proxmox clients through dependency aliases.
 3. Service modules fetch source data, normalize it through schemas, and create or update NetBox objects.
-4. Route handlers translate those workflows into HTTP, SSE, or WebSocket responses.
-5. Generated Proxmox routes are mounted at lifespan startup and may fail open or fail closed depending on `PROXBOX_STRICT_STARTUP`.
+4. Full VM sync prepares Proxmox VM state plus a NetBox snapshot, then calls
+   `proxbox_api.services.sync.reconciliation.build_vm_operation_queue()` to
+   classify `CREATE`, `GET`, and `UPDATE` operations before dispatch.
+5. Route handlers translate those workflows into HTTP, SSE, or WebSocket responses.
+6. Generated Proxmox routes are mounted at lifespan startup and may fail open or fail closed depending on `PROXBOX_STRICT_STARTUP`.
 
 ## Extension Guidance
 
@@ -59,6 +65,8 @@ Core FastAPI package for `proxbox-api`. This package owns application compositio
 - Preserve ASCII-only documentation and source text unless a file already requires otherwise.
 - Prefer `ProxboxException` for expected API failures and `logger` for operational messages.
 - When adding new sync behavior, keep WebSocket and SSE payload shapes aligned.
+- Keep deterministic reconciliation logic in `services/sync/reconciliation/`.
+  Do not re-grow operation-queue diffing inside VM route modules.
 - For new runtime tunables, prefer a `ProxboxPluginSettings` field on the
   `netbox-proxbox` side over a fresh `PROXBOX_*` env var. Read it through
   `proxbox_api.runtime_settings.get_int / get_float / get_bool / get_str`, which

--- a/proxbox_api/routes/virtualization/virtual_machines/CLAUDE.md
+++ b/proxbox_api/routes/virtualization/virtual_machines/CLAUDE.md
@@ -22,7 +22,9 @@ Main synchronization endpoints for virtual machines and related resources.
 - `helpers.py`: shared VM route helpers and concurrency helpers.
 - `snapshots_vm.py`: snapshot reconciliation helpers and routes.
 - `storages_vm.py`: storage reconciliation helpers and routes.
-- `sync_vm.py`: VM sync orchestration routes, including the create and stream entrypoints.
+- `sync_vm.py`: VM sync orchestration routes, including the create and stream
+  entrypoints. Deterministic operation-queue reconciliation is delegated to
+  `proxbox_api.services.sync.reconciliation`.
 
 ## How These Routes Work
 
@@ -31,6 +33,9 @@ Main synchronization endpoints for virtual machines and related resources.
 - They write journal entries to NetBox for auditability of each synchronization run.
 - Some paths stream progress over WebSocket or SSE, so those payloads must stay aligned.
 - `sync_vm.py` also exposes the test route and the summary example route used by stub/coverage checks.
+- Full VM sync prepares desired VM state and the NetBox snapshot here, but queue
+  classification (`CREATE`, `GET`, `UPDATE`) belongs to the reconciliation
+  service seam.
 
 ## Extension Guidance
 
@@ -38,3 +43,6 @@ Main synchronization endpoints for virtual machines and related resources.
 - Keep WebSocket and non-WebSocket code paths behaviorally equivalent.
 - Use `WebSocketSSEBridge` and `StreamingResponse` with `text/event-stream` for new stream endpoints.
 - Keep read routes explicit about not-found and upstream-error behavior.
+- Do not reintroduce VM operation diffing in the route. Update
+  `proxbox_api/services/sync/reconciliation/` and `tests/reconciliation/`
+  instead.

--- a/proxbox_api/services/CLAUDE.md
+++ b/proxbox_api/services/CLAUDE.md
@@ -18,6 +18,8 @@ Reusable business workflows for synchronization, reconciliation, and Proxmox hel
 - `__init__.py`: service package namespace.
 - `proxmox_helpers.py`: typed Proxmox helper functions used by route orchestration and validated against generated models.
 - `sync/`: main synchronization workflows for clusters, devices, virtual machines, storage, backups, snapshots, disks, interfaces, IPs, and task history.
+- `sync/reconciliation/`: pure operation-queue builders, including the VM queue
+  Python fallback and optional Rust bridge.
 - `sync/individual/`: targeted single-object sync workflows with dependency auto-creation and dry-run support.
 
 ## How Services Are Used
@@ -25,6 +27,8 @@ Reusable business workflows for synchronization, reconciliation, and Proxmox hel
 - Route handlers import these modules to keep HTTP, SSE, and WebSocket code thin.
 - `session/` provides the authenticated clients that service functions consume.
 - `schemas/` and `proxmox_to_netbox/` provide the normalization layer that services rely on.
+- VM full sync uses `sync/reconciliation/build_vm_operation_queue()` as the
+  synchronous boundary between prepared desired state and NetBox write dispatch.
 
 ## Extension Guidance
 
@@ -32,3 +36,5 @@ Reusable business workflows for synchronization, reconciliation, and Proxmox hel
 - Prefer idempotent operations so repeated sync runs are safe.
 - Surface predictable errors through `ProxboxException`.
 - Keep response payloads compatible with both JSON and stream transports when a service is reused in SSE or WebSocket paths.
+- Keep reconciliation seams pure: no HTTP clients, async I/O, database writes,
+  retry loops, or stream emission inside queue builders.

--- a/proxbox_api/services/sync/CLAUDE.md
+++ b/proxbox_api/services/sync/CLAUDE.md
@@ -20,6 +20,8 @@ Synchronization services responsible for NetBox object creation from Proxmox dat
 - `device_ensure.py`: device creation and reconciliation helpers.
 - `devices.py`: device synchronization from Proxmox nodes to NetBox.
 - `network.py`: network and interface sync helpers.
+- `reconciliation/`: pure operation-queue reconciliation, Python fallback,
+  optional Rust bridge, mismatch metric, and shared VM operation types.
 - `snapshots.py`: snapshot sync helpers.
 - `storage_links.py`: storage-to-NetBox relationship helpers.
 - `storages.py`: storage sync helpers.
@@ -40,6 +42,8 @@ Synchronization services responsible for NetBox object creation from Proxmox dat
 - Route handlers call these helpers to keep HTTP orchestration thin.
 - These modules implement idempotent Proxmox-to-NetBox sync flows and journal tracking.
 - The VM helpers split orchestration, filtering, network processing, and object creation so the route layer does not need to duplicate state handling.
+- `reconciliation/` is the deterministic sync seam: it receives prepared state
+  and NetBox snapshots, returns queue operations, and performs no I/O.
 
 ## Extension Guidance
 
@@ -47,3 +51,5 @@ Synchronization services responsible for NetBox object creation from Proxmox dat
 - Emit structured errors with `ProxboxException` for route-level handling.
 - Keep progress reporting compatible with both WebSocket and SSE transport.
 - Prefer small helper functions for object-specific concerns instead of growing a single coordinator module.
+- For VM queue changes, update `tests/reconciliation/` and preserve
+  Rust/Python parity before touching dispatch behavior.

--- a/proxbox_api/services/sync/reconciliation/CLAUDE.md
+++ b/proxbox_api/services/sync/reconciliation/CLAUDE.md
@@ -1,0 +1,78 @@
+# proxbox_api/services/sync/reconciliation Directory Guide
+
+## Workspace Context
+
+This file lives at `/root/personal-context/nmulticloud-context/proxbox-api/proxbox_api/services/sync/reconciliation/CLAUDE.md` inside the `personal-context` workspace.
+Workspace guidance: `/root/personal-context/CLAUDE.md`.
+Per-repo deep-dive: `/root/personal-context/claude-reference/proxbox-api.md`.
+Submodule layout and cross-repo links: `/root/personal-context/claude-reference/dependency-map.md`.
+
+---
+
+## Purpose
+
+Pure, synchronous reconciliation seams used by sync routes. The current seam is
+the VM operation-queue builder extracted from
+`proxbox_api/routes/virtualization/virtual_machines/sync_vm.py`.
+
+The service turns prepared VM state and a NetBox VM snapshot into deterministic
+NetBox operations:
+
+```text
+CREATE | GET | UPDATE + patch_payload
+```
+
+No HTTP, async, database access, auth, retry handling, dispatch execution, SSE,
+or WebSocket code belongs here.
+
+## Current Files
+
+- `__init__.py`: public reconciliation package exports.
+- `types.py`: `PreparedVMState`, `NetBoxVMOperation`, and shared key aliases.
+- `vm_queue.py`: engine-neutral VM queue entry point, Python implementation,
+  Rust compare/rust dispatch, mismatch diffing, and operation adaptation.
+- `rust_bridge.py`: Pydantic v2 JSON-byte bridge into the optional
+  `proxbox-reconcile-rs` native package.
+- `metrics.py`: mismatch counter plumbing exposed through cache metrics.
+
+## Engine Modes
+
+- `PROXBOX_RECONCILIATION_ENGINE=python`: default. Always available.
+- `PROXBOX_RECONCILIATION_ENGINE=compare`: run Python and Rust, log/increment
+  mismatches, return Python output.
+- `PROXBOX_RECONCILIATION_ENGINE=rust`: return Rust output. Requires
+  `proxbox-reconcile-rs` to be installed.
+- `PROXBOX_RECONCILIATION_COMPARE_STRICT=true`: raise on mismatch in compare
+  mode. Use in CI and local parity debugging.
+
+## Parity Rules
+
+- Preserve input order in output operations.
+- Include `vm_type` in VM identity/adaptation keys to avoid QEMU/LXC collisions
+  when both have the same VMID in a cluster.
+- Treat `2048` and `2048.0` as equal.
+- Compare tags order-independently, but preserve merge semantics when
+  `overwrite_vm_tags=True`.
+- Keep relation handling tolerant of both integer IDs and nested objects with
+  `id`.
+- Preserve documented `custom_fields: {"foo": None}` versus `{}` behavior.
+- If NetBox lacks the `virtual_machine_type` field, do not generate a patch for
+  that field.
+
+## Checks
+
+Run these for this directory:
+
+```bash
+uv run pytest tests/reconciliation -q
+```
+
+When the Rust package is installed or changed, run strict parity:
+
+```bash
+cargo test --no-default-features --manifest-path proxbox-reconcile-rs/Cargo.toml
+uv pip install -e proxbox-reconcile-rs
+PROXBOX_RECONCILIATION_ENGINE=compare \
+  PROXBOX_RECONCILIATION_COMPARE_STRICT=true \
+  uv run pytest tests/reconciliation -q
+```

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -45,6 +45,10 @@ Unit, integration, and end-to-end tests for the `proxbox_api` backend package. A
 | `test_pydantic_generator_models.py` | Pydantic model generation from OpenAPI specs |
 | `test_qemu_guest_agent_helpers.py` | QEMU guest agent utility functions |
 | `test_qemu_guest_agent_sync.py` | QEMU guest agent sync workflows |
+| `reconciliation/test_rust_bridge_python.py` | Pydantic bridge serialization and optional Rust import behavior |
+| `reconciliation/test_vm_queue_engine_modes.py` | `python`, `compare`, and `rust` reconciliation engine-mode behavior |
+| `reconciliation/test_vm_queue_parity.py` | Rust/Python fixture parity for VM operation queues |
+| `reconciliation/test_vm_queue_python.py` | Python VM operation-queue contract and edge-case semantics |
 | `test_replications_backup_routines_sync.py` | Replication and backup-routine sync workflows |
 | `test_schema_contracts.py` | Pydantic schema validation and contract checks |
 | `test_session_and_helpers.py` | Session factory creation and dependency wiring |
@@ -99,6 +103,12 @@ uv run pytest tests/e2e -m mock_backend
 
 # E2E tests against HTTP mock container (requires the proxmox-mock service running)
 uv run pytest tests/e2e -m mock_http
+
+# VM reconciliation contract and optional Rust parity tests
+uv run pytest tests/reconciliation -q
+PROXBOX_RECONCILIATION_ENGINE=compare \
+  PROXBOX_RECONCILIATION_COMPARE_STRICT=true \
+  uv run pytest tests/reconciliation -q
 ```
 
 ## Conventions
@@ -108,6 +118,9 @@ uv run pytest tests/e2e -m mock_http
 - `proxmox_sdk` is the canonical mock source for Proxmox API responses.
 - Keep each test file scoped to one module or workflow; cross-cutting concerns go in `fixtures.py`.
 - The global `tests/conftest.py` sets `PROXBOX_RATE_LIMIT=999999` at module-import time so SlowAPI does not trip during the suite.
+- Reconciliation fixtures must stay deterministic. Include `vm_type` in VM
+  identity expectations so QEMU and LXC resources with the same VMID do not
+  collide.
 
 ## TestClient Fixtures (conftest.py)
 


### PR DESCRIPTION
Closes #184

## Summary

- Updates the root `CLAUDE.md` and `AGENTS.md` guidance with the merged optional Rust VM reconciliation engine, engine modes, and focused parity checks.
- Adds scoped agent docs for `proxbox-reconcile-rs/` and `proxbox_api/services/sync/reconciliation/`.
- Updates sync-service, VM-route, tests, docs, and CI guides so future agents know the queue builder lives in the pure reconciliation seam and Python remains the default engine.
- Corrects the Rust crate README statement that previously said the package was not wired into reconciliation.

## Verification

- `git diff --check`
- `cargo test --no-default-features --manifest-path proxbox-reconcile-rs/Cargo.toml`
- `XDG_DATA_HOME=/tmp/xdg-data UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/reconciliation -q` -> 38 passed, 10 skipped
- `XDG_DATA_HOME=/tmp/xdg-data UV_CACHE_DIR=/tmp/uv-cache PROXBOX_RECONCILIATION_ENGINE=compare PROXBOX_RECONCILIATION_COMPARE_STRICT=true uv run pytest tests/reconciliation -q` -> 48 passed

## Notes

The workspace-level `/root/personal-context/CLAUDE.md`, `/root/personal-context/AGENTS.md`, and `/root/personal-context/claude-reference/proxbox-api.md` were also updated locally so the parent agent index reflects the Rust reconciliation engine. Those files live outside this repository and are not part of this PR.