### PR TITLE
Fix VM disk aggregate drift during sync

### DIFF
--- a/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
+++ b/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
@@ -110,6 +110,7 @@ from proxbox_api.services.sync.virtual_machines import (
 from proxbox_api.services.sync.vm_create import ensure_vm_type
 from proxbox_api.services.sync.vm_helpers import (
     _compute_vm_patchable_fields,
+    extract_vm_disk_aggregate_size,
     normalized_mac,
     parse_comma_separated_ints,
     parse_key_value_string,
@@ -423,6 +424,46 @@ def _log_vm_reconciliation_measurement(
     return operation_counts
 
 
+async def _patch_vm_with_disk_aggregate_retry(
+    nb: object,
+    *,
+    record_id: int,
+    payload: dict[str, object],
+    cluster_name: str,
+    vmid: int,
+) -> dict[str, object] | object:
+    """Patch a VM, retrying once when NetBox requires the current child-disk sum."""
+
+    try:
+        return await rest_patch_async(
+            nb,
+            "/api/virtualization/virtual-machines/",
+            record_id,
+            payload,
+        )
+    except ProxboxException as exc:
+        aggregate_disk = extract_vm_disk_aggregate_size(exc)
+        if aggregate_disk is None:
+            raise
+
+        retry_payload = {**payload, "disk": aggregate_disk}
+        logger.warning(
+            "Retrying VM patch with NetBox virtual-disk aggregate: cluster=%s vmid=%s "
+            "record_id=%s requested_disk=%s aggregate_disk=%s",
+            cluster_name,
+            vmid,
+            record_id,
+            payload.get("disk"),
+            aggregate_disk,
+        )
+        return await rest_patch_async(
+            nb,
+            "/api/virtualization/virtual-machines/",
+            record_id,
+            retry_payload,
+        )
+
+
 async def _dispatch_vm_operation_queue(
     nb: object,
     operation_queue: list[_NetBoxVMOperation],
@@ -478,11 +519,12 @@ async def _dispatch_vm_operation_queue(
                     python_exception=f"cluster={operation.prepared.cluster_name} vmid={vmid}",
                 )
 
-            patched = await rest_patch_async(
+            patched = await _patch_vm_with_disk_aggregate_retry(
                 nb,
-                "/api/virtualization/virtual-machines/",
-                record_id,
-                operation.patch_payload,
+                record_id=record_id,
+                payload=operation.patch_payload,
+                cluster_name=operation.prepared.cluster_name,
+                vmid=vmid,
             )
             if isinstance(patched, dict) and patched:
                 resolved_records[key] = patched

--- a/proxbox_api/services/sync/virtual_disks.py
+++ b/proxbox_api/services/sync/virtual_disks.py
@@ -384,8 +384,7 @@ async def create_virtual_disks(  # noqa: C901
                 disk_payloads.append(disk_payload)
 
             desired_disk_sizes = {
-                str(payload.get("name")): int(payload.get("size") or 0)
-                for payload in disk_payloads
+                str(payload.get("name")): int(payload.get("size") or 0) for payload in disk_payloads
             }
             desired_disk_total = sum(int(payload.get("size") or 0) for payload in disk_payloads)
 

--- a/proxbox_api/services/sync/virtual_disks.py
+++ b/proxbox_api/services/sync/virtual_disks.py
@@ -56,9 +56,9 @@ async def _delete_stale_virtual_disks(
     nb: object,
     *,
     vm_id: int,
-    desired_names: set[str],
+    desired_disks: dict[str, int],
 ) -> int:
-    """Delete VM disk records that no longer exist in the Proxmox config."""
+    """Delete VM disk records missing from Proxmox, including duplicate names."""
 
     existing_disks = await rest_list_async(
         nb,
@@ -66,16 +66,37 @@ async def _delete_stale_virtual_disks(
         query={"virtual_machine_id": vm_id, "limit": 500},
     )
     stale_ids: list[int] = []
+    desired_names = set(desired_disks)
+    desired_records: dict[str, list[tuple[int, int]]] = {}
     for record in existing_disks:
         data = to_mapping(record)
         name = str(data.get("name") or "").strip()
         record_id = relation_id(data.get("id"))
-        if name and name not in desired_names and record_id is not None:
+        if not name or record_id is None:
+            continue
+        if name not in desired_names:
             stale_ids.append(record_id)
+            continue
+        try:
+            size = int(data.get("size") or 0)
+        except (TypeError, ValueError):
+            size = 0
+        desired_records.setdefault(name, []).append((record_id, size))
+
+    for name, records in desired_records.items():
+        if len(records) <= 1:
+            continue
+        desired_size = desired_disks[name]
+        keep_id = next(
+            (record_id for record_id, size in records if size == desired_size),
+            records[0][0],
+        )
+        stale_ids.extend(record_id for record_id, _size in records if record_id != keep_id)
 
     if not stale_ids:
         return 0
 
+    stale_ids = sorted(set(stale_ids))
     deleted = await rest_bulk_delete_async(nb, "/api/virtualization/virtual-disks/", stale_ids)
     logger.info(
         "Deleted %s stale virtual disk(s) for VM id=%s: %s",
@@ -362,7 +383,10 @@ async def create_virtual_disks(  # noqa: C901
                     disk_payload["custom_fields"] = custom_fields
                 disk_payloads.append(disk_payload)
 
-            desired_disk_names = {str(payload.get("name")) for payload in disk_payloads}
+            desired_disk_sizes = {
+                str(payload.get("name")): int(payload.get("size") or 0)
+                for payload in disk_payloads
+            }
             desired_disk_total = sum(int(payload.get("size") or 0) for payload in disk_payloads)
 
             if disk_payloads:
@@ -394,7 +418,7 @@ async def create_virtual_disks(  # noqa: C901
                 disks_deleted = await _delete_stale_virtual_disks(
                     nb,
                     vm_id=vm_id_int,
-                    desired_names=desired_disk_names,
+                    desired_disks=desired_disk_sizes,
                 )
                 parent_vm_disk_updated = await _sync_parent_vm_disk_total(
                     nb,

--- a/proxbox_api/services/sync/virtual_disks.py
+++ b/proxbox_api/services/sync/virtual_disks.py
@@ -3,7 +3,13 @@
 from __future__ import annotations
 
 from proxbox_api.logger import logger
-from proxbox_api.netbox_rest import RestRecord, rest_bulk_reconcile_async, rest_list_async
+from proxbox_api.netbox_rest import (
+    RestRecord,
+    rest_bulk_delete_async,
+    rest_bulk_reconcile_async,
+    rest_list_async,
+    rest_patch_async,
+)
 from proxbox_api.proxmox_to_netbox.models import NetBoxVirtualDiskSyncState, ProxmoxVmConfigInput
 from proxbox_api.services.proxmox.config import resolve_vm_config
 from proxbox_api.services.sync.storage_links import (
@@ -11,6 +17,7 @@ from proxbox_api.services.sync.storage_links import (
     find_storage_record,
     storage_name_from_volume_id,
 )
+from proxbox_api.services.sync.vm_helpers import relation_id, to_mapping
 from proxbox_api.services.sync.vmid_helpers import (
     extract_proxmox_vm_type,
     extract_proxmox_vmid,
@@ -43,6 +50,72 @@ async def _list_all_vms_with_proxmox_id(
         offset += batch_size
 
     return all_vms
+
+
+async def _delete_stale_virtual_disks(
+    nb: object,
+    *,
+    vm_id: int,
+    desired_names: set[str],
+) -> int:
+    """Delete VM disk records that no longer exist in the Proxmox config."""
+
+    existing_disks = await rest_list_async(
+        nb,
+        "/api/virtualization/virtual-disks/",
+        query={"virtual_machine_id": vm_id, "limit": 500},
+    )
+    stale_ids: list[int] = []
+    for record in existing_disks:
+        data = to_mapping(record)
+        name = str(data.get("name") or "").strip()
+        record_id = relation_id(data.get("id"))
+        if name and name not in desired_names and record_id is not None:
+            stale_ids.append(record_id)
+
+    if not stale_ids:
+        return 0
+
+    deleted = await rest_bulk_delete_async(nb, "/api/virtualization/virtual-disks/", stale_ids)
+    logger.info(
+        "Deleted %s stale virtual disk(s) for VM id=%s: %s",
+        deleted,
+        vm_id,
+        sorted(stale_ids),
+    )
+    return deleted
+
+
+async def _sync_parent_vm_disk_total(
+    nb: object,
+    *,
+    vm: dict[str, object],
+    desired_disk_total: int,
+) -> bool:
+    """Patch the VM disk total after child virtual disks have converged."""
+
+    if "disk" not in vm:
+        return False
+
+    vm_id = relation_id(vm.get("id"))
+    if vm_id is None:
+        return False
+
+    try:
+        current_disk = int(vm.get("disk") or 0)
+    except (TypeError, ValueError):
+        current_disk = 0
+    if current_disk == desired_disk_total:
+        return False
+
+    await rest_patch_async(
+        nb,
+        "/api/virtualization/virtual-machines/",
+        vm_id,
+        {"disk": desired_disk_total},
+    )
+    vm["disk"] = desired_disk_total
+    return True
 
 
 async def create_virtual_disks(  # noqa: C901
@@ -260,6 +333,8 @@ async def create_virtual_disks(  # noqa: C901
 
             disks_created = 0
             disks_updated = 0
+            disks_deleted = 0
+            parent_vm_disk_updated = False
 
             disk_payloads: list[dict[str, object]] = []
             for disk_entry in disk_entries:
@@ -287,6 +362,9 @@ async def create_virtual_disks(  # noqa: C901
                     disk_payload["custom_fields"] = custom_fields
                 disk_payloads.append(disk_payload)
 
+            desired_disk_names = {str(payload.get("name")) for payload in disk_payloads}
+            desired_disk_total = sum(int(payload.get("size") or 0) for payload in disk_payloads)
+
             if disk_payloads:
                 bulk_result = await rest_bulk_reconcile_async(
                     nb,
@@ -311,15 +389,29 @@ async def create_virtual_disks(  # noqa: C901
                 disks_created = bulk_result.created
                 disks_updated = bulk_result.updated
 
+            vm_id_int = relation_id(vm_id)
+            if vm_id_int is not None:
+                disks_deleted = await _delete_stale_virtual_disks(
+                    nb,
+                    vm_id=vm_id_int,
+                    desired_names=desired_disk_names,
+                )
+                parent_vm_disk_updated = await _sync_parent_vm_disk_total(
+                    nb,
+                    vm=vm,
+                    desired_disk_total=desired_disk_total,
+                )
+
             if disks_created > 0:
                 created += 1
-            elif disks_updated > 0:
+            elif disks_updated > 0 or disks_deleted > 0 or parent_vm_disk_updated:
                 updated += 1
             else:
                 skipped += 1
 
             disk_summary = (
-                f"{len(disk_entries)} disks ({disks_created} created, {disks_updated} updated)"
+                f"{len(disk_entries)} disks ({disks_created} created, "
+                f"{disks_updated} updated, {disks_deleted} deleted)"
             )
 
             if use_websocket and websocket:

--- a/proxbox_api/services/sync/vm_helpers.py
+++ b/proxbox_api/services/sync/vm_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from ipaddress import ip_address, ip_interface
 from typing import Literal
 
@@ -9,6 +10,11 @@ from proxbox_api.logger import logger
 from proxbox_api.schemas.sync import SyncOverwriteFlags
 
 PrimaryIPPreference = Literal["ipv4", "ipv6"]
+
+_VM_DISK_AGGREGATE_ERROR_RE = re.compile(
+    r"aggregate size of assigned virtual disks \((\d+)\)",
+    flags=re.IGNORECASE,
+)
 
 
 def _compute_vm_patchable_fields(
@@ -69,6 +75,19 @@ def normalize_current_virtual_machine_payload(
     if supports_virtual_machine_type_field:
         payload["virtual_machine_type"] = record.get("virtual_machine_type")
     return payload
+
+
+def extract_vm_disk_aggregate_size(error: Exception) -> int | None:
+    """Extract NetBox's current virtual-disk aggregate from VM validation errors."""
+    detail = getattr(error, "detail", None)
+    text = str(detail) if detail else str(error)
+    match = _VM_DISK_AGGREGATE_ERROR_RE.search(text)
+    if not match:
+        return None
+    try:
+        return int(match.group(1))
+    except (TypeError, ValueError):
+        return None
 
 
 def to_mapping(value: object) -> dict[str, object]:

--- a/proxbox_api/services/sync/vm_network.py
+++ b/proxbox_api/services/sync/vm_network.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import re
 from datetime import datetime, timezone
 from ipaddress import ip_address, ip_interface
 
@@ -24,31 +23,14 @@ from proxbox_api.services.sync.network import _resolve_vm_interface_ips
 from proxbox_api.services.sync.storage_links import find_storage_record, storage_name_from_volume_id
 from proxbox_api.services.sync.vm_filter import get_interface_name_from_config_and_agent
 from proxbox_api.services.sync.vm_helpers import (
+    extract_vm_disk_aggregate_size,
     normalize_primary_ip_preference,
     normalized_mac,
-)
-
-_VM_DISK_AGGREGATE_ERROR_RE = re.compile(
-    r"aggregate size of assigned virtual disks \((\d+)\)",
-    flags=re.IGNORECASE,
 )
 
 _PRIMARY_IP_REASSIGN_ERROR = (
     "Cannot reassign IP address while it is designated as the primary IP for the parent object"
 )
-
-
-def _extract_vm_disk_aggregate_size(error: Exception) -> int | None:
-    """Extract the expected VM disk size from NetBox disk aggregate validation errors."""
-    detail = getattr(error, "detail", None)
-    text = str(detail) if detail else str(error)
-    match = _VM_DISK_AGGREGATE_ERROR_RE.search(text)
-    if not match:
-        return None
-    try:
-        return int(match.group(1))
-    except (TypeError, ValueError):
-        return None
 
 
 def _primary_field_from_ip_address(address: object) -> str | None:
@@ -594,7 +576,7 @@ async def set_primary_ip(  # noqa: C901
         )
         return True
     except Exception as exc:
-        aggregate_disk = _extract_vm_disk_aggregate_size(exc)
+        aggregate_disk = extract_vm_disk_aggregate_size(exc)
         if aggregate_disk and aggregate_disk > 0:
             try:
                 await rest_patch_async(

--- a/tests/test_virtual_disks_sync.py
+++ b/tests/test_virtual_disks_sync.py
@@ -140,6 +140,7 @@ def test_create_virtual_disks_deletes_stale_disks_and_updates_vm_total(monkeypat
             assert query == {"virtual_machine_id": 7, "limit": 500}
             return [
                 {"id": 10, "virtual_machine": {"id": 7}, "name": "scsi0", "size": 2252},
+                {"id": 12, "virtual_machine": {"id": 7}, "name": "scsi0", "size": 2252},
                 {"id": 11, "virtual_machine": {"id": 7}, "name": "efidisk0", "size": 4},
             ]
         return []
@@ -203,7 +204,7 @@ def test_create_virtual_disks_deletes_stale_disks_and_updates_vm_total(monkeypat
         )
     )
 
-    assert deleted_ids == [11]
+    assert deleted_ids == [11, 12]
     assert parent_vm_patches == [{"record_id": 7, "disk": 2252}]
     assert result == {"count": 1, "created": 0, "updated": 1, "skipped": 0}
 

--- a/tests/test_virtual_disks_sync.py
+++ b/tests/test_virtual_disks_sync.py
@@ -119,6 +119,95 @@ def test_create_virtual_disks_uses_custom_fields_proxmox_vm_id(monkeypatch):
     assert reconciled_payloads[0].get("custom_fields", {}).get("proxbox_storage_id") == 42
 
 
+def test_create_virtual_disks_deletes_stale_disks_and_updates_vm_total(monkeypatch):
+    deleted_ids: list[int] = []
+    parent_vm_patches: list[dict[str, object]] = []
+
+    async def _fake_rest_list(_nb, _path, query=None):
+        if _path == "/api/virtualization/virtual-machines/":
+            return [
+                {
+                    "id": 7,
+                    "name": "vm-101",
+                    "disk": 2256,
+                    "cluster": {"name": "cluster-a"},
+                    "custom_fields": {"proxmox_vm_id": 101},
+                }
+            ]
+        if _path == "/api/plugins/proxbox/storage/":
+            return []
+        if _path == "/api/virtualization/virtual-disks/":
+            assert query == {"virtual_machine_id": 7, "limit": 500}
+            return [
+                {"id": 10, "virtual_machine": {"id": 7}, "name": "scsi0", "size": 2252},
+                {"id": 11, "virtual_machine": {"id": 7}, "name": "efidisk0", "size": 4},
+            ]
+        return []
+
+    async def _fake_resolve_vm_config(**kwargs):
+        return {"scsi0": "local-lvm:vm-101-disk-0,size=2252M"}
+
+    async def _fake_bulk_reconcile(_nb, _path, *, payloads, **kwargs):
+        assert payloads == [
+            {
+                "virtual_machine": 7,
+                "name": "scsi0",
+                "size": 2252,
+                "storage": None,
+                "description": "Storage: local-lvm",
+                "tags": [],
+            }
+        ]
+        return SimpleNamespace(records=[], created=0, updated=0, unchanged=1, failed=0)
+
+    async def _fake_bulk_delete(_nb, _path, ids):
+        deleted_ids.extend(ids)
+        return len(ids)
+
+    async def _fake_patch(_nb, _path, record_id, payload):
+        parent_vm_patches.append({"record_id": record_id, **payload})
+        return {"id": record_id, **payload}
+
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.virtual_disks.rest_list_async",
+        _fake_rest_list,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.virtual_disks.resolve_vm_config",
+        _fake_resolve_vm_config,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.virtual_disks.rest_bulk_reconcile_async",
+        _fake_bulk_reconcile,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.virtual_disks.rest_bulk_delete_async",
+        _fake_bulk_delete,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.virtual_disks.rest_patch_async",
+        _fake_patch,
+    )
+
+    result = asyncio.run(
+        create_virtual_disks(
+            netbox_session=object(),
+            pxs=[],
+            cluster_status=[],
+            cluster_resources=[
+                {"cluster-a": [{"type": "qemu", "name": "vm-101", "vmid": "101", "node": "pve01"}]}
+            ],
+            tag=None,
+            use_websocket=False,
+            use_css=False,
+        )
+    )
+
+    assert deleted_ids == [11]
+    assert parent_vm_patches == [{"record_id": 7, "disk": 2252}]
+    assert result == {"count": 1, "created": 0, "updated": 1, "skipped": 0}
+
+
 def test_cdrom_disk_is_included_with_size_zero(monkeypatch):
     """CD-ROM drives (size=None) must appear in the reconcile payloads with size=0.
 

--- a/tests/test_vm_sync_reconciliation_queue.py
+++ b/tests/test_vm_sync_reconciliation_queue.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 
 import pytest
 
+from proxbox_api.exception import ProxboxException
 from proxbox_api.proxmox_to_netbox.models import ProxmoxVmConfigInput
 from proxbox_api.routes.virtualization.virtual_machines import sync_vm
 
@@ -228,6 +229,49 @@ async def test_dispatch_vm_operation_queue_runs_writes_sequentially(monkeypatch)
     assert resolved[("cluster-a", 202, "qemu")]["id"] == 4202
     assert resolved[("cluster-a", 201, "qemu")]["id"] == 3201
     assert resolved[("cluster-a", 203, "qemu")]["id"] == 4203
+
+
+@pytest.mark.asyncio
+async def test_dispatch_vm_operation_queue_retries_disk_aggregate_validation(monkeypatch):
+    patch_payloads: list[dict[str, object]] = []
+
+    monkeypatch.setattr(sync_vm, "resolve_netbox_write_concurrency", lambda: 1)
+
+    async def _fake_patch(nb, path, record_id, payload):
+        patch_payloads.append(dict(payload))
+        if len(patch_payloads) == 1:
+            raise ProxboxException(
+                message="NetBox REST request failed",
+                detail=(
+                    '{"disk":["The specified disk size (2252) must match the aggregate size '
+                    'of assigned virtual disks (2256)."]}'
+                ),
+            )
+        return {"id": record_id, **payload}
+
+    monkeypatch.setattr(sync_vm, "rest_patch_async", _fake_patch)
+
+    prepared_update = _prepared_vm(cluster_name="cluster-a", vmid=204, memory=4096)
+    queue = [
+        sync_vm._NetBoxVMOperation(
+            method="UPDATE",
+            prepared=prepared_update,
+            existing_record={
+                "id": 4204,
+                "custom_fields": {"proxmox_vm_id": 204},
+                "disk": 2256,
+            },
+            patch_payload={"memory": 4096, "disk": 2252},
+        )
+    ]
+
+    resolved = await sync_vm._dispatch_vm_operation_queue(object(), queue)
+
+    assert patch_payloads == [
+        {"memory": 4096, "disk": 2252},
+        {"memory": 4096, "disk": 2256},
+    ]
+    assert resolved[("cluster-a", 204, "qemu")]["disk"] == 2256
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #188

## Summary

- Retry VM update patches with the aggregate disk size NetBox reports when the virtual-disk aggregate validator rejects an update.
- Delete stale VM virtual-disk records that are no longer present in the Proxmox config.
- Remove duplicate virtual-disk child records per VM/name, preferring a record that matches the desired Proxmox size.
- Patch the parent VM disk total after child virtual disks converge so the sync can recover in one run.

## Tests

- uv run ruff check proxbox_api/services/sync/vm_helpers.py proxbox_api/services/sync/vm_network.py proxbox_api/routes/virtualization/virtual_machines/sync_vm.py proxbox_api/services/sync/virtual_disks.py tests/test_vm_sync_reconciliation_queue.py tests/test_virtual_disks_sync.py
- uv run ruff check proxbox_api/services/sync/virtual_disks.py tests/test_virtual_disks_sync.py
- uv run pytest tests/test_vm_sync.py tests/test_proxmox_to_netbox_contracts.py tests/test_proxmox_disk_parsing.py tests/test_vm_sync_reconciliation_queue.py tests/test_virtual_disks_sync.py tests/test_vm_network.py