### PR TITLE
Pin proxbox-api to proxmox-sdk 0.0.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV UV_COMPILE_BYTECODE=1 \
 
 # build-base ensures C extensions (httptools, uvloop, etc.) can compile if no
 # musllinux wheel is available for the target arch.
-# git is required for uv to fetch the proxmox-sdk git dependency from uv.lock.
+# git is required for DEV_OVERRIDES that install SDK branches during CI smoke runs.
 RUN apk add --no-cache build-base git
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "fastapi[standard]==0.136.1",
-    "proxmox-sdk==0.0.7",
+    "proxmox-sdk==0.0.9",
     "netbox-sdk==0.0.8.post1",
     "sqlmodel==0.0.38",
     "pydantic==2.13.3",
@@ -52,10 +52,10 @@ granian = [
     "granian>=2.7.4",
 ]
 pbs = [
-    "proxmox-sdk[pbs]==0.0.7",
+    "proxmox-sdk[pbs]==0.0.9",
 ]
 pdm = [
-    "proxmox-sdk[pdm]==0.0.7",
+    "proxmox-sdk[pdm]==0.0.9",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -1574,9 +1574,9 @@ requires-dist = [
     { name = "netbox-sdk", specifier = "==0.0.8.post1" },
     { name = "playwright", marker = "extra == 'playwright'", specifier = ">=1.58.0" },
     { name = "playwright", marker = "extra == 'test'", specifier = ">=1.58.0" },
-    { name = "proxmox-sdk", specifier = "==0.0.7" },
-    { name = "proxmox-sdk", extras = ["pbs"], marker = "extra == 'pbs'", specifier = "==0.0.7" },
-    { name = "proxmox-sdk", extras = ["pdm"], marker = "extra == 'pdm'", specifier = "==0.0.7" },
+    { name = "proxmox-sdk", specifier = "==0.0.9" },
+    { name = "proxmox-sdk", extras = ["pbs"], marker = "extra == 'pbs'", specifier = "==0.0.9" },
+    { name = "proxmox-sdk", extras = ["pdm"], marker = "extra == 'pdm'", specifier = "==0.0.9" },
     { name = "pydantic", specifier = "==2.13.3" },
     { name = "pytest", marker = "extra == 'e2e'", specifier = ">=9.0.3" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3" },
@@ -1618,7 +1618,7 @@ dev = [{ name = "ruff", specifier = ">=0.15.8" }]
 
 [[package]]
 name = "proxmox-sdk"
-version = "0.0.7"
+version = "0.0.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1627,9 +1627,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "slowapi" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/ab/03b5ade045a0814691744c07480be602043817687366bb9df53acfe78cce/proxmox_sdk-0.0.7.tar.gz", hash = "sha256:bdcf47abd072a414c63133d8e694aaffab788b0dd1540cd0349db228ada11d30", size = 2070468, upload-time = "2026-05-22T21:16:04.537Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/9c/5337eb2bddc42db69753609e4031d04c9444a82c69b19aead2fac38a3b54/proxmox_sdk-0.0.9.tar.gz", hash = "sha256:794f11324db6ad594488644ec735723a9f307674ebc1cc8f89ad9012b4b49d5a", size = 3499721, upload-time = "2026-05-24T21:01:28.634Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/7f/6bf96c5ce607fcfa25426f3348addf778c1e8d38bf30f54642434e883a45/proxmox_sdk-0.0.7-py3-none-any.whl", hash = "sha256:1588736d3cdb08a5e49fb58973b0302967e5eba327b4ed0c786a9140b83e5308", size = 2219490, upload-time = "2026-05-22T21:16:02.709Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/f4/875110ac6dc77fbf24c703ae75ac2b3f83980f6aaf1fe68bce91abea7fd2/proxmox_sdk-0.0.9-py3-none-any.whl", hash = "sha256:a947985e7e5e33958d6f35a879857ae33d6d06c02f6459525130a9cd861c3e43", size = 3709607, upload-time = "2026-05-24T21:01:26.732Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #191

## Summary
- Pins the runtime dependency and pbs/pdm extras to proxmox-sdk==0.0.9.
- Refreshes uv.lock to the published PyPI 0.0.9 wheel/sdist hashes.
- Updates the Dockerfile git comment now that uv.lock is PyPI-backed again.

## Verification
Post-rebase on current origin/main:
- uv sync --locked --extra test
- uv run ruff check .
- uv run ruff format --check .
- uv run python -m compileall proxbox_api tests
- uv run python -c "import proxmox_sdk; assert proxmox_sdk.__version__ == '0.0.9', proxmox_sdk.__version__; from proxbox_api.proxmox_to_netbox.proxmox_schema import load_proxmox_generated_openapi; assert load_proxmox_generated_openapi().get('paths'); print(proxmox_sdk.__version__)"
- uv run ty check proxbox_api/types proxbox_api/utils/retry.py proxbox_api/schemas/sync.py
- uv run pytest tests/test_proxmox_sdk_dependency.py tests/test_generated_proxmox_routes.py tests/test_session_and_helpers.py tests/test_proxmox_auth_pve9.py tests/test_pve91_501_graceful_handling.py tests/cloud/test_provision_lifecycle.py -q -> 3831 passed, 33 warnings

Additional pre-rebase full-suite signal on the same 0.0.9 lock:
- uv run pytest tests -q -> 5169 passed, 22 skipped, 67 warnings