### PR TITLE
Add firewall write endpoints and intent support

### DIFF
--- a/proxbox_api/database.py
+++ b/proxbox_api/database.py
@@ -173,6 +173,24 @@ class DeletionRequestRecord(SQLModel, table=True):
     updated_at: float = Field(default_factory=time.time)
 
 
+class FirewallIntentRequestRecord(SQLModel, table=True):
+    __tablename__: ClassVar[str] = "firewall_intent_request"
+    __table_args__ = {"extend_existing": True}
+
+    id: int | None = Field(default=None, primary_key=True)
+    endpoint_id: int = Field(index=True)
+    actor: str | None = Field(default=None, index=True)
+    action: str = Field(index=True)
+    state: str = Field(default="planned", index=True)
+    payload: dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON, nullable=False))
+    plan_snapshot: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
+    created_at: float = Field(default_factory=time.time)
+    updated_at: float = Field(default_factory=time.time)
+
+
 class PBSEndpoint(SQLModel, table=True):
     """Proxmox Backup Server (PBS) endpoint record.
 

--- a/proxbox_api/routes/intent/apply.py
+++ b/proxbox_api/routes/intent/apply.py
@@ -21,10 +21,12 @@ from proxbox_api.routes.intent.schemas import (
     ApplyRequest,
     ApplyResponse,
     ApplyResultItem,
+    FirewallIntentPayload,
     LXCIntentPayload,
     VMIntentPayload,
 )
 from proxbox_api.runtime_settings import get_bool
+from proxbox_api.services.firewall_intent import apply_firewall_diff
 from proxbox_api.services.verb_dispatch import write_verb_journal_entry
 
 router = APIRouter()
@@ -41,6 +43,8 @@ def _overall(results: list[ApplyResultItem]) -> str:
 
 
 def _vmid(diff: ApplyDiff) -> int:
+    if isinstance(diff.payload, FirewallIntentPayload):
+        return diff.payload.vmid or 0
     return diff.payload.vmid
 
 
@@ -127,7 +131,7 @@ async def _dispatch_update_diff(
     response_model=ApplyResponse,
     summary="Apply NetBox→Proxmox intent diffs",
 )
-async def apply_intent(
+async def apply_intent(  # noqa: C901
     request: Request,
     body: ApplyRequest,
     session: SessionDep,
@@ -142,6 +146,17 @@ async def apply_intent(
                 endpoint_id=endpoint_id,
                 netbox_id=diff.netbox_id,
             )
+            if diff.kind == "firewall":
+                results.append(
+                    await apply_firewall_diff(
+                        diff=diff,
+                        endpoint_context=endpoint_context,
+                        actor=body.actor,
+                        run_uuid=body.run_uuid,
+                    )
+                )
+                continue
+
             if diff.op == "create" and diff.kind == "qemu":
                 if not isinstance(diff.payload, VMIntentPayload):
                     results.append(

--- a/proxbox_api/routes/intent/plan.py
+++ b/proxbox_api/routes/intent/plan.py
@@ -38,6 +38,7 @@ from proxbox_api.routes.intent.schemas import (
     PlanResponse,
     PlanVerdict,
 )
+from proxbox_api.services.firewall_intent import is_firewall_plan_diff, plan_firewall_diff
 
 router = APIRouter()
 
@@ -50,6 +51,9 @@ def _verdict_for(diff: IntentDiff) -> PlanVerdict:
     endpoint end-to-end during Sub-PR D without spurious blocks while
     later sub-PRs are still in flight.
     """
+    if is_firewall_plan_diff(diff):
+        return plan_firewall_diff(diff)
+
     if diff.op == "delete":
         return PlanVerdict(
             netbox_id=diff.netbox_id,

--- a/proxbox_api/routes/intent/schemas.py
+++ b/proxbox_api/routes/intent/schemas.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from proxbox_api.routes.intent.cloud_init import CloudInitPayload
 
 DiffOp = Literal["create", "update", "delete"]
-VMKind = Literal["virtualmachine", "lxc"]
+VMKind = Literal["virtualmachine", "lxc", "firewall"]
 Verdict = Literal["permitted", "blocked", "warning"]
 DeletionRequestKind = Literal["qemu", "lxc"]
 DeletionRequestState = Literal[
@@ -149,11 +149,26 @@ class LXCIntentPayload(BaseModel):
     password: str | None = None
 
 
+class FirewallIntentPayload(BaseModel):
+    action: str
+    zone: str | None = None
+    node: str | None = None
+    vmid: int | None = None
+    vm_type: Literal["qemu", "lxc"] | None = None
+    vnet: str | None = None
+    group: str | None = None
+    pos: int | None = None
+    name: str | None = None
+    cidr: str | None = None
+    body: dict[str, object] = Field(default_factory=dict)
+    rollback: dict[str, object] = Field(default_factory=dict)
+
+
 class ApplyDiff(BaseModel):
     op: Literal["create", "update", "delete"]
-    kind: Literal["qemu", "lxc"]
+    kind: Literal["qemu", "lxc", "firewall"]
     netbox_id: int | None = None
-    payload: VMIntentPayload | LXCIntentPayload
+    payload: VMIntentPayload | LXCIntentPayload | FirewallIntentPayload
 
     @model_validator(mode="before")
     @classmethod
@@ -169,6 +184,8 @@ class ApplyDiff(BaseModel):
             coerced["payload"] = VMIntentPayload.model_validate(payload)
         elif kind == "lxc":
             coerced["payload"] = LXCIntentPayload.model_validate(payload)
+        elif kind == "firewall":
+            coerced["payload"] = FirewallIntentPayload.model_validate(payload)
         return coerced
 
 

--- a/proxbox_api/routes/proxmox/firewall.py
+++ b/proxbox_api/routes/proxmox/firewall.py
@@ -288,7 +288,7 @@ async def _firewall_write(
     unsupported_reason: str = "firewall_write_not_supported",
     probe_supported: bool = False,
 ) -> FirewallWriteResponse | JSONResponse:
-    """Dispatch one write through proxmox-sdk with gate and 501 handling."""
+    """Dispatch one write through proxmox-sdk with gate and unsupported-surface handling."""
     actor_value = _require_actor(actor)
     endpoint_or_response = await _firewall_gate(db, endpoint_id)
     if isinstance(endpoint_or_response, JSONResponse):
@@ -316,7 +316,7 @@ async def _firewall_write(
             write_call = getattr(resource, method)
             raw = await resolve_async(write_call(**(payload or {})))
         except ResourceException as exc:
-            if exc.status_code in {404, 501}:
+            if probe_supported and exc.status_code in {404, 501}:
                 return _unsupported_response(
                     endpoint=endpoint,
                     actor=actor_value,
@@ -595,7 +595,13 @@ async def create_datacenter_firewall_group(
 ):
     body = payload.pve_payload()
     if not body.get("group"):
-        raise HTTPException(status_code=422, detail="group or name is required")
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "reason": "firewall_group_name_required",
+                "detail": "group or name is required",
+            },
+        )
     return await _firewall_write(
         db=db,
         endpoint_id=endpoint_id,

--- a/proxbox_api/routes/proxmox/firewall.py
+++ b/proxbox_api/routes/proxmox/firewall.py
@@ -1,4 +1,4 @@
-"""Proxmox VE firewall endpoints (read-only).
+"""Proxmox VE firewall endpoints.
 
 Surfaces firewall rules, security groups, IP sets, aliases, and options for all
 firewall zones: datacenter, node, VM (QEMU + LXC), and VNet SDN (tech-preview).
@@ -8,21 +8,37 @@ The nftables vs iptables backend difference is a runtime flag, not an API
 difference. SDK calls that are not implemented on older/newer clusters degrade
 gracefully — HTTP 500 responses are caught and return empty lists silently.
 
-All endpoints are read-only by design. Firewall write operations are
-explicitly out of scope for this release.
+Write endpoints are intentionally explicit operator actions. They are gated by
+``ProxmoxEndpoint.allow_writes`` and require ``X-Proxbox-Actor`` attribution.
 """
 
 from __future__ import annotations
 
 import asyncio
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Header, HTTPException, Query, status
+from fastapi.responses import JSONResponse
+from proxmox_sdk.sdk.exceptions import ResourceException
 from pydantic import BaseModel
 
+from proxbox_api.database import AsyncDatabaseSessionDep as SessionDep
+from proxbox_api.database import ProxmoxEndpoint
 from proxbox_api.logger import logger
 from proxbox_api.proxmox_async import resolve_async
 from proxbox_api.routes.intent.dispatchers.common import get_vm_proxy
-from proxbox_api.session.proxmox import ProxmoxSessionsDep
+from proxbox_api.schemas.firewall import (
+    FirewallAliasWrite,
+    FirewallIPSetEntryWrite,
+    FirewallIPSetWrite,
+    FirewallOptionsWrite,
+    FirewallRuleWrite,
+    FirewallSecurityGroupWrite,
+    FirewallVmType,
+    FirewallWriteResponse,
+)
+from proxbox_api.session.proxmox import ProxmoxSession, ProxmoxSessionsDep
+from proxbox_api.session.proxmox_providers import _parse_db_endpoint
+from proxbox_api.utils.async_compat import maybe_await as _maybe_await
 
 router = APIRouter()
 
@@ -162,6 +178,186 @@ async def _safe_get_dict(coro_or_result) -> dict:
         return result if isinstance(result, dict) else {}
     except Exception:
         return {}
+
+
+async def _firewall_gate(
+    session: SessionDep,
+    endpoint_id: int | None,
+) -> JSONResponse | ProxmoxEndpoint:
+    """Resolve the target endpoint and enforce the firewall write gate."""
+    if endpoint_id is None:
+        return JSONResponse(
+            status_code=status.HTTP_403_FORBIDDEN,
+            content={
+                "reason": "endpoint_id_required",
+                "detail": "Firewall writes require an explicit endpoint_id query parameter.",
+            },
+        )
+
+    endpoint = await _maybe_await(session.get(ProxmoxEndpoint, endpoint_id))
+    if endpoint is None:
+        return JSONResponse(
+            status_code=status.HTTP_403_FORBIDDEN,
+            content={
+                "reason": "endpoint_not_found",
+                "detail": f"No ProxmoxEndpoint with id={endpoint_id}.",
+            },
+        )
+
+    if not endpoint.allow_writes:
+        return JSONResponse(
+            status_code=status.HTTP_403_FORBIDDEN,
+            content={
+                "reason": "writes_disabled_for_endpoint",
+                "detail": (
+                    "Firewall writes are disabled on this endpoint. Enable "
+                    "ProxmoxEndpoint.allow_writes before pushing firewall changes."
+                ),
+                "endpoint_id": endpoint.id,
+            },
+        )
+
+    return endpoint
+
+
+async def _open_proxmox_session(endpoint: ProxmoxEndpoint) -> ProxmoxSession:
+    """Open a Proxmox API session for a DB endpoint."""
+    schema = _parse_db_endpoint(endpoint)
+    return await ProxmoxSession.create(schema)
+
+
+async def _close_proxmox_session(proxmox: ProxmoxSession) -> None:
+    close_method = getattr(proxmox, "aclose", None)
+    if callable(close_method):
+        try:
+            await close_method()
+        except Exception as exc:  # pragma: no cover - best-effort cleanup
+            logger.debug("Failed to close firewall write Proxmox session: %s", exc)
+
+
+def _require_actor(actor: str | None) -> str:
+    actor_value = (actor or "").strip()
+    if not actor_value:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "reason": "actor_required",
+                "detail": "Firewall writes require X-Proxbox-Actor.",
+            },
+        )
+    return actor_value
+
+
+def _task_id(raw: object) -> str | None:
+    if isinstance(raw, str) and raw.startswith("UPID:"):
+        return raw
+    if isinstance(raw, dict):
+        value = raw.get("upid") or raw.get("task") or raw.get("data")
+        if isinstance(value, str) and value.startswith("UPID:"):
+            return value
+    return None
+
+
+def _unsupported_response(
+    *,
+    endpoint: ProxmoxEndpoint,
+    actor: str,
+    path: str,
+    reason: str,
+    detail: str,
+) -> FirewallWriteResponse:
+    return FirewallWriteResponse(
+        status="skipped",
+        endpoint_id=endpoint.id,
+        cluster_name=endpoint.name,
+        actor=actor,
+        path=path,
+        reason=reason,
+        detail=detail,
+    )
+
+
+async def _firewall_write(
+    *,
+    db: SessionDep,
+    endpoint_id: int | None,
+    actor: str | None,
+    method: str,
+    path: str,
+    payload: dict[str, object] | None = None,
+    unsupported_reason: str = "firewall_write_not_supported",
+    probe_supported: bool = False,
+) -> FirewallWriteResponse | JSONResponse:
+    """Dispatch one write through proxmox-sdk with gate and 501 handling."""
+    actor_value = _require_actor(actor)
+    endpoint_or_response = await _firewall_gate(db, endpoint_id)
+    if isinstance(endpoint_or_response, JSONResponse):
+        return endpoint_or_response
+    endpoint = endpoint_or_response
+
+    try:
+        proxmox = await _open_proxmox_session(endpoint)
+    except Exception as exc:
+        logger.warning("Failed to open Proxmox session for firewall write: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail={
+                "reason": "proxmox_session_unreachable",
+                "detail": str(exc),
+                "endpoint_id": endpoint.id,
+            },
+        ) from exc
+
+    try:
+        resource = proxmox.session(path)
+        try:
+            if probe_supported:
+                await resolve_async(resource.get())
+            write_call = getattr(resource, method)
+            raw = await resolve_async(write_call(**(payload or {})))
+        except ResourceException as exc:
+            if exc.status_code in {404, 501}:
+                return _unsupported_response(
+                    endpoint=endpoint,
+                    actor=actor_value,
+                    path=path,
+                    reason=unsupported_reason,
+                    detail=f"Upstream Proxmox returned HTTP {exc.status_code}.",
+                )
+            raise
+
+        return FirewallWriteResponse(
+            status="deleted" if method == "delete" else "pushed",
+            endpoint_id=endpoint.id,
+            cluster_name=endpoint.name,
+            actor=actor_value,
+            path=path,
+            proxmox_task_id=_task_id(raw),
+            response=raw,
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Firewall write failed for endpoint=%s path=%s", endpoint.id, path)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail={
+                "reason": "proxmox_firewall_write_failed",
+                "detail": str(exc),
+                "endpoint_id": endpoint.id,
+                "path": path,
+            },
+        ) from exc
+    finally:
+        await _close_proxmox_session(proxmox)
+
+
+def _rule_payload(payload: FirewallRuleWrite) -> dict[str, object]:
+    return payload.pve_payload()
+
+
+def _entry_payload(payload: FirewallIPSetEntryWrite) -> dict[str, object]:
+    return payload.pve_payload()
 
 
 _OPTIONS_KNOWN_KEYS: frozenset[str] = frozenset(
@@ -336,6 +532,320 @@ async def datacenter_firewall_options(pxs: ProxmoxSessionsDep):
     return None
 
 
+# ── Datacenter-level write endpoints ─────────────────────────────────────────
+
+
+@router.post("/firewall/datacenter/rules", response_model=FirewallWriteResponse)
+async def create_datacenter_firewall_rule(
+    payload: FirewallRuleWrite,
+    db: SessionDep,
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="post",
+        path="cluster/firewall/rules",
+        payload=_rule_payload(payload),
+    )
+
+
+@router.put("/firewall/datacenter/rules/{pos}", response_model=FirewallWriteResponse)
+async def update_datacenter_firewall_rule(
+    pos: int,
+    payload: FirewallRuleWrite,
+    db: SessionDep,
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="put",
+        path=f"cluster/firewall/rules/{pos}",
+        payload=_rule_payload(payload),
+    )
+
+
+@router.delete("/firewall/datacenter/rules/{pos}", response_model=FirewallWriteResponse)
+async def delete_datacenter_firewall_rule(
+    pos: int,
+    db: SessionDep,
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="delete",
+        path=f"cluster/firewall/rules/{pos}",
+    )
+
+
+@router.post("/firewall/datacenter/groups", response_model=FirewallWriteResponse)
+async def create_datacenter_firewall_group(
+    payload: FirewallSecurityGroupWrite,
+    db: SessionDep,
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    body = payload.pve_payload()
+    if not body.get("group"):
+        raise HTTPException(status_code=422, detail="group or name is required")
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="post",
+        path="cluster/firewall/groups",
+        payload=body,
+    )
+
+
+@router.delete("/firewall/datacenter/groups/{group}", response_model=FirewallWriteResponse)
+async def delete_datacenter_firewall_group(
+    group: str,
+    db: SessionDep,
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="delete",
+        path=f"cluster/firewall/groups/{group}",
+    )
+
+
+@router.post("/firewall/datacenter/groups/{group}/rules", response_model=FirewallWriteResponse)
+async def create_datacenter_firewall_group_rule(
+    group: str,
+    payload: FirewallRuleWrite,
+    db: SessionDep,
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="post",
+        path=f"cluster/firewall/groups/{group}",
+        payload=_rule_payload(payload),
+    )
+
+
+@router.put(
+    "/firewall/datacenter/groups/{group}/rules/{pos}",
+    response_model=FirewallWriteResponse,
+)
+async def update_datacenter_firewall_group_rule(
+    group: str,
+    pos: int,
+    payload: FirewallRuleWrite,
+    db: SessionDep,
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="put",
+        path=f"cluster/firewall/groups/{group}/{pos}",
+        payload=_rule_payload(payload),
+    )
+
+
+@router.delete(
+    "/firewall/datacenter/groups/{group}/rules/{pos}",
+    response_model=FirewallWriteResponse,
+)
+async def delete_datacenter_firewall_group_rule(
+    group: str,
+    pos: int,
+    db: SessionDep,
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="delete",
+        path=f"cluster/firewall/groups/{group}/{pos}",
+    )
+
+
+@router.post("/firewall/datacenter/ipsets", response_model=FirewallWriteResponse)
+async def create_datacenter_firewall_ipset(
+    payload: FirewallIPSetWrite,
+    db: SessionDep,
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="post",
+        path="cluster/firewall/ipset",
+        payload=payload.pve_payload(),
+    )
+
+
+@router.delete("/firewall/datacenter/ipsets/{name}", response_model=FirewallWriteResponse)
+async def delete_datacenter_firewall_ipset(
+    name: str,
+    db: SessionDep,
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="delete",
+        path=f"cluster/firewall/ipset/{name}",
+    )
+
+
+@router.post(
+    "/firewall/datacenter/ipsets/{name}/entries",
+    response_model=FirewallWriteResponse,
+)
+async def create_datacenter_firewall_ipset_entry(
+    name: str,
+    payload: FirewallIPSetEntryWrite,
+    db: SessionDep,
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="post",
+        path=f"cluster/firewall/ipset/{name}",
+        payload=_entry_payload(payload),
+    )
+
+
+@router.put(
+    "/firewall/datacenter/ipsets/{name}/entries/{cidr:path}",
+    response_model=FirewallWriteResponse,
+)
+async def update_datacenter_firewall_ipset_entry(
+    name: str,
+    cidr: str,
+    payload: FirewallIPSetEntryWrite,
+    db: SessionDep,
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="put",
+        path=f"cluster/firewall/ipset/{name}/{cidr}",
+        payload=_entry_payload(payload),
+    )
+
+
+@router.delete(
+    "/firewall/datacenter/ipsets/{name}/entries/{cidr:path}",
+    response_model=FirewallWriteResponse,
+)
+async def delete_datacenter_firewall_ipset_entry(
+    name: str,
+    cidr: str,
+    db: SessionDep,
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="delete",
+        path=f"cluster/firewall/ipset/{name}/{cidr}",
+    )
+
+
+@router.post("/firewall/datacenter/aliases", response_model=FirewallWriteResponse)
+async def create_datacenter_firewall_alias(
+    payload: FirewallAliasWrite,
+    db: SessionDep,
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="post",
+        path="cluster/firewall/aliases",
+        payload=payload.pve_payload(),
+    )
+
+
+@router.put("/firewall/datacenter/aliases/{name}", response_model=FirewallWriteResponse)
+async def update_datacenter_firewall_alias(
+    name: str,
+    payload: FirewallAliasWrite,
+    db: SessionDep,
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="put",
+        path=f"cluster/firewall/aliases/{name}",
+        payload=payload.pve_payload(exclude={"name"}),
+    )
+
+
+@router.delete("/firewall/datacenter/aliases/{name}", response_model=FirewallWriteResponse)
+async def delete_datacenter_firewall_alias(
+    name: str,
+    db: SessionDep,
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="delete",
+        path=f"cluster/firewall/aliases/{name}",
+    )
+
+
+@router.put("/firewall/datacenter/options", response_model=FirewallWriteResponse)
+async def update_datacenter_firewall_options(
+    payload: FirewallOptionsWrite,
+    db: SessionDep,
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="put",
+        path="cluster/firewall/options",
+        payload=payload.pve_payload(),
+    )
+
+
 # ── Node-level endpoints ──────────────────────────────────────────────────────
 
 
@@ -369,6 +879,81 @@ async def node_firewall_options(node: str, pxs: ProxmoxSessionsDep):
         except Exception:
             logger.exception("Error fetching node %s firewall options for %s", node, px.name)
     return None
+
+
+# ── Node-level write endpoints ───────────────────────────────────────────────
+
+
+@router.post("/firewall/nodes/{node}/rules", response_model=FirewallWriteResponse)
+async def create_node_firewall_rule(
+    node: str,
+    payload: FirewallRuleWrite,
+    db: SessionDep,
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="post",
+        path=f"nodes/{node}/firewall/rules",
+        payload=_rule_payload(payload),
+    )
+
+
+@router.put("/firewall/nodes/{node}/rules/{pos}", response_model=FirewallWriteResponse)
+async def update_node_firewall_rule(
+    node: str,
+    pos: int,
+    payload: FirewallRuleWrite,
+    db: SessionDep,
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="put",
+        path=f"nodes/{node}/firewall/rules/{pos}",
+        payload=_rule_payload(payload),
+    )
+
+
+@router.delete("/firewall/nodes/{node}/rules/{pos}", response_model=FirewallWriteResponse)
+async def delete_node_firewall_rule(
+    node: str,
+    pos: int,
+    db: SessionDep,
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="delete",
+        path=f"nodes/{node}/firewall/rules/{pos}",
+    )
+
+
+@router.put("/firewall/nodes/{node}/options", response_model=FirewallWriteResponse)
+async def update_node_firewall_options(
+    node: str,
+    payload: FirewallOptionsWrite,
+    db: SessionDep,
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="put",
+        path=f"nodes/{node}/firewall/options",
+        payload=payload.pve_payload(),
+    )
 
 
 # ── VM-level endpoints ────────────────────────────────────────────────────────
@@ -500,6 +1085,325 @@ async def vm_firewall_options(vmid: int, node: str, pxs: ProxmoxSessionsDep, vm_
         except Exception:
             logger.exception("Error fetching VM %s firewall options for %s", vmid, px.name)
     return None
+
+
+def _vm_firewall_base(node: str, vmid: int, vm_type: FirewallVmType) -> str:
+    return f"nodes/{node}/{vm_type}/{vmid}/firewall"
+
+
+# ── VM-level write endpoints ─────────────────────────────────────────────────
+
+
+@router.post("/firewall/vms/{vmid}/rules", response_model=FirewallWriteResponse)
+async def create_vm_firewall_rule(
+    vmid: int,
+    node: str,
+    payload: FirewallRuleWrite,
+    db: SessionDep,
+    vm_type: FirewallVmType = Query(default="qemu"),
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="post",
+        path=f"{_vm_firewall_base(node, vmid, vm_type)}/rules",
+        payload=_rule_payload(payload),
+    )
+
+
+@router.put("/firewall/vms/{vmid}/rules/{pos}", response_model=FirewallWriteResponse)
+async def update_vm_firewall_rule(
+    vmid: int,
+    pos: int,
+    node: str,
+    payload: FirewallRuleWrite,
+    db: SessionDep,
+    vm_type: FirewallVmType = Query(default="qemu"),
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="put",
+        path=f"{_vm_firewall_base(node, vmid, vm_type)}/rules/{pos}",
+        payload=_rule_payload(payload),
+    )
+
+
+@router.delete("/firewall/vms/{vmid}/rules/{pos}", response_model=FirewallWriteResponse)
+async def delete_vm_firewall_rule(
+    vmid: int,
+    pos: int,
+    node: str,
+    db: SessionDep,
+    vm_type: FirewallVmType = Query(default="qemu"),
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="delete",
+        path=f"{_vm_firewall_base(node, vmid, vm_type)}/rules/{pos}",
+    )
+
+
+@router.post("/firewall/vms/{vmid}/ipsets", response_model=FirewallWriteResponse)
+async def create_vm_firewall_ipset(
+    vmid: int,
+    node: str,
+    payload: FirewallIPSetWrite,
+    db: SessionDep,
+    vm_type: FirewallVmType = Query(default="qemu"),
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="post",
+        path=f"{_vm_firewall_base(node, vmid, vm_type)}/ipset",
+        payload=payload.pve_payload(),
+    )
+
+
+@router.delete("/firewall/vms/{vmid}/ipsets/{name}", response_model=FirewallWriteResponse)
+async def delete_vm_firewall_ipset(
+    vmid: int,
+    name: str,
+    node: str,
+    db: SessionDep,
+    vm_type: FirewallVmType = Query(default="qemu"),
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="delete",
+        path=f"{_vm_firewall_base(node, vmid, vm_type)}/ipset/{name}",
+    )
+
+
+@router.post("/firewall/vms/{vmid}/ipsets/{name}/entries", response_model=FirewallWriteResponse)
+async def create_vm_firewall_ipset_entry(
+    vmid: int,
+    name: str,
+    node: str,
+    payload: FirewallIPSetEntryWrite,
+    db: SessionDep,
+    vm_type: FirewallVmType = Query(default="qemu"),
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="post",
+        path=f"{_vm_firewall_base(node, vmid, vm_type)}/ipset/{name}",
+        payload=_entry_payload(payload),
+    )
+
+
+@router.put(
+    "/firewall/vms/{vmid}/ipsets/{name}/entries/{cidr:path}",
+    response_model=FirewallWriteResponse,
+)
+async def update_vm_firewall_ipset_entry(
+    vmid: int,
+    name: str,
+    cidr: str,
+    node: str,
+    payload: FirewallIPSetEntryWrite,
+    db: SessionDep,
+    vm_type: FirewallVmType = Query(default="qemu"),
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="put",
+        path=f"{_vm_firewall_base(node, vmid, vm_type)}/ipset/{name}/{cidr}",
+        payload=_entry_payload(payload),
+    )
+
+
+@router.delete(
+    "/firewall/vms/{vmid}/ipsets/{name}/entries/{cidr:path}",
+    response_model=FirewallWriteResponse,
+)
+async def delete_vm_firewall_ipset_entry(
+    vmid: int,
+    name: str,
+    cidr: str,
+    node: str,
+    db: SessionDep,
+    vm_type: FirewallVmType = Query(default="qemu"),
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="delete",
+        path=f"{_vm_firewall_base(node, vmid, vm_type)}/ipset/{name}/{cidr}",
+    )
+
+
+@router.post("/firewall/vms/{vmid}/aliases", response_model=FirewallWriteResponse)
+async def create_vm_firewall_alias(
+    vmid: int,
+    node: str,
+    payload: FirewallAliasWrite,
+    db: SessionDep,
+    vm_type: FirewallVmType = Query(default="qemu"),
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="post",
+        path=f"{_vm_firewall_base(node, vmid, vm_type)}/aliases",
+        payload=payload.pve_payload(),
+    )
+
+
+@router.put("/firewall/vms/{vmid}/aliases/{name}", response_model=FirewallWriteResponse)
+async def update_vm_firewall_alias(
+    vmid: int,
+    name: str,
+    node: str,
+    payload: FirewallAliasWrite,
+    db: SessionDep,
+    vm_type: FirewallVmType = Query(default="qemu"),
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="put",
+        path=f"{_vm_firewall_base(node, vmid, vm_type)}/aliases/{name}",
+        payload=payload.pve_payload(exclude={"name"}),
+    )
+
+
+@router.delete("/firewall/vms/{vmid}/aliases/{name}", response_model=FirewallWriteResponse)
+async def delete_vm_firewall_alias(
+    vmid: int,
+    name: str,
+    node: str,
+    db: SessionDep,
+    vm_type: FirewallVmType = Query(default="qemu"),
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="delete",
+        path=f"{_vm_firewall_base(node, vmid, vm_type)}/aliases/{name}",
+    )
+
+
+@router.put("/firewall/vms/{vmid}/options", response_model=FirewallWriteResponse)
+async def update_vm_firewall_options(
+    vmid: int,
+    node: str,
+    payload: FirewallOptionsWrite,
+    db: SessionDep,
+    vm_type: FirewallVmType = Query(default="qemu"),
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="put",
+        path=f"{_vm_firewall_base(node, vmid, vm_type)}/options",
+        payload=payload.pve_payload(),
+    )
+
+
+# ── VNet/SDN firewall write endpoints ────────────────────────────────────────
+
+
+@router.post("/firewall/vnets/{vnet}/rules", response_model=FirewallWriteResponse)
+async def create_vnet_firewall_rule(
+    vnet: str,
+    payload: FirewallRuleWrite,
+    db: SessionDep,
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    path = f"cluster/sdn/vnets/{vnet}/firewall/rules"
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="post",
+        path=path,
+        payload=_rule_payload(payload),
+        unsupported_reason="vnet_firewall_not_supported",
+        probe_supported=True,
+    )
+
+
+@router.put("/firewall/vnets/{vnet}/rules/{pos}", response_model=FirewallWriteResponse)
+async def update_vnet_firewall_rule(
+    vnet: str,
+    pos: int,
+    payload: FirewallRuleWrite,
+    db: SessionDep,
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="put",
+        path=f"cluster/sdn/vnets/{vnet}/firewall/rules/{pos}",
+        payload=_rule_payload(payload),
+        unsupported_reason="vnet_firewall_not_supported",
+        probe_supported=True,
+    )
+
+
+@router.delete("/firewall/vnets/{vnet}/rules/{pos}", response_model=FirewallWriteResponse)
+async def delete_vnet_firewall_rule(
+    vnet: str,
+    pos: int,
+    db: SessionDep,
+    endpoint_id: int | None = Query(default=None),
+    actor: str | None = Header(default=None, alias="X-Proxbox-Actor"),
+):
+    return await _firewall_write(
+        db=db,
+        endpoint_id=endpoint_id,
+        actor=actor,
+        method="delete",
+        path=f"cluster/sdn/vnets/{vnet}/firewall/rules/{pos}",
+        unsupported_reason="vnet_firewall_not_supported",
+        probe_supported=True,
+    )
 
 
 # ── Aggregated summary endpoint ───────────────────────────────────────────────

--- a/proxbox_api/schemas/firewall.py
+++ b/proxbox_api/schemas/firewall.py
@@ -1,0 +1,122 @@
+"""Pydantic schemas for Proxmox firewall write routes."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+FirewallZone = Literal[
+    "datacenter",
+    "node",
+    "vm_qemu",
+    "vm_lxc",
+    "security_group",
+    "vnet",
+]
+FirewallVmType = Literal["qemu", "lxc"]
+
+
+class FirewallWriteModel(BaseModel):
+    """Base model that accepts either Python or Proxmox-style field names."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    def pve_payload(self, *, exclude: set[str] | None = None) -> dict[str, Any]:
+        """Return a Proxmox API payload with unset/None fields removed."""
+        payload = self.model_dump(
+            mode="python",
+            by_alias=True,
+            exclude_none=True,
+            exclude=exclude or set(),
+        )
+        return {key: value for key, value in payload.items() if value is not None}
+
+
+class FirewallRuleWrite(FirewallWriteModel):
+    """Payload for creating or updating a firewall rule."""
+
+    pos: int | None = None
+    type: str | None = None
+    action: str | None = None
+    enable: bool | int | None = None
+    macro: str | None = None
+    iface: str | None = None
+    source: str | None = None
+    dest: str | None = None
+    proto: str | None = None
+    dport: str | None = None
+    sport: str | None = None
+    log: str | None = None
+    icmp_type: str | None = Field(default=None, alias="icmp-type")
+    comment: str | None = None
+    digest: str | None = None
+
+
+class FirewallSecurityGroupWrite(FirewallWriteModel):
+    """Payload for creating a datacenter security group."""
+
+    group: str | None = None
+    name: str | None = None
+    comment: str | None = None
+
+    def pve_payload(self, *, exclude: set[str] | None = None) -> dict[str, Any]:
+        payload = super().pve_payload(exclude=exclude)
+        if "group" not in payload and payload.get("name"):
+            payload["group"] = payload.pop("name")
+        else:
+            payload.pop("name", None)
+        return payload
+
+
+class FirewallIPSetWrite(FirewallWriteModel):
+    """Payload for creating a firewall IP set."""
+
+    name: str
+    comment: str | None = None
+
+
+class FirewallIPSetEntryWrite(FirewallWriteModel):
+    """Payload for creating or updating an IP set entry."""
+
+    cidr: str | None = None
+    comment: str | None = None
+    nomatch: bool | int | None = None
+
+
+class FirewallAliasWrite(FirewallWriteModel):
+    """Payload for creating or updating a firewall alias."""
+
+    name: str | None = None
+    cidr: str
+    comment: str | None = None
+    digest: str | None = None
+
+
+class FirewallOptionsWrite(FirewallWriteModel):
+    """Payload for updating firewall options."""
+
+    enable: bool | int | None = None
+    policy_in: str | None = None
+    policy_out: str | None = None
+    log_ratelimit: str | None = None
+    options: dict[str, Any] = Field(default_factory=dict)
+
+    def pve_payload(self, *, exclude: set[str] | None = None) -> dict[str, Any]:
+        payload = super().pve_payload(exclude=(exclude or set()) | {"options"})
+        payload.update(self.options)
+        return {key: value for key, value in payload.items() if value is not None}
+
+
+class FirewallWriteResponse(BaseModel):
+    """Common response for firewall mutation routes."""
+
+    status: Literal["pushed", "deleted", "skipped"]
+    endpoint_id: int | None = None
+    cluster_name: str | None = None
+    actor: str
+    path: str
+    reason: str | None = None
+    detail: str | None = None
+    proxmox_task_id: str | None = None
+    response: Any = None

--- a/proxbox_api/services/firewall_intent.py
+++ b/proxbox_api/services/firewall_intent.py
@@ -51,7 +51,12 @@ def _path_for(payload: FirewallIntentPayload) -> tuple[str, str, bool, str]:  # 
     if action == "firewall.group.delete":
         if not payload.group:
             raise ValueError("firewall.group.delete requires group")
-        return "delete", f"cluster/firewall/groups/{payload.group}", False, "firewall_write_not_supported"
+        return (
+            "delete",
+            f"cluster/firewall/groups/{payload.group}",
+            False,
+            "firewall_write_not_supported",
+        )
 
     if action.startswith("firewall.rule."):
         base = _rule_base(payload, zone)
@@ -73,8 +78,11 @@ def _path_for(payload: FirewallIntentPayload) -> tuple[str, str, bool, str]:  # 
     if action == "firewall.alias.upsert":
         if not payload.name:
             raise ValueError("firewall.alias.upsert requires name")
-        return "put", f"{_scoped_base(payload, zone, 'aliases')}/{payload.name}", False, (
-            "firewall_write_not_supported"
+        return (
+            "put",
+            f"{_scoped_base(payload, zone, 'aliases')}/{payload.name}",
+            False,
+            ("firewall_write_not_supported"),
         )
 
     if action == "firewall.options.update":

--- a/proxbox_api/services/firewall_intent.py
+++ b/proxbox_api/services/firewall_intent.py
@@ -9,7 +9,7 @@ from fastapi.responses import JSONResponse
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from proxbox_api.database import FirewallIntentRequestRecord
-from proxbox_api.routes.intent.dispatchers.common import IntentEndpointContext
+from proxbox_api.routes.intent.dispatchers.common import IntentEndpointContext, scrub_message
 from proxbox_api.routes.intent.schemas import (
     ApplyDiff,
     ApplyResultItem,
@@ -114,6 +114,10 @@ def _rule_base(payload: FirewallIntentPayload, zone: str) -> str:
 def _scoped_base(payload: FirewallIntentPayload, zone: str, resource: str) -> str:
     if zone == "datacenter":
         return f"cluster/firewall/{resource}"
+    if zone == "node" and resource == "options":
+        if not payload.node:
+            raise ValueError("node options intent requires node")
+        return f"nodes/{payload.node}/firewall/options"
     if zone in {"vm_qemu", "vm_lxc"}:
         return f"{_vm_base(payload, zone)}/{resource}"
     raise ValueError(f"{resource} is not supported for firewall zone {zone}")
@@ -122,7 +126,9 @@ def _scoped_base(payload: FirewallIntentPayload, zone: str, resource: str) -> st
 def _vm_base(payload: FirewallIntentPayload, zone: str) -> str:
     if not payload.node or payload.vmid is None:
         raise ValueError(f"{zone} firewall intent requires node and vmid")
-    vm_type = payload.vm_type or ("qemu" if zone == "vm_qemu" else "lxc")
+    vm_type = "qemu" if zone == "vm_qemu" else "lxc"
+    if payload.vm_type is not None and payload.vm_type != vm_type:
+        raise ValueError(f"vm_type {payload.vm_type!r} does not match firewall zone {zone!r}")
     return f"nodes/{payload.node}/{vm_type}/{payload.vmid}/firewall"
 
 
@@ -150,6 +156,7 @@ async def apply_firewall_diff(
             message="firewall apply requires FirewallIntentPayload",
         )
 
+    raw_payload = diff.payload.model_dump(mode="python")
     try:
         method, path, probe, unsupported_reason = _path_for(diff.payload)
         result = await _firewall_write(
@@ -200,7 +207,7 @@ async def apply_firewall_diff(
             kind=diff.kind,
             status="failed",
             reason="firewall_apply_failed",
-            message=str(error),
+            message=scrub_message(str(error), raw_payload),
         )
 
 

--- a/proxbox_api/services/firewall_intent.py
+++ b/proxbox_api/services/firewall_intent.py
@@ -1,0 +1,218 @@
+"""Plan/apply helpers for firewall intent actions."""
+
+from __future__ import annotations
+
+import json
+import time
+
+from fastapi.responses import JSONResponse
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from proxbox_api.database import FirewallIntentRequestRecord
+from proxbox_api.routes.intent.dispatchers.common import IntentEndpointContext
+from proxbox_api.routes.intent.schemas import (
+    ApplyDiff,
+    ApplyResultItem,
+    FirewallIntentPayload,
+    IntentDiff,
+    PlanVerdict,
+)
+from proxbox_api.routes.proxmox.firewall import _firewall_write
+
+
+def is_firewall_plan_diff(diff: IntentDiff) -> bool:
+    """Return True when an intent plan diff is a firewall mutation."""
+    action = getattr(diff, "type", None) or getattr(diff, "action", None)
+    return diff.kind == "firewall" or str(action or "").startswith("firewall.")
+
+
+def plan_firewall_diff(diff: IntentDiff) -> PlanVerdict:
+    """Return a plan verdict for a firewall mutation."""
+    action = getattr(diff, "type", None) or getattr(diff, "action", None)
+    return PlanVerdict(
+        netbox_id=diff.netbox_id,
+        op=diff.op,
+        verdict="warning",
+        reason="firewall_plan_preview",
+        message=(
+            f"Firewall action {action or diff.op!r} will be re-read and "
+            "write-gated during /intent/apply."
+        ),
+    )
+
+
+def _path_for(payload: FirewallIntentPayload) -> tuple[str, str, bool, str]:  # noqa: C901
+    """Map a firewall intent payload to method/path/probe/reason."""
+    action = payload.action
+    zone = payload.zone or "datacenter"
+
+    if action == "firewall.group.create":
+        return "post", "cluster/firewall/groups", False, "firewall_write_not_supported"
+    if action == "firewall.group.delete":
+        if not payload.group:
+            raise ValueError("firewall.group.delete requires group")
+        return "delete", f"cluster/firewall/groups/{payload.group}", False, "firewall_write_not_supported"
+
+    if action.startswith("firewall.rule."):
+        base = _rule_base(payload, zone)
+        if action.endswith(".create"):
+            return "post", base, zone == "vnet", _unsupported_reason(zone)
+        if payload.pos is None:
+            raise ValueError(f"{action} requires pos")
+        method = "put" if action.endswith(".update") else "delete"
+        return method, f"{base}/{payload.pos}", zone == "vnet", _unsupported_reason(zone)
+
+    if action.startswith("firewall.ipset."):
+        base = _scoped_base(payload, zone, "ipset")
+        if action.endswith(".create"):
+            return "post", base, False, "firewall_write_not_supported"
+        if not payload.name:
+            raise ValueError(f"{action} requires name")
+        return "delete", f"{base}/{payload.name}", False, "firewall_write_not_supported"
+
+    if action == "firewall.alias.upsert":
+        if not payload.name:
+            raise ValueError("firewall.alias.upsert requires name")
+        return "put", f"{_scoped_base(payload, zone, 'aliases')}/{payload.name}", False, (
+            "firewall_write_not_supported"
+        )
+
+    if action == "firewall.options.update":
+        return "put", _scoped_base(payload, zone, "options"), False, "firewall_write_not_supported"
+
+    raise ValueError(f"Unsupported firewall intent action: {action}")
+
+
+def _rule_base(payload: FirewallIntentPayload, zone: str) -> str:
+    if zone == "datacenter":
+        return "cluster/firewall/rules"
+    if zone == "security_group":
+        if not payload.group:
+            raise ValueError("security_group rule intent requires group")
+        return f"cluster/firewall/groups/{payload.group}"
+    if zone == "node":
+        if not payload.node:
+            raise ValueError("node rule intent requires node")
+        return f"nodes/{payload.node}/firewall/rules"
+    if zone in {"vm_qemu", "vm_lxc"}:
+        return f"{_vm_base(payload, zone)}/rules"
+    if zone == "vnet":
+        if not payload.vnet:
+            raise ValueError("vnet rule intent requires vnet")
+        return f"cluster/sdn/vnets/{payload.vnet}/firewall/rules"
+    raise ValueError(f"Unsupported firewall rule zone: {zone}")
+
+
+def _scoped_base(payload: FirewallIntentPayload, zone: str, resource: str) -> str:
+    if zone == "datacenter":
+        return f"cluster/firewall/{resource}"
+    if zone in {"vm_qemu", "vm_lxc"}:
+        return f"{_vm_base(payload, zone)}/{resource}"
+    raise ValueError(f"{resource} is not supported for firewall zone {zone}")
+
+
+def _vm_base(payload: FirewallIntentPayload, zone: str) -> str:
+    if not payload.node or payload.vmid is None:
+        raise ValueError(f"{zone} firewall intent requires node and vmid")
+    vm_type = payload.vm_type or ("qemu" if zone == "vm_qemu" else "lxc")
+    return f"nodes/{payload.node}/{vm_type}/{payload.vmid}/firewall"
+
+
+def _unsupported_reason(zone: str) -> str:
+    return "vnet_firewall_not_supported" if zone == "vnet" else "firewall_write_not_supported"
+
+
+async def apply_firewall_diff(
+    *,
+    diff: ApplyDiff,
+    endpoint_context: IntentEndpointContext,
+    actor: str | None,
+    run_uuid: str,
+) -> ApplyResultItem:
+    """Apply one firewall intent diff through the firewall write route helper."""
+    del run_uuid
+    if not isinstance(diff.payload, FirewallIntentPayload):
+        return ApplyResultItem(
+            netbox_id=diff.netbox_id,
+            vmid=0,
+            op=diff.op,
+            kind=diff.kind,
+            status="failed",
+            reason="invalid_firewall_payload",
+            message="firewall apply requires FirewallIntentPayload",
+        )
+
+    try:
+        method, path, probe, unsupported_reason = _path_for(diff.payload)
+        result = await _firewall_write(
+            db=endpoint_context.session,
+            endpoint_id=endpoint_context.endpoint_id,
+            actor=actor,
+            method=method,
+            path=path,
+            payload=diff.payload.body if method != "delete" else None,
+            probe_supported=probe,
+            unsupported_reason=unsupported_reason,
+        )
+        if isinstance(result, JSONResponse):
+            body = json.loads(result.body.decode("utf-8"))
+            return ApplyResultItem(
+                netbox_id=diff.netbox_id,
+                vmid=diff.payload.vmid or 0,
+                op=diff.op,
+                kind=diff.kind,
+                status="failed",
+                reason=str(body.get("reason") or "firewall_apply_failed"),
+                message=str(body.get("detail") or body),
+            )
+
+        await _record_firewall_intent(
+            session=endpoint_context.session,
+            endpoint_id=endpoint_context.endpoint_id or 0,
+            actor=actor,
+            payload=diff.payload,
+            state=result.status,
+        )
+        status = "skipped" if result.status == "skipped" else "succeeded"
+        return ApplyResultItem(
+            netbox_id=diff.netbox_id,
+            vmid=diff.payload.vmid or 0,
+            op=diff.op,
+            kind=diff.kind,
+            status=status,
+            reason=result.reason,
+            message=result.detail or f"{diff.payload.action} {result.status}",
+            proxmox_upid=result.proxmox_task_id,
+        )
+    except Exception as error:  # noqa: BLE001
+        return ApplyResultItem(
+            netbox_id=diff.netbox_id,
+            vmid=getattr(diff.payload, "vmid", None) or 0,
+            op=diff.op,
+            kind=diff.kind,
+            status="failed",
+            reason="firewall_apply_failed",
+            message=str(error),
+        )
+
+
+async def _record_firewall_intent(
+    *,
+    session: object,
+    endpoint_id: int,
+    actor: str | None,
+    payload: FirewallIntentPayload,
+    state: str,
+) -> None:
+    if not isinstance(session, AsyncSession):
+        return
+    record = FirewallIntentRequestRecord(
+        endpoint_id=endpoint_id,
+        actor=actor,
+        action=payload.action,
+        state=state,
+        payload=payload.model_dump(mode="python"),
+        plan_snapshot={"recorded_at": time.time()},
+    )
+    session.add(record)
+    await session.commit()

--- a/tests/intent/test_static_destroy_gate.py
+++ b/tests/intent/test_static_destroy_gate.py
@@ -11,7 +11,7 @@ ALLOWLIST = {
     Path("routes/intent/dispatchers/lxc_destroy.py"),
 }
 DESTROY_PATTERNS = (
-    re.compile(r"\.delete\s*\(.*nodes"),
+    re.compile(r"(?<!router)\.delete\s*\(.*nodes"),
     re.compile(r"\.qemu\.delete\("),
     re.compile(r"\.lxc\.delete\("),
     re.compile(r"requests\.delete\(.*nodes/"),

--- a/tests/proxmox/test_firewall_write.py
+++ b/tests/proxmox/test_firewall_write.py
@@ -68,6 +68,14 @@ def _make_501() -> ResourceException:
     )
 
 
+def _make_404() -> ResourceException:
+    return ResourceException(
+        status_code=404,
+        status_message="Not Found",
+        content="No such rule",
+    )
+
+
 @dataclass
 class _Call:
     method: str
@@ -142,6 +150,20 @@ def test_firewall_write_requires_actor(auth_test_client, db_engine):
     assert response.json()["detail"]["reason"] == "actor_required"
 
 
+def test_firewall_group_create_requires_structured_name_error(auth_test_client):
+    response = auth_test_client.post(
+        "/proxmox/firewall/datacenter/groups",
+        headers={"X-Proxbox-Actor": "ops@example.com"},
+        json={"comment": "missing group"},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == {
+        "reason": "firewall_group_name_required",
+        "detail": "group or name is required",
+    }
+
+
 def test_datacenter_rule_create_dispatches_to_proxmox_sdk(
     auth_test_client,
     db_engine,
@@ -199,6 +221,28 @@ def test_vnet_501_returns_skipped(auth_test_client, db_engine, monkeypatch):
     body = response.json()
     assert body["status"] == "skipped"
     assert body["reason"] == "vnet_firewall_not_supported"
+
+
+def test_regular_firewall_write_404_returns_failure(auth_test_client, db_engine, monkeypatch):
+    endpoint_id = _make_endpoint(db_engine, allow_writes=True)
+    fake = _FakeProxmoxSession(exc=_make_404())
+
+    import proxbox_api.routes.proxmox.firewall as firewall_routes
+
+    async def _open(_endpoint):
+        return fake
+
+    monkeypatch.setattr(firewall_routes, "_open_proxmox_session", _open)
+
+    response = auth_test_client.post(
+        "/proxmox/firewall/datacenter/rules",
+        params={"endpoint_id": endpoint_id},
+        headers={"X-Proxbox-Actor": "ops@example.com"},
+        json={"type": "in", "action": "ACCEPT", "enable": True},
+    )
+
+    assert response.status_code == 502
+    assert response.json()["detail"]["reason"] == "proxmox_firewall_write_failed"
 
 
 def test_openapi_contains_full_firewall_write_matrix():

--- a/tests/proxmox/test_firewall_write.py
+++ b/tests/proxmox/test_firewall_write.py
@@ -5,10 +5,42 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+import pytest
 from proxmox_sdk.sdk.exceptions import ResourceException
 from sqlmodel import Session
 
 from proxbox_api.database import ProxmoxEndpoint
+from proxbox_api.main import app
+
+WRITE_ROUTE_MATRIX = {
+    "/proxmox/firewall/datacenter/rules": {"post"},
+    "/proxmox/firewall/datacenter/rules/{pos}": {"put", "delete"},
+    "/proxmox/firewall/datacenter/groups": {"post"},
+    "/proxmox/firewall/datacenter/groups/{group}": {"delete"},
+    "/proxmox/firewall/datacenter/groups/{group}/rules": {"post"},
+    "/proxmox/firewall/datacenter/groups/{group}/rules/{pos}": {"put", "delete"},
+    "/proxmox/firewall/datacenter/ipsets": {"post"},
+    "/proxmox/firewall/datacenter/ipsets/{name}": {"delete"},
+    "/proxmox/firewall/datacenter/ipsets/{name}/entries": {"post"},
+    "/proxmox/firewall/datacenter/ipsets/{name}/entries/{cidr}": {"put", "delete"},
+    "/proxmox/firewall/datacenter/aliases": {"post"},
+    "/proxmox/firewall/datacenter/aliases/{name}": {"put", "delete"},
+    "/proxmox/firewall/datacenter/options": {"put"},
+    "/proxmox/firewall/nodes/{node}/rules": {"post"},
+    "/proxmox/firewall/nodes/{node}/rules/{pos}": {"put", "delete"},
+    "/proxmox/firewall/nodes/{node}/options": {"put"},
+    "/proxmox/firewall/vms/{vmid}/rules": {"post"},
+    "/proxmox/firewall/vms/{vmid}/rules/{pos}": {"put", "delete"},
+    "/proxmox/firewall/vms/{vmid}/ipsets": {"post"},
+    "/proxmox/firewall/vms/{vmid}/ipsets/{name}": {"delete"},
+    "/proxmox/firewall/vms/{vmid}/ipsets/{name}/entries": {"post"},
+    "/proxmox/firewall/vms/{vmid}/ipsets/{name}/entries/{cidr}": {"put", "delete"},
+    "/proxmox/firewall/vms/{vmid}/aliases": {"post"},
+    "/proxmox/firewall/vms/{vmid}/aliases/{name}": {"put", "delete"},
+    "/proxmox/firewall/vms/{vmid}/options": {"put"},
+    "/proxmox/firewall/vnets/{vnet}/rules": {"post"},
+    "/proxmox/firewall/vnets/{vnet}/rules/{pos}": {"put", "delete"},
+}
 
 
 def _make_endpoint(db_engine, *, allow_writes: bool) -> int:
@@ -167,3 +199,84 @@ def test_vnet_501_returns_skipped(auth_test_client, db_engine, monkeypatch):
     body = response.json()
     assert body["status"] == "skipped"
     assert body["reason"] == "vnet_firewall_not_supported"
+
+
+def test_openapi_contains_full_firewall_write_matrix():
+    paths = app.openapi()["paths"]
+    for route, methods in WRITE_ROUTE_MATRIX.items():
+        assert route in paths
+        available = {method.lower() for method in paths[route]}
+        assert methods.issubset(available), (route, methods, available)
+
+
+@pytest.mark.parametrize(
+    ("method", "url", "json_body", "expected_call"),
+    [
+        (
+            "put",
+            "/proxmox/firewall/datacenter/aliases/web",
+            {"cidr": "10.0.0.10", "comment": "web"},
+            _Call("put", "cluster/firewall/aliases/web", {"cidr": "10.0.0.10", "comment": "web"}),
+        ),
+        (
+            "post",
+            "/proxmox/firewall/datacenter/ipsets/mgmt/entries",
+            {"cidr": "10.0.0.0/8", "nomatch": False},
+            _Call("post", "cluster/firewall/ipset/mgmt", {"cidr": "10.0.0.0/8", "nomatch": False}),
+        ),
+        (
+            "put",
+            "/proxmox/firewall/nodes/pve-a/options",
+            {"enable": True, "policy_in": "DROP"},
+            _Call("put", "nodes/pve-a/firewall/options", {"enable": True, "policy_in": "DROP"}),
+        ),
+        (
+            "post",
+            "/proxmox/firewall/vms/101/rules?node=pve-a&vm_type=lxc",
+            {"type": "in", "action": "ACCEPT", "enable": True},
+            _Call(
+                "post",
+                "nodes/pve-a/lxc/101/firewall/rules",
+                {"type": "in", "action": "ACCEPT", "enable": True},
+            ),
+        ),
+        (
+            "put",
+            "/proxmox/firewall/vms/101/options?node=pve-a&vm_type=qemu",
+            {"enable": True, "policy_out": "ACCEPT"},
+            _Call(
+                "put",
+                "nodes/pve-a/qemu/101/firewall/options",
+                {"enable": True, "policy_out": "ACCEPT"},
+            ),
+        ),
+    ],
+)
+def test_representative_write_routes_dispatch_to_expected_sdk_paths(
+    auth_test_client,
+    db_engine,
+    monkeypatch,
+    method,
+    url,
+    json_body,
+    expected_call,
+):
+    endpoint_id = _make_endpoint(db_engine, allow_writes=True)
+    fake = _FakeProxmoxSession()
+
+    import proxbox_api.routes.proxmox.firewall as firewall_routes
+
+    async def _open(_endpoint):
+        return fake
+
+    monkeypatch.setattr(firewall_routes, "_open_proxmox_session", _open)
+
+    separator = "&" if "?" in url else "?"
+    response = getattr(auth_test_client, method)(
+        f"{url}{separator}endpoint_id={endpoint_id}",
+        headers={"X-Proxbox-Actor": "ops@example.com"},
+        json=json_body,
+    )
+
+    assert response.status_code == 200, response.text
+    assert fake.calls == [expected_call]

--- a/tests/proxmox/test_firewall_write.py
+++ b/tests/proxmox/test_firewall_write.py
@@ -1,0 +1,169 @@
+"""Tests for proxbox-api firewall write routes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from proxmox_sdk.sdk.exceptions import ResourceException
+from sqlmodel import Session
+
+from proxbox_api.database import ProxmoxEndpoint
+
+
+def _make_endpoint(db_engine, *, allow_writes: bool) -> int:
+    with Session(db_engine) as session:
+        endpoint = ProxmoxEndpoint(
+            name="pve-test",
+            ip_address="10.0.0.10",
+            port=8006,
+            username="root@pam",
+            verify_ssl=False,
+            allow_writes=allow_writes,
+        )
+        session.add(endpoint)
+        session.commit()
+        session.refresh(endpoint)
+        assert endpoint.id is not None
+        return endpoint.id
+
+
+def _make_501() -> ResourceException:
+    return ResourceException(
+        status_code=501,
+        status_message="Not Implemented",
+        content="Method not implemented",
+    )
+
+
+@dataclass
+class _Call:
+    method: str
+    path: str
+    payload: dict[str, Any]
+
+
+@dataclass
+class _FakeProxmoxSession:
+    calls: list[_Call] = field(default_factory=list)
+    exc: Exception | None = None
+
+    def session(self, path: str):
+        calls = self.calls
+        exc = self.exc
+
+        class _Resource:
+            async def get(self):
+                if exc is not None:
+                    raise exc
+                calls.append(_Call("get", path, {}))
+                return []
+
+            async def post(self, **payload):
+                if exc is not None:
+                    raise exc
+                calls.append(_Call("post", path, payload))
+                return {"data": "UPID:pve-test:1"}
+
+            async def put(self, **payload):
+                if exc is not None:
+                    raise exc
+                calls.append(_Call("put", path, payload))
+                return {"ok": True}
+
+            async def delete(self, **payload):
+                if exc is not None:
+                    raise exc
+                calls.append(_Call("delete", path, payload))
+                return None
+
+        return _Resource()
+
+    async def aclose(self) -> None:
+        return None
+
+
+def test_firewall_write_disabled_returns_403(auth_test_client, db_engine):
+    endpoint_id = _make_endpoint(db_engine, allow_writes=False)
+
+    response = auth_test_client.post(
+        "/proxmox/firewall/datacenter/rules",
+        params={"endpoint_id": endpoint_id},
+        headers={"X-Proxbox-Actor": "ops@example.com"},
+        json={"type": "in", "action": "ACCEPT", "enable": True},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["reason"] == "writes_disabled_for_endpoint"
+
+
+def test_firewall_write_requires_actor(auth_test_client, db_engine):
+    endpoint_id = _make_endpoint(db_engine, allow_writes=True)
+
+    response = auth_test_client.post(
+        "/proxmox/firewall/datacenter/rules",
+        params={"endpoint_id": endpoint_id},
+        json={"type": "in", "action": "ACCEPT", "enable": True},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["reason"] == "actor_required"
+
+
+def test_datacenter_rule_create_dispatches_to_proxmox_sdk(
+    auth_test_client,
+    db_engine,
+    monkeypatch,
+):
+    endpoint_id = _make_endpoint(db_engine, allow_writes=True)
+    fake = _FakeProxmoxSession()
+
+    import proxbox_api.routes.proxmox.firewall as firewall_routes
+
+    async def _open(_endpoint):
+        return fake
+
+    monkeypatch.setattr(firewall_routes, "_open_proxmox_session", _open)
+
+    response = auth_test_client.post(
+        "/proxmox/firewall/datacenter/rules",
+        params={"endpoint_id": endpoint_id},
+        headers={"X-Proxbox-Actor": "ops@example.com"},
+        json={"type": "in", "action": "ACCEPT", "enable": True, "comment": "allow"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "pushed"
+    assert body["proxmox_task_id"] == "UPID:pve-test:1"
+    assert fake.calls == [
+        _Call(
+            "post",
+            "cluster/firewall/rules",
+            {"type": "in", "action": "ACCEPT", "enable": True, "comment": "allow"},
+        )
+    ]
+
+
+def test_vnet_501_returns_skipped(auth_test_client, db_engine, monkeypatch):
+    endpoint_id = _make_endpoint(db_engine, allow_writes=True)
+    fake = _FakeProxmoxSession(exc=_make_501())
+
+    import proxbox_api.routes.proxmox.firewall as firewall_routes
+
+    async def _open(_endpoint):
+        return fake
+
+    monkeypatch.setattr(firewall_routes, "_open_proxmox_session", _open)
+
+    response = auth_test_client.post(
+        "/proxmox/firewall/vnets/vnet0/rules",
+        params={"endpoint_id": endpoint_id},
+        headers={"X-Proxbox-Actor": "ops@example.com"},
+        json={"type": "forward", "action": "ACCEPT", "enable": True},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "skipped"
+    assert body["reason"] == "vnet_firewall_not_supported"

--- a/tests/test_firewall_intent.py
+++ b/tests/test_firewall_intent.py
@@ -1,0 +1,144 @@
+"""Tests for firewall intent plan/apply helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi.responses import JSONResponse
+
+from proxbox_api.routes.intent.dispatchers.common import IntentEndpointContext
+from proxbox_api.routes.intent.schemas import ApplyDiff, FirewallIntentPayload, IntentDiff
+from proxbox_api.schemas.firewall import FirewallWriteResponse
+from proxbox_api.services import firewall_intent
+
+
+def test_firewall_plan_diff_returns_warning_verdict():
+    diff = IntentDiff(
+        op="create",
+        kind="firewall",
+        netbox_id=123,
+        type="firewall.rule.create",
+    )
+
+    verdict = firewall_intent.plan_firewall_diff(diff)
+
+    assert verdict.verdict == "warning"
+    assert verdict.reason == "firewall_plan_preview"
+    assert "Firewall action" in verdict.message
+
+
+@pytest.mark.asyncio
+async def test_apply_firewall_diff_dispatches_write_and_returns_upid(monkeypatch):
+    calls = []
+
+    async def _write(**kwargs):
+        calls.append(kwargs)
+        return FirewallWriteResponse(
+            status="pushed",
+            endpoint_id=1,
+            actor="alice",
+            path=kwargs["path"],
+            proxmox_task_id="UPID:pve:1",
+        )
+
+    monkeypatch.setattr(firewall_intent, "_firewall_write", _write)
+    diff = ApplyDiff(
+        op="create",
+        kind="firewall",
+        netbox_id=123,
+        payload=FirewallIntentPayload(
+            action="firewall.rule.create",
+            zone="node",
+            node="pve-a",
+            body={"type": "in", "action": "ACCEPT"},
+        ),
+    )
+
+    result = await firewall_intent.apply_firewall_diff(
+        diff=diff,
+        endpoint_context=IntentEndpointContext(
+            session=SimpleNamespace(),
+            endpoint_id=1,
+            netbox_id=123,
+        ),
+        actor="alice",
+        run_uuid="run-1",
+    )
+
+    assert calls[0]["method"] == "post"
+    assert calls[0]["path"] == "nodes/pve-a/firewall/rules"
+    assert calls[0]["payload"] == {"type": "in", "action": "ACCEPT"}
+    assert result.status == "succeeded"
+    assert result.proxmox_upid == "UPID:pve:1"
+
+
+@pytest.mark.asyncio
+async def test_apply_firewall_diff_surfaces_write_gate_json(monkeypatch):
+    async def _write(**_kwargs):
+        return JSONResponse(
+            status_code=403,
+            content={
+                "reason": "writes_disabled_for_endpoint",
+                "detail": "writes are disabled",
+            },
+        )
+
+    monkeypatch.setattr(firewall_intent, "_firewall_write", _write)
+    diff = ApplyDiff(
+        op="update",
+        kind="firewall",
+        netbox_id=123,
+        payload=FirewallIntentPayload(
+            action="firewall.options.update",
+            zone="datacenter",
+            body={"enable": True},
+        ),
+    )
+
+    result = await firewall_intent.apply_firewall_diff(
+        diff=diff,
+        endpoint_context=IntentEndpointContext(session=SimpleNamespace(), endpoint_id=1),
+        actor="alice",
+        run_uuid="run-1",
+    )
+
+    assert result.status == "failed"
+    assert result.reason == "writes_disabled_for_endpoint"
+    assert result.message == "writes are disabled"
+
+
+@pytest.mark.asyncio
+async def test_apply_firewall_diff_maps_vnet_unsupported_to_skipped(monkeypatch):
+    async def _write(**kwargs):
+        return FirewallWriteResponse(
+            status="skipped",
+            endpoint_id=1,
+            actor="alice",
+            path=kwargs["path"],
+            reason="vnet_firewall_not_supported",
+            detail="Upstream Proxmox returned HTTP 501.",
+        )
+
+    monkeypatch.setattr(firewall_intent, "_firewall_write", _write)
+    diff = ApplyDiff(
+        op="create",
+        kind="firewall",
+        netbox_id=123,
+        payload=FirewallIntentPayload(
+            action="firewall.rule.create",
+            zone="vnet",
+            vnet="tenant-vnet",
+            body={"type": "forward", "action": "ACCEPT"},
+        ),
+    )
+
+    result = await firewall_intent.apply_firewall_diff(
+        diff=diff,
+        endpoint_context=IntentEndpointContext(session=SimpleNamespace(), endpoint_id=1),
+        actor="alice",
+        run_uuid="run-1",
+    )
+
+    assert result.status == "skipped"
+    assert result.reason == "vnet_firewall_not_supported"

--- a/tests/test_firewall_intent.py
+++ b/tests/test_firewall_intent.py
@@ -28,6 +28,36 @@ def test_firewall_plan_diff_returns_warning_verdict():
     assert "Firewall action" in verdict.message
 
 
+def test_firewall_options_update_supports_node_zone():
+    payload = FirewallIntentPayload(
+        action="firewall.options.update",
+        zone="node",
+        node="pve-a",
+        body={"enable": True},
+    )
+
+    method, path, probe, reason = firewall_intent._path_for(payload)
+
+    assert method == "put"
+    assert path == "nodes/pve-a/firewall/options"
+    assert probe is False
+    assert reason == "firewall_write_not_supported"
+
+
+def test_vm_zone_rejects_mismatched_vm_type():
+    payload = FirewallIntentPayload(
+        action="firewall.rule.create",
+        zone="vm_qemu",
+        node="pve-a",
+        vmid=101,
+        vm_type="lxc",
+        body={"type": "in", "action": "ACCEPT"},
+    )
+
+    with pytest.raises(ValueError, match="does not match firewall zone"):
+        firewall_intent._path_for(payload)
+
+
 @pytest.mark.asyncio
 async def test_apply_firewall_diff_dispatches_write_and_returns_upid(monkeypatch):
     calls = []
@@ -142,3 +172,32 @@ async def test_apply_firewall_diff_maps_vnet_unsupported_to_skipped(monkeypatch)
 
     assert result.status == "skipped"
     assert result.reason == "vnet_firewall_not_supported"
+
+
+@pytest.mark.asyncio
+async def test_apply_firewall_diff_scrubs_exception_message(monkeypatch):
+    async def _write(**_kwargs):
+        raise RuntimeError("upstream echoed secret value: s3cr3t-token")
+
+    monkeypatch.setattr(firewall_intent, "_firewall_write", _write)
+    diff = ApplyDiff(
+        op="update",
+        kind="firewall",
+        netbox_id=123,
+        payload=FirewallIntentPayload(
+            action="firewall.options.update",
+            zone="datacenter",
+            body={"token": "s3cr3t-token"},
+        ),
+    )
+
+    result = await firewall_intent.apply_firewall_diff(
+        diff=diff,
+        endpoint_context=IntentEndpointContext(session=SimpleNamespace(), endpoint_id=1),
+        actor="alice",
+        run_uuid="run-1",
+    )
+
+    assert result.status == "failed"
+    assert "s3cr3t-token" not in result.message
+    assert "***" in result.message


### PR DESCRIPTION
Refs emersonfelipesp/netbox-proxbox#476 and emersonfelipesp/netbox-proxbox#485.\n\nSummary:\n- Adds allow_writes-gated firewall mutation routes for datacenter, node, VM/CT, security-group, IP set, alias, options, and VNet rule scopes.\n- Requires X-Proxbox-Actor attribution and surfaces unsupported VNet firewalls as skipped results.\n- Extends intent plan/apply schemas and persistence for firewall diffs.\n\nVerification:\n- uv run ruff check proxbox_api tests/proxmox/test_firewall_write.py\n- uv run python -m compileall proxbox_api/routes/proxmox/firewall.py proxbox_api/routes/intent proxbox_api/services/firewall_intent.py proxbox_api/database.py\n- uv run pytest tests/proxmox/test_firewall_write.py tests/test_intent_plan_endpoint.py -q