### PR TITLE
Publish experimental PyO3/Rust Docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,3 +19,5 @@ tasks
 coverage.xml
 .coverage
 htmlcov
+proxbox-reconcile-rs/target
+proxbox-reconcile-rs/python/proxbox_reconcile_rs/_native*.so

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -19,7 +19,7 @@ GitHub Actions CI/CD workflows for `proxbox-api`. All workflows live under `.git
 |------|---------|--------------|
 | `ci.yml` | Push / PR to any branch; Release published; manual dispatch | Lint (ruff), compile, import smoke checks, run `tests/` with coverage, then E2E Docker matrix (dev or pypi mode). Docker-backed E2E runs with the `mock_http` marker; the in-process MockBackend pass runs separately. |
 | `docs.yml` | Push to `main` | Builds MkDocs site and deploys to GitHub Pages |
-| `docker-hub-publish.yml` | Called by `publish-testpypi.yml` on Release, or manual dispatch | Builds and pushes three Alpine-based Docker images to Docker Hub: raw (uvicorn), nginx (nginx+mkcert+uvicorn), granian (granian+mkcert) |
+| `docker-hub-publish.yml` | Called by `publish-testpypi.yml` on Release, or manual dispatch | Builds and pushes Alpine-based Docker images to Docker Hub: raw (uvicorn), nginx (nginx+mkcert+uvicorn), granian (granian+mkcert), plus experimental PyO3/Rust variants |
 | `publish-testpypi.yml` | Version tag push, GitHub Release published, or manual dispatch | Validates release metadata, builds dist, then runs either the TestPyPI lane or the PyPI lane. `rcN` tag pushes publish to TestPyPI for release-candidate validation; non-rc tag pushes (`vX.Y.Z`, `vX.Y.Z.postN`), GitHub releases, and `publish_target=pypi` dispatches publish to PyPI. PyPI success then publishes Docker images and runs post-publish E2E. |
 | `rust-reconcile.yml` | Push / PR to `main`, `testing`, or `v*`; manual dispatch | Runs Rust unit tests for `proxbox-reconcile-rs`, installs the local native extension, runs strict Rust/Python reconciliation parity tests, and builds wheel artifacts across Linux/macOS/Windows for Python 3.12 and 3.13. |
 | `nightly-schema-refresh.yml` | Scheduled (nightly) | Runs `scripts/refresh_schemas.py` and opens a PR if schemas changed |
@@ -80,8 +80,11 @@ publish-testpypi.yml (staged package release)
 | Raw (uvicorn, HTTP) | `latest` | `<version>` |
 | Nginx (nginx+mkcert, HTTPS) | `latest-nginx` | `<version>-nginx` |
 | Granian (granian+mkcert, HTTPS) | `latest-granian` | `<version>-granian` |
+| Raw PyO3/Rust experimental | `experimental`, `pyo3-rust` | `<version>-pyo3-rust` |
+| Nginx PyO3/Rust experimental | `experimental-nginx`, `pyo3-rust-nginx` | `<version>-pyo3-rust-nginx` |
+| Granian PyO3/Rust experimental | `experimental-granian`, `pyo3-rust-granian` | `<version>-pyo3-rust-granian` |
 
-All tags also have `sha-<commit>` variants (e.g., `sha-abc1234`, `sha-abc1234-nginx`, `sha-abc1234-granian`).
+All tags also have `sha-<commit>` variants (e.g., `sha-abc1234`, `sha-abc1234-nginx`, `sha-abc1234-granian`, `sha-abc1234-pyo3-rust`).
 
 ## Key Rules
 

--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -1,4 +1,5 @@
-# Three Alpine-based images: raw (uvicorn), nginx (nginx+mkcert+uvicorn), granian (granian+mkcert).
+# Alpine-based images: raw (uvicorn), nginx (nginx+mkcert+uvicorn), granian
+# (granian+mkcert), plus experimental PyO3/Rust engine variants.
 # Triggers:
 # - workflow_call: CI (main/testing) and release → always build, test, push (parallel jobs).
 # - workflow_dispatch: manual — test-only (no Hub) or full publish (parallel jobs, same as call).
@@ -15,7 +16,8 @@ on:
       mode:
         description: >-
           build-and-test-only — amd64 build + in-container tests, no Docker Hub.
-          publish — build, smoke-test, and push raw + nginx + granian images.
+          publish — build, smoke-test, and push raw + nginx + granian images,
+          plus experimental PyO3/Rust engine variants.
         type: string
         required: false
         default: publish
@@ -29,7 +31,8 @@ on:
       mode:
         description: >-
           build-and-test-only — amd64 build + in-container tests, no Docker Hub.
-          publish — same as CI/release (push raw + nginx + granian, multi-arch).
+          publish — same as CI/release (push raw + nginx + granian and
+          experimental PyO3/Rust variants, multi-arch).
         type: choice
         required: true
         options:
@@ -392,6 +395,201 @@ jobs:
             ok=0
             for i in $(seq 1 40); do
               if curl -fsS --max-time 5 http://127.0.0.1:18080/ >/dev/null 2>&1; then
+                ok=1
+                break
+              fi
+              sleep 2
+            done
+            if [ "$ok" -ne 1 ]; then
+              docker logs "$NAME"
+              docker rm -f "$NAME"
+              exit 1
+            fi
+            docker rm -f "$NAME"
+          done
+
+  docker-pyo3-rust:
+    if: inputs.mode == 'publish'
+    name: Docker Hub — ${{ matrix.variant }} PyO3/Rust experimental
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: raw
+            target: raw-pyo3-rust
+            version_suffix: -pyo3-rust
+            experimental_tag: experimental
+            pyo3_tag: pyo3-rust
+            cache_scope: raw-pyo3-rust
+            smoke_name: raw-pyo3-rust
+            smoke_port: "18081"
+            smoke_url: http://127.0.0.1:18081/
+            curl_flags: -fsS
+          - variant: nginx
+            target: nginx-pyo3-rust
+            version_suffix: -pyo3-rust-nginx
+            experimental_tag: experimental-nginx
+            pyo3_tag: pyo3-rust-nginx
+            cache_scope: nginx-pyo3-rust
+            smoke_name: nginx-pyo3-rust
+            smoke_port: "18445"
+            smoke_url: https://127.0.0.1:18445/
+            curl_flags: -kfsS
+          - variant: granian
+            target: granian-pyo3-rust
+            version_suffix: -pyo3-rust-granian
+            experimental_tag: experimental-granian
+            pyo3_tag: pyo3-rust-granian
+            cache_scope: granian-pyo3-rust
+            smoke_name: granian-pyo3-rust
+            smoke_port: "18446"
+            smoke_url: https://127.0.0.1:18446/
+            curl_flags: -kfsS
+    steps:
+      - name: Resolve checkout ref
+        id: checkout_source
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_REF: ${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}
+        run: |
+          set -euo pipefail
+          encoded_ref="$(python3 - <<'PY'
+          import os
+          from urllib.parse import quote
+
+          print(quote(os.environ["SOURCE_REF"], safe=""))
+          PY
+          )"
+          sha="$(gh api "repos/${{ github.repository }}/commits/$encoded_ref" --jq .sha)"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.checkout_source.outputs.sha }}
+
+      - name: Resolve source revision
+        id: source
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Resolve image version from pyproject
+        id: version
+        env:
+          GIT_REF: ${{ inputs.source_ref != '' && inputs.source_ref || github.ref_name }}
+        run: |
+          python3 <<'PY'
+          import os
+          import pathlib
+          import tomllib
+
+          data = tomllib.loads(pathlib.Path("pyproject.toml").read_text(encoding="utf-8"))
+          version = data["project"]["version"]
+          expected_tag = f"v{version}"
+          git_ref = os.environ["GIT_REF"].strip()
+          if git_ref.startswith("v") and git_ref != expected_tag:
+              raise SystemExit(
+                  f"git ref / pyproject mismatch: ref={git_ref!r}, expected {expected_tag!r}"
+              )
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"tag={version}\n")
+          PY
+
+      - name: Keep image tag in env
+        run: echo "IMAGE_TAG=${{ steps.version.outputs.tag }}" >> $GITHUB_ENV
+
+      - name: Build amd64 ${{ matrix.variant }} PyO3/Rust image for pre-release tests
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: ${{ matrix.target }}
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: emersonfelipesp/proxbox-api:${{ env.IMAGE_TAG }}${{ matrix.version_suffix }}-pre
+          cache-from: type=gha,scope=${{ matrix.cache_scope }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.cache_scope }}
+
+      - name: Verify native Rust engine before push
+        run: |
+          set -eux
+          docker run --rm \
+            -e PROXBOX_ENCRYPTION_KEY \
+            emersonfelipesp/proxbox-api:${{ env.IMAGE_TAG }}${{ matrix.version_suffix }}-pre \
+            python -c "import os; from proxbox_api.services.sync.reconciliation.rust_bridge import rust_available; assert os.environ.get('PROXBOX_RECONCILIATION_ENGINE') == 'rust'; assert rust_available()"
+
+      - name: Smoke-test ${{ matrix.variant }} PyO3/Rust image before push
+        run: |
+          set -eux
+          NAME=proxbox-smoke-${{ matrix.smoke_name }}
+          docker rm -f "$NAME" 2>/dev/null || true
+          docker run -d --name "$NAME" \
+            -p 127.0.0.1:${{ matrix.smoke_port }}:8000 \
+            -e PROXBOX_SKIP_NETBOX_BOOTSTRAP=1 \
+            -e PROXBOX_ENCRYPTION_KEY \
+            emersonfelipesp/proxbox-api:${{ env.IMAGE_TAG }}${{ matrix.version_suffix }}-pre
+          for i in $(seq 1 40); do
+            if curl ${{ matrix.curl_flags }} --max-time 5 ${{ matrix.smoke_url }} >/dev/null 2>&1; then
+              docker rm -f "$NAME"
+              exit 0
+            fi
+            sleep 2
+          done
+          docker logs "$NAME"
+          docker rm -f "$NAME"
+          exit 1
+
+      - name: Build and push ${{ matrix.variant }} PyO3/Rust Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: ${{ matrix.target }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            emersonfelipesp/proxbox-api:${{ env.IMAGE_TAG }}${{ matrix.version_suffix }}
+            emersonfelipesp/proxbox-api:${{ matrix.experimental_tag }}
+            emersonfelipesp/proxbox-api:${{ matrix.pyo3_tag }}
+            emersonfelipesp/proxbox-api:sha-${{ steps.source.outputs.sha }}${{ matrix.version_suffix }}
+          cache-from: type=gha,scope=${{ matrix.cache_scope }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.cache_scope }}
+
+      - name: Smoke-test pushed ${{ matrix.variant }} PyO3/Rust images
+        run: |
+          set -eux
+          for TAG in \
+            "${{ env.IMAGE_TAG }}${{ matrix.version_suffix }}" \
+            "${{ matrix.experimental_tag }}" \
+            "${{ matrix.pyo3_tag }}" \
+            "sha-${{ steps.source.outputs.sha }}${{ matrix.version_suffix }}"; do
+            NAME=$(printf 'proxbox-smoke-%s' "$TAG" | tr '.:' '-')
+            docker rm -f "$NAME" 2>/dev/null || true
+            docker run --rm \
+              -e PROXBOX_ENCRYPTION_KEY \
+              emersonfelipesp/proxbox-api:"$TAG" \
+              python -c "import os; from proxbox_api.services.sync.reconciliation.rust_bridge import rust_available; assert os.environ.get('PROXBOX_RECONCILIATION_ENGINE') == 'rust'; assert rust_available()"
+            docker run -d --name "$NAME" \
+              -p 127.0.0.1:${{ matrix.smoke_port }}:8000 \
+              -e PROXBOX_SKIP_NETBOX_BOOTSTRAP=1 \
+              -e PROXBOX_ENCRYPTION_KEY \
+              emersonfelipesp/proxbox-api:"$TAG"
+            ok=0
+            for i in $(seq 1 40); do
+              if curl ${{ matrix.curl_flags }} --max-time 5 ${{ matrix.smoke_url }} >/dev/null 2>&1; then
                 ok=1
                 break
               fi

--- a/.github/workflows/release-docker-verify.yml
+++ b/.github/workflows/release-docker-verify.yml
@@ -54,6 +54,15 @@ jobs:
           pull_with_retry emersonfelipesp/proxbox-api:latest-nginx
           pull_with_retry emersonfelipesp/proxbox-api:"${TAG}-granian"
           pull_with_retry emersonfelipesp/proxbox-api:latest-granian
+          pull_with_retry emersonfelipesp/proxbox-api:"${TAG}-pyo3-rust"
+          pull_with_retry emersonfelipesp/proxbox-api:experimental
+          pull_with_retry emersonfelipesp/proxbox-api:pyo3-rust
+          pull_with_retry emersonfelipesp/proxbox-api:"${TAG}-pyo3-rust-nginx"
+          pull_with_retry emersonfelipesp/proxbox-api:experimental-nginx
+          pull_with_retry emersonfelipesp/proxbox-api:pyo3-rust-nginx
+          pull_with_retry emersonfelipesp/proxbox-api:"${TAG}-pyo3-rust-granian"
+          pull_with_retry emersonfelipesp/proxbox-api:experimental-granian
+          pull_with_retry emersonfelipesp/proxbox-api:pyo3-rust-granian
 
       - name: Smoke-test published startup
         run: |
@@ -120,3 +129,47 @@ jobs:
               exit 1
             fi
           done
+
+          verify_rust_image() {
+            local tag="$1"
+            local name="$2"
+            local port="$3"
+            local url="$4"
+            local curl_flags="$5"
+
+            docker run --rm \
+              -e PROXBOX_ENCRYPTION_KEY \
+              "emersonfelipesp/proxbox-api:$tag" \
+              python -c "import os; from proxbox_api.services.sync.reconciliation.rust_bridge import rust_available; assert os.environ.get('PROXBOX_RECONCILIATION_ENGINE') == 'rust'; assert rust_available()"
+
+            docker rm -f "$name" 2>/dev/null || true
+            docker run -d --name "$name" \
+              -p "127.0.0.1:${port}:8000" \
+              -e PROXBOX_SKIP_NETBOX_BOOTSTRAP=1 \
+              -e PROXBOX_ENCRYPTION_KEY \
+              "emersonfelipesp/proxbox-api:$tag"
+            for i in $(seq 1 40); do
+              if curl $curl_flags --max-time 5 "$url" >/dev/null 2>&1; then
+                docker rm -f "$name"
+                return 0
+              fi
+              sleep 2
+              if [ "$i" -eq 40 ]; then
+                docker logs "$name"
+                docker rm -f "$name"
+                return 1
+              fi
+            done
+          }
+
+          verify_rust_image "${TAG}-pyo3-rust" proxbox-release-pyo3-rust 18081 http://127.0.0.1:18081/ "-fsS"
+          verify_rust_image experimental proxbox-release-experimental 18082 http://127.0.0.1:18082/ "-fsS"
+          verify_rust_image pyo3-rust proxbox-release-pyo3-rust-alias 18083 http://127.0.0.1:18083/ "-fsS"
+
+          verify_rust_image "${TAG}-pyo3-rust-nginx" proxbox-release-pyo3-rust-nginx 18445 https://127.0.0.1:18445/ "-kfsS"
+          verify_rust_image experimental-nginx proxbox-release-experimental-nginx 18447 https://127.0.0.1:18447/ "-kfsS"
+          verify_rust_image pyo3-rust-nginx proxbox-release-pyo3-rust-nginx-alias 18448 https://127.0.0.1:18448/ "-kfsS"
+
+          verify_rust_image "${TAG}-pyo3-rust-granian" proxbox-release-pyo3-rust-granian 18446 https://127.0.0.1:18446/ "-kfsS"
+          verify_rust_image experimental-granian proxbox-release-experimental-granian 18449 https://127.0.0.1:18449/ "-kfsS"
+          verify_rust_image pyo3-rust-granian proxbox-release-pyo3-rust-granian-alias 18450 https://127.0.0.1:18450/ "-kfsS"

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,18 @@ ARG DEV_OVERRIDES=""
 RUN uv sync --frozen --no-dev --no-editable && \
     if [ -n "${DEV_OVERRIDES}" ]; then uv pip install --python /app/.venv/bin/python ${DEV_OVERRIDES}; fi
 
-# Application tree + venv only (shared by all runtime images).
+# Optional native reconciliation engine build. This intentionally stays out of
+# the default builder so the published latest/version images remain Python-only.
+FROM builder AS builder-pyo3-rust
+
+RUN apk add --no-cache cargo rust
+
+COPY proxbox-reconcile-rs ./proxbox-reconcile-rs
+
+RUN uv pip install --python /app/.venv/bin/python ./proxbox-reconcile-rs && \
+    /app/.venv/bin/python -c "from proxbox_api.services.sync.reconciliation.rust_bridge import rust_available; assert rust_available()"
+
+# Application tree + venv only (shared by Python-only runtime images).
 FROM python:3.13-alpine AS runtime-base
 
 WORKDIR /app
@@ -37,8 +48,36 @@ RUN mkdir -p /app/scripts
 
 EXPOSE 8000
 
+# Application tree + venv only (shared by PyO3/Rust runtime images).
+FROM python:3.13-alpine AS runtime-base-pyo3-rust
+
+WORKDIR /app
+
+ENV PATH="/app/.venv/bin:$PATH" \
+    PORT=8000 \
+    PYTHONUNBUFFERED=1 \
+    PROXBOX_RECONCILIATION_ENGINE=rust
+
+COPY --from=builder-pyo3-rust /app/.venv /app/.venv
+
+RUN apk add --no-cache libgcc && \
+    mkdir -p /app/scripts && \
+    /app/.venv/bin/python -c "from proxbox_reconcile_rs._native import build_vm_operation_queue_json"
+
+EXPOSE 8000
+
 # Default image: raw uvicorn, no proxy, HTTP only. Smallest possible image.
 FROM runtime-base AS raw
+
+COPY docker/entrypoint-raw.sh /usr/local/bin/docker-entrypoint-raw.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint-raw.sh
+
+ENV PROXBOX_BIND_HOST=0.0.0.0
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint-raw.sh"]
+CMD []
+
+# Experimental raw image: raw uvicorn plus the PyO3/Rust reconciliation engine.
+FROM runtime-base-pyo3-rust AS raw-pyo3-rust
 
 COPY docker/entrypoint-raw.sh /usr/local/bin/docker-entrypoint-raw.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint-raw.sh
@@ -63,7 +102,35 @@ RUN apk add --no-cache \
     curl \
     nss-tools \
   && rm -f /etc/nginx/conf.d/default.conf \
-  && curl -fsSL -o /usr/local/bin/mkcert \
+  && curl --retry 5 --retry-delay 2 --retry-all-errors -fsSL -o /usr/local/bin/mkcert \
+     "https://github.com/FiloSottile/mkcert/releases/download/v${MKCERT_VERSION}/mkcert-v${MKCERT_VERSION}-linux-${TARGETARCH}" \
+  && chmod +x /usr/local/bin/mkcert
+
+COPY docker/nginx/proxbox-https.conf.template /etc/proxbox/nginx-https.conf.template
+COPY docker/supervisor/supervisord.conf /etc/supervisor/supervisord.conf
+COPY docker/supervisor/proxbox.conf /etc/supervisor/conf.d/proxbox.conf
+COPY docker/entrypoint-nginx.sh /usr/local/bin/docker-entrypoint-nginx.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint-nginx.sh
+
+ENV MKCERT_CERT_DIR=/certs
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint-nginx.sh"]
+CMD []
+
+# Experimental nginx image: nginx plus the PyO3/Rust reconciliation engine.
+FROM raw-pyo3-rust AS nginx-pyo3-rust
+
+ARG MKCERT_VERSION=1.4.4
+ARG TARGETARCH
+
+RUN apk add --no-cache \
+    nginx \
+    supervisor \
+    ca-certificates \
+    curl \
+    nss-tools \
+  && rm -f /etc/nginx/conf.d/default.conf \
+  && curl --retry 5 --retry-delay 2 --retry-all-errors -fsSL -o /usr/local/bin/mkcert \
      "https://github.com/FiloSottile/mkcert/releases/download/v${MKCERT_VERSION}/mkcert-v${MKCERT_VERSION}-linux-${TARGETARCH}" \
   && chmod +x /usr/local/bin/mkcert
 
@@ -93,7 +160,33 @@ RUN apk add --no-cache \
     nss-tools \
     openssl \
   && uv pip install --python /app/.venv/bin/python 'granian>=2.7.0' \
-  && curl -fsSL -o /usr/local/bin/mkcert \
+  && curl --retry 5 --retry-delay 2 --retry-all-errors -fsSL -o /usr/local/bin/mkcert \
+     "https://github.com/FiloSottile/mkcert/releases/download/v${MKCERT_VERSION}/mkcert-v${MKCERT_VERSION}-linux-${TARGETARCH}" \
+  && chmod +x /usr/local/bin/mkcert
+
+COPY docker/entrypoint-granian.sh /usr/local/bin/docker-entrypoint-granian.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint-granian.sh
+
+ENV MKCERT_CERT_DIR=/certs
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint-granian.sh"]
+CMD []
+
+# Experimental granian image: granian plus the PyO3/Rust reconciliation engine.
+FROM runtime-base-pyo3-rust AS granian-pyo3-rust
+
+ARG MKCERT_VERSION=1.4.4
+ARG TARGETARCH
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+RUN apk add --no-cache \
+    ca-certificates \
+    curl \
+    nss-tools \
+    openssl \
+  && uv pip install --python /app/.venv/bin/python 'granian>=2.7.0' \
+  && curl --retry 5 --retry-delay 2 --retry-all-errors -fsSL -o /usr/local/bin/mkcert \
      "https://github.com/FiloSottile/mkcert/releases/download/v${MKCERT_VERSION}/mkcert-v${MKCERT_VERSION}-linux-${TARGETARCH}" \
   && chmod +x /usr/local/bin/mkcert
 

--- a/README.md
+++ b/README.md
@@ -73,13 +73,16 @@ uv run mkdocs serve
 
 ## Using docker (recommended)
 
-All images are **Alpine-based** (smaller footprint), built from this repository with **uv** and **`uv.lock`** in a multi-stage Dockerfile. Three variants are published to Docker Hub:
+All images are **Alpine-based** (smaller footprint), built from this repository with **uv** and **`uv.lock`** in a multi-stage Dockerfile. Three Python-only variants are published to Docker Hub by default, plus opt-in experimental PyO3/Rust variants:
 
 | Variant | Tags | Description |
 |---------|------|-------------|
 | **Raw** (default) | `latest`, `<version>` | Pure uvicorn, HTTP only. Smallest image. |
 | **Nginx** | `latest-nginx`, `<version>-nginx` | nginx terminates HTTPS via mkcert; proxies to uvicorn. |
 | **Granian** | `latest-granian`, `<version>-granian` | [Granian](https://github.com/emmett-framework/granian) (Rust ASGI server) with native TLS via mkcert. No nginx. |
+| **Raw PyO3/Rust** (experimental) | `experimental`, `pyo3-rust`, `<version>-pyo3-rust` | Raw image with the optional PyO3 reconciliation engine installed and enabled. |
+| **Nginx PyO3/Rust** (experimental) | `experimental-nginx`, `pyo3-rust-nginx`, `<version>-pyo3-rust-nginx` | nginx image with the optional PyO3 reconciliation engine installed and enabled. |
+| **Granian PyO3/Rust** (experimental) | `experimental-granian`, `pyo3-rust-granian`, `<version>-pyo3-rust-granian` | granian image with the optional PyO3 reconciliation engine installed and enabled. |
 
 > **Upgrade note:** before v0.0.7, `latest` was the nginx+HTTP image. It is now the raw uvicorn image. Pull `latest-nginx` for the previous behavior.
 
@@ -140,9 +143,25 @@ docker build --target granian -t proxbox-api:granian .
 docker run -d -p 8443:8000 proxbox-api:granian
 ```
 
+### Experimental PyO3/Rust images
+
+The default images above continue to use the Python reconciliation engine. To opt in to the native PyO3/Rust implementation, run one of the experimental tags. The raw alias is the easiest path:
+
+```bash
+docker pull emersonfelipesp/proxbox-api:pyo3-rust
+docker run -d -p 8000:8000 --name proxbox-api-rust \
+  emersonfelipesp/proxbox-api:pyo3-rust
+```
+
+Equivalent HTTPS variants are available as `pyo3-rust-nginx` and
+`pyo3-rust-granian`. These images set
+`PROXBOX_RECONCILIATION_ENGINE=rust` and include the local
+`proxbox-reconcile-rs` native extension. Use the standard Python-only tags to
+roll back immediately.
+
 ### Docker runtime environment variables
 
-Common to all images (`raw`, `nginx`, `granian`):
+Common to all images, including the experimental PyO3/Rust variants:
 
 | Variable | Default | Description |
 |----------|---------|-------------|

--- a/docs/development/ci-e2e-workflows.md
+++ b/docs/development/ci-e2e-workflows.md
@@ -10,8 +10,8 @@ matrix, and staged package publication.
 |---|---|---|
 | `.github/workflows/ci.yml` | Push, pull request, release, manual dispatch | Runs core checks and the NetBox + Proxmox Docker E2E matrix. |
 | `.github/workflows/publish-testpypi.yml` | Version tag, GitHub release, manual dispatch | Publishes immutable package versions through TestPyPI, PyPI release candidates, final PyPI releases, Docker images, and post-publish E2E. |
-| `.github/workflows/docker-hub-publish.yml` | Reusable workflow / manual dispatch | Builds and publishes raw, nginx, and granian Docker image variants. |
-| `.github/workflows/release-docker-verify.yml` | Release / manual dispatch | Pulls the published Docker image tags and verifies container startup. |
+| `.github/workflows/docker-hub-publish.yml` | Reusable workflow / manual dispatch | Builds and publishes raw, nginx, granian, and experimental PyO3/Rust Docker image variants. |
+| `.github/workflows/release-docker-verify.yml` | Release / manual dispatch | Pulls the published Docker image tags, including experimental PyO3/Rust tags, and verifies container startup. |
 | `.github/workflows/docs.yml` | Docs changes on main / PR | Builds and publishes the MkDocs site. |
 | `.github/workflows/nightly-schema-refresh.yml` | Schedule / manual dispatch | Refreshes generated Proxmox schemas and opens a PR when they change. |
 
@@ -101,7 +101,7 @@ sequenceDiagram
     WF->>E2E: Run pre-publish E2E with dev dependencies
     WF->>PY: Upload proxbox-api
     WF->>PY: Reinstall exact package
-    WF->>DH: Publish raw, nginx, granian images
+    WF->>DH: Publish raw, nginx, granian images + experimental PyO3/Rust variants
     WF->>E2E: Run post-publish E2E with published package + image
 ```
 

--- a/docs/development/release-publishing.md
+++ b/docs/development/release-publishing.md
@@ -25,7 +25,7 @@ flowchart TD
     FinalTag[Create or dispatch final tag\nvX.Y.Z]
     FinalUpload[Upload vX.Y.Z to PyPI]
     FinalValidate[Install final from PyPI\non Python 3.11, 3.12, 3.13]
-    Docker[Publish Docker images\nraw, nginx, granian]
+    Docker[Publish Docker images\nraw, nginx, granian\n+ experimental PyO3/Rust]
     FinalE2E[Run post-publish E2E\npublished package + Docker image]
     FinalFailed{Post-release fix needed?}
     Post[Bump to vX.Y.Z.postN\npublish .postN to PyPI]
@@ -60,7 +60,7 @@ sequenceDiagram
     WF->>E2E: Wait for NetBox migrations and /api/status/ readiness
     WF->>PY: Upload package
     WF->>PY: Reinstall exact package version
-    WF->>DH: Publish raw, nginx, and granian images
+    WF->>DH: Publish raw, nginx, granian, and experimental PyO3/Rust images
     WF->>E2E: Verify published PyPI package and Docker image
 ```
 
@@ -75,7 +75,8 @@ sequenceDiagram
 - PyPI publication must pass package reinstall validation before Docker images
   are published.
 - Docker image tags use the same version as the PyPI package that passed
-  validation.
+  validation. Experimental PyO3/Rust images add `-pyo3-rust` tag suffixes and
+  opt-in aliases (`experimental`, `pyo3-rust`, and HTTPS variant suffixes).
 - Pre-publish and post-publish E2E jobs allow NetBox up to 20 minutes to finish
   migrations/search indexing and require `/api/status/` readiness before
   configuring tokens or backend endpoints.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -10,13 +10,16 @@ This page documents supported ways to run `proxbox-api`.
 
 ## Option 1: Docker (recommended for quick start)
 
-All Docker images are **Alpine-based** (smaller footprint). Three variants are available:
+All Docker images are **Alpine-based** (smaller footprint). The default tags use the Python reconciliation engine. Experimental PyO3/Rust tags are available for opt-in native-engine testing:
 
 | Variant | Tags | Description |
 |---------|------|-------------|
 | **Raw** (default) | `latest`, `<version>` | Pure uvicorn, HTTP only. Smallest image. |
 | **Nginx** | `latest-nginx`, `<version>-nginx` | nginx terminates HTTPS via mkcert; proxies to uvicorn. |
 | **Granian** | `latest-granian`, `<version>-granian` | Granian (Rust ASGI server) with native TLS via mkcert. |
+| **Raw PyO3/Rust** (experimental) | `experimental`, `pyo3-rust`, `<version>-pyo3-rust` | Raw image with the optional PyO3 reconciliation engine installed and enabled. |
+| **Nginx PyO3/Rust** (experimental) | `experimental-nginx`, `pyo3-rust-nginx`, `<version>-pyo3-rust-nginx` | nginx image with the optional PyO3 reconciliation engine installed and enabled. |
+| **Granian PyO3/Rust** (experimental) | `experimental-granian`, `pyo3-rust-granian`, `<version>-pyo3-rust-granian` | granian image with the optional PyO3 reconciliation engine installed and enabled. |
 
 ### Raw image — HTTP only (default)
 
@@ -78,9 +81,25 @@ Service URL:
 
 - <https://127.0.0.1:8443>
 
+### Experimental PyO3/Rust images
+
+Use the experimental images when you want the optional native reconciliation
+engine to run by default. The raw alias is the simplest Docker command:
+
+```bash
+docker pull emersonfelipesp/proxbox-api:pyo3-rust
+docker run -d -p 8000:8000 --name proxbox-api-rust \
+  emersonfelipesp/proxbox-api:pyo3-rust
+```
+
+HTTPS variants are published as `pyo3-rust-nginx` and `pyo3-rust-granian`.
+These images set `PROXBOX_RECONCILIATION_ENGINE=rust` and include the
+`proxbox-reconcile-rs` PyO3 extension. Switch back to `latest`, `latest-nginx`,
+or `latest-granian` to return to the Python-only implementation.
+
 ### Docker runtime environment variables
 
-Common to all images (`raw`, `nginx`, `granian`):
+Common to all images, including the experimental PyO3/Rust variants:
 
 | Variable | Default | Description |
 |----------|---------|-------------|

--- a/docs/pt-BR/development/ci-e2e-workflows.md
+++ b/docs/pt-BR/development/ci-e2e-workflows.md
@@ -10,8 +10,8 @@ NetBox e publicacao em etapas.
 |---|---|---|
 | `.github/workflows/ci.yml` | Push, pull request, release, dispatch manual | Roda checagens principais e a matriz E2E Docker com NetBox + Proxmox. |
 | `.github/workflows/publish-testpypi.yml` | Tag de versao, GitHub release, dispatch manual | Publica versoes imutaveis no TestPyPI, candidatos PyPI, releases finais PyPI, imagens Docker e E2E pos-publicacao. |
-| `.github/workflows/docker-hub-publish.yml` | Workflow reutilizavel / dispatch manual | Constroi e publica variantes raw, nginx e granian da imagem Docker. |
-| `.github/workflows/release-docker-verify.yml` | Release / dispatch manual | Baixa as tags Docker publicadas e verifica startup dos conteineres. |
+| `.github/workflows/docker-hub-publish.yml` | Workflow reutilizavel / dispatch manual | Constroi e publica variantes raw, nginx, granian e experimentais PyO3/Rust da imagem Docker. |
+| `.github/workflows/release-docker-verify.yml` | Release / dispatch manual | Baixa as tags Docker publicadas, incluindo as tags experimentais PyO3/Rust, e verifica startup dos conteineres. |
 | `.github/workflows/docs.yml` | Mudancas de docs em main / PR | Constroi e publica o site MkDocs. |
 | `.github/workflows/nightly-schema-refresh.yml` | Agendamento / dispatch manual | Atualiza schemas Proxmox gerados e abre PR quando houver mudanca. |
 
@@ -102,7 +102,7 @@ sequenceDiagram
     WF->>E2E: Rodar E2E pre-publicacao com dependencias dev
     WF->>PY: Publicar proxbox-api
     WF->>PY: Reinstalar pacote exato
-    WF->>DH: Publicar imagens raw, nginx, granian
+    WF->>DH: Publicar imagens raw, nginx, granian + variantes experimentais PyO3/Rust
     WF->>E2E: Rodar E2E pos-publicacao com pacote + imagem publicados
 ```
 

--- a/docs/pt-BR/development/release-publishing.md
+++ b/docs/pt-BR/development/release-publishing.md
@@ -25,7 +25,7 @@ flowchart TD
     FinalTag[Criar ou disparar tag final\nvX.Y.Z]
     FinalUpload[Upload vX.Y.Z para PyPI]
     FinalValidate[Instalar final do PyPI\nem Python 3.11, 3.12, 3.13]
-    Docker[Publicar imagens Docker\nraw, nginx, granian]
+    Docker[Publicar imagens Docker\nraw, nginx, granian\n+ experimentais PyO3/Rust]
     FinalE2E[Rodar E2E pos-publicacao\npacote PyPI + imagem Docker]
     FinalFailed{Precisa de fix\npos-release?}
     Post[Bump para vX.Y.Z.postN\npublicar .postN no PyPI]
@@ -60,7 +60,7 @@ sequenceDiagram
     WF->>E2E: Aguardar migracoes do NetBox e /api/status/
     WF->>PY: Upload do pacote
     WF->>PY: Reinstalar versao exata do pacote
-    WF->>DH: Publicar imagens raw, nginx e granian
+    WF->>DH: Publicar imagens raw, nginx, granian e experimentais PyO3/Rust
     WF->>E2E: Verificar pacote PyPI e imagem Docker publicados
 ```
 
@@ -75,7 +75,9 @@ sequenceDiagram
   `.postN` ou `rcN`.
 - Publicacao no PyPI precisa passar pela validacao de reinstalacao do pacote
   antes das imagens Docker serem publicadas.
-- Tags Docker usam a mesma versao do pacote PyPI que passou na validacao.
+- Tags Docker usam a mesma versao do pacote PyPI que passou na validacao. As
+  imagens experimentais PyO3/Rust adicionam sufixos `-pyo3-rust` e aliases
+  opt-in (`experimental`, `pyo3-rust` e sufixos para variantes HTTPS).
 - Jobs E2E pre-publicacao e pos-publicacao aguardam ate 20 minutos para o
   NetBox concluir migracoes/indexacao e exigem `/api/status/` pronto antes de
   configurar tokens ou endpoints do backend.

--- a/docs/pt-BR/getting-started/installation.md
+++ b/docs/pt-BR/getting-started/installation.md
@@ -10,13 +10,16 @@ Esta pagina documenta formas suportadas para executar o `proxbox-api`.
 
 ## Opcao 1: Docker (recomendado para inicio rapido)
 
-Todas as imagens Docker sao baseadas em **Alpine** (menor footprint). Tres variantes estao disponiveis:
+Todas as imagens Docker sao baseadas em **Alpine** (menor footprint). As tags padrao usam o engine de reconciliacao em Python. Tags experimentais com PyO3/Rust estao disponiveis para testes opt-in do engine nativo:
 
 | Variante | Tags | Descricao |
 |---------|------|-----------|
 | **Raw** (padrao) | `latest`, `<versao>` | Uvicorn puro, somente HTTP. Imagem menor. |
 | **Nginx** | `latest-nginx`, `<versao>-nginx` | nginx encerra HTTPS via mkcert; proxy para uvicorn. |
 | **Granian** | `latest-granian`, `<versao>-granian` | Granian (servidor ASGI em Rust) com TLS nativo via mkcert. |
+| **Raw PyO3/Rust** (experimental) | `experimental`, `pyo3-rust`, `<versao>-pyo3-rust` | Imagem raw com o engine opcional PyO3 instalado e habilitado. |
+| **Nginx PyO3/Rust** (experimental) | `experimental-nginx`, `pyo3-rust-nginx`, `<versao>-pyo3-rust-nginx` | Imagem nginx com o engine opcional PyO3 instalado e habilitado. |
+| **Granian PyO3/Rust** (experimental) | `experimental-granian`, `pyo3-rust-granian`, `<versao>-pyo3-rust-granian` | Imagem granian com o engine opcional PyO3 instalado e habilitado. |
 
 ### Imagem Raw — somente HTTP (padrao)
 
@@ -75,9 +78,26 @@ URL do servico:
 
 - <https://127.0.0.1:8443>
 
+### Imagens experimentais PyO3/Rust
+
+Use as imagens experimentais quando quiser que o engine nativo de reconciliacao
+rode por padrao. O alias raw e o caminho Docker mais simples:
+
+```bash
+docker pull emersonfelipesp/proxbox-api:pyo3-rust
+docker run -d -p 8000:8000 --name proxbox-api-rust \
+  emersonfelipesp/proxbox-api:pyo3-rust
+```
+
+As variantes HTTPS sao publicadas como `pyo3-rust-nginx` e
+`pyo3-rust-granian`. Essas imagens definem
+`PROXBOX_RECONCILIATION_ENGINE=rust` e incluem a extensao PyO3
+`proxbox-reconcile-rs`. Volte para `latest`, `latest-nginx` ou
+`latest-granian` para retornar a implementacao Python-only.
+
 ### Variaveis de ambiente Docker em tempo de execucao
 
-Comuns a todas as imagens (`raw`, `nginx`, `granian`):
+Comuns a todas as imagens, incluindo as variantes experimentais PyO3/Rust:
 
 | Variavel | Padrao | Descricao |
 |----------|--------|-----------|


### PR DESCRIPTION
Closes #186

## Summary
- add PyO3/Rust Docker targets for raw, nginx, and granian images while keeping the default raw/latest/version image Python-only
- publish Docker Hub aliases for the experimental implementation: experimental and pyo3-rust for raw, plus nginx/granian suffixed aliases
- extend release verification and docs for the new opt-in images
- make PyO3/Rust runtime images install the native package non-editably, include libgcc, and verify native import at build time

## Validation
- uv run pytest tests/reconciliation -q
- PROXBOX_RECONCILIATION_ENGINE=compare PROXBOX_RECONCILIATION_COMPARE_STRICT=true uv run pytest tests/reconciliation -q
- PROXBOX_RECONCILIATION_ENGINE=rust uv run pytest tests/reconciliation -q
- cargo test --no-default-features
- workflow YAML parse for Docker publish and release verify workflows
- git diff --check
- docker build --target raw -t proxbox-api:raw-python-check .
- docker build --target raw-pyo3-rust -t proxbox-api:raw-pyo3-rust-check .
- docker build --build-arg TARGETARCH=amd64 --target nginx-pyo3-rust -t proxbox-api:nginx-pyo3-rust-check .
- docker build --build-arg TARGETARCH=amd64 --target granian-pyo3-rust -t proxbox-api:granian-pyo3-rust-check .

Local docker run smoke is blocked on this host by OCI runtime sysctl permission, so runtime native import is enforced by the Dockerfile build-time check.