### PR TITLE
Add SSH terminal gateway

### DIFF
--- a/proxbox_api/app/factory.py
+++ b/proxbox_api/app/factory.py
@@ -56,6 +56,7 @@ from proxbox_api.routes.proxmox.replication import router as px_replication_rout
 from proxbox_api.routes.proxmox.runtime_generated import register_generated_proxmox_routes
 from proxbox_api.routes.proxmox.sdn import router as px_sdn_router
 from proxbox_api.routes.proxmox_actions import router as proxmox_actions_router
+from proxbox_api.routes.ssh_terminal import router as ssh_terminal_router
 from proxbox_api.routes.sync.active import router as sync_active_router
 from proxbox_api.routes.sync.individual import router as sync_individual_router
 from proxbox_api.routes.virtualization import router as virtualization_router
@@ -460,6 +461,7 @@ def create_app() -> FastAPI:  # noqa: C901
         app.include_router(cloud_pve_template_router, prefix="/cloud", tags=["cloud"])
         app.include_router(cloud_templates_router, prefix="/cloud", tags=["cloud"])
         app.include_router(cloud_versions_router, prefix="/cloud", tags=["cloud"])
+        app.include_router(ssh_terminal_router, prefix="/ssh", tags=["ssh terminal"])
         app.include_router(
             sync_individual_router, prefix="/sync/individual", tags=["sync / individual"]
         )

--- a/proxbox_api/routes/ssh_terminal.py
+++ b/proxbox_api/routes/ssh_terminal.py
@@ -1,0 +1,142 @@
+"""SSH terminal ticket and WebSocket routes."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException, Request, WebSocket
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from proxbox_api.dependencies import NetBoxSessionDep
+from proxbox_api.logger import logger
+from proxbox_api.services.ssh_terminal import (
+    TerminalCredentialError,
+    TerminalSessionError,
+    connect_and_relay,
+    fetch_terminal_credential,
+    terminal_session_manager,
+)
+
+router = APIRouter()
+
+
+class TerminalSessionCreate(BaseModel):
+    """HTTP request for creating a one-time browser SSH session ticket."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    target_type: Literal["node", "endpoint"]
+    endpoint_id: int = Field(ge=1)
+    node_id: int | None = Field(default=None, ge=1)
+    host: str | None = None
+    actor: str | None = None
+    cols: int = Field(default=120, ge=20, le=400)
+    rows: int = Field(default=32, ge=5, le=200)
+
+    @model_validator(mode="after")
+    def validate_target(self) -> "TerminalSessionCreate":
+        if self.target_type == "node":
+            if self.node_id is None:
+                raise ValueError("node_id is required for node SSH terminal sessions")
+            if not (self.host or "").strip():
+                raise ValueError("host is required for node SSH terminal sessions")
+        return self
+
+
+class TerminalSessionPublic(BaseModel):
+    """Created terminal session details returned to NetBox."""
+
+    session_id: str
+    ticket: str
+    websocket_path: str
+    expires_at: str
+    target_type: Literal["node", "endpoint"]
+
+
+@router.post("/sessions", response_model=TerminalSessionPublic, status_code=201)
+async def create_terminal_session(
+    payload: TerminalSessionCreate,
+    request: Request,
+) -> TerminalSessionPublic:
+    actor = payload.actor or request.headers.get("X-Proxbox-Actor")
+    try:
+        session, ticket = await terminal_session_manager.create_session(
+            target_type=payload.target_type,
+            endpoint_id=payload.endpoint_id,
+            node_id=payload.node_id,
+            host=payload.host,
+            actor=actor,
+            cols=payload.cols,
+            rows=payload.rows,
+        )
+    except TerminalSessionError as exc:
+        raise HTTPException(status_code=429, detail=str(exc)) from exc
+
+    return TerminalSessionPublic(
+        session_id=session.session_id,
+        ticket=ticket,
+        websocket_path=f"/ssh/sessions/{session.session_id}/ws",
+        expires_at=session.expires_at.isoformat(),
+        target_type=session.target_type,
+    )
+
+
+async def _receive_auth_message(websocket: WebSocket) -> dict:
+    try:
+        message = await asyncio.wait_for(websocket.receive_json(), timeout=10)
+    except TimeoutError as exc:
+        raise TerminalSessionError("SSH terminal authentication timed out") from exc
+    if not isinstance(message, dict):
+        raise TerminalSessionError("Invalid SSH terminal authentication frame")
+    if message.get("type") != "auth":
+        raise TerminalSessionError("First SSH terminal frame must be type=auth")
+    ticket = str(message.get("ticket") or "").strip()
+    if not ticket:
+        raise TerminalSessionError("SSH terminal ticket is required")
+    return {"ticket": ticket}
+
+
+@router.websocket("/sessions/{session_id}/ws")
+async def ssh_terminal_websocket(
+    websocket: WebSocket,
+    session_id: str,
+    netbox_session: NetBoxSessionDep,
+) -> None:
+    """Authenticate a ticket, resolve SSH credentials, and bridge the PTY."""
+    await websocket.accept()
+    session = None
+    try:
+        auth = await _receive_auth_message(websocket)
+        session = await terminal_session_manager.consume_ticket(
+            session_id,
+            str(auth["ticket"]),
+        )
+    except TerminalSessionError as exc:
+        await websocket.send_json({"type": "error", "message": str(exc)})
+        await websocket.close(code=4001)
+        return
+
+    try:
+        credential = await fetch_terminal_credential(netbox_session, session)
+        await connect_and_relay(websocket, session, credential)
+    except TerminalCredentialError as exc:
+        await websocket.send_json({"type": "error", "message": str(exc)})
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "SSH terminal session failed",
+            extra={
+                "session_id": session.session_id,
+                "target_type": session.target_type,
+                "endpoint_id": session.endpoint_id,
+                "node_id": session.node_id,
+            },
+        )
+        await websocket.send_json({"type": "error", "message": "SSH terminal failed"})
+    finally:
+        if session is not None:
+            await terminal_session_manager.release(session.session_id)
+        try:
+            await websocket.close()
+        except Exception:  # noqa: BLE001
+            pass

--- a/proxbox_api/services/ssh_terminal.py
+++ b/proxbox_api/services/ssh_terminal.py
@@ -1,0 +1,626 @@
+"""Browser SSH terminal session manager and AsyncSSH relay."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import importlib
+import inspect
+import json
+import os
+import secrets
+import ssl
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any, Literal
+
+from fastapi import WebSocket
+from netbox_sdk.config import authorization_header_value
+from starlette.websockets import WebSocketDisconnect
+
+from proxbox_api.services.hardware_discovery import (
+    HardwareDiscoveryError,
+    fetch_credential,
+)
+
+if TYPE_CHECKING:
+    from netbox_sdk.facade import Api
+
+
+TerminalTargetType = Literal["node", "endpoint"]
+
+
+class TerminalSessionError(Exception):
+    """Base terminal-session failure."""
+
+
+class TerminalCredentialError(TerminalSessionError):
+    """Raised when SSH credential material cannot be resolved."""
+
+
+@dataclass
+class TerminalSession:
+    """Short-lived ticket state for a browser terminal session."""
+
+    session_id: str
+    ticket_hash: str
+    target_type: TerminalTargetType
+    endpoint_id: int
+    node_id: int | None
+    host: str | None
+    actor: str | None
+    cols: int
+    rows: int
+    created_at: datetime
+    expires_at: datetime
+    last_activity_at: datetime
+    consumed: bool = False
+
+
+@dataclass(frozen=True)
+class TerminalCredential:
+    """Decrypted SSH credential for the relay boundary."""
+
+    target_type: TerminalTargetType
+    target_id: int
+    host: str
+    port: int
+    username: str
+    known_host_fingerprint: str
+    password: str | None = None
+    private_key: str | None = None
+    display: str = ""
+
+
+def _env_int(name: str, default: int, *, minimum: int = 1) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return max(minimum, value)
+
+
+class TerminalSessionManager:
+    """In-memory one-time ticket store for SSH terminal handoff."""
+
+    def __init__(self) -> None:
+        self.ticket_ttl_seconds = _env_int(
+            "PROXBOX_SSH_TERMINAL_TICKET_TTL_SECONDS", 60
+        )
+        self.idle_timeout_seconds = _env_int(
+            "PROXBOX_SSH_TERMINAL_IDLE_TIMEOUT_SECONDS", 900
+        )
+        self.max_lifetime_seconds = _env_int(
+            "PROXBOX_SSH_TERMINAL_MAX_LIFETIME_SECONDS", 7200
+        )
+        self.max_sessions = _env_int("PROXBOX_SSH_TERMINAL_MAX_SESSIONS", 10)
+        self._sessions: dict[str, TerminalSession] = {}
+        self._lock = asyncio.Lock()
+
+    async def create_session(
+        self,
+        *,
+        target_type: TerminalTargetType,
+        endpoint_id: int,
+        node_id: int | None,
+        host: str | None,
+        actor: str | None,
+        cols: int,
+        rows: int,
+    ) -> tuple[TerminalSession, str]:
+        """Create a short-lived ticket and return ``(session, plaintext_ticket)``."""
+        async with self._lock:
+            now = datetime.now(UTC)
+            self._cleanup_locked(now)
+            if len(self._sessions) >= self.max_sessions:
+                raise TerminalSessionError("Maximum SSH terminal session count reached")
+
+            ticket = secrets.token_urlsafe(32)
+            session_id = secrets.token_urlsafe(24)
+            session = TerminalSession(
+                session_id=session_id,
+                ticket_hash=self._hash_ticket(ticket),
+                target_type=target_type,
+                endpoint_id=endpoint_id,
+                node_id=node_id,
+                host=host.strip() if host else None,
+                actor=actor.strip() if actor else None,
+                cols=cols,
+                rows=rows,
+                created_at=now,
+                expires_at=now + timedelta(seconds=self.ticket_ttl_seconds),
+                last_activity_at=now,
+            )
+            self._sessions[session.session_id] = session
+            return session, ticket
+
+    async def consume_ticket(self, session_id: str, ticket: str) -> TerminalSession:
+        """Validate and consume a one-time ticket for WebSocket upgrade."""
+        async with self._lock:
+            now = datetime.now(UTC)
+            self._cleanup_locked(now)
+            session = self._sessions.get(session_id)
+            if session is None:
+                raise TerminalSessionError("SSH terminal session not found")
+            if session.consumed:
+                raise TerminalSessionError("SSH terminal ticket has already been used")
+            if now > session.expires_at:
+                self._sessions.pop(session_id, None)
+                raise TerminalSessionError("SSH terminal ticket has expired")
+            if not secrets.compare_digest(session.ticket_hash, self._hash_ticket(ticket)):
+                raise TerminalSessionError("Invalid SSH terminal ticket")
+            session.consumed = True
+            session.last_activity_at = now
+            return session
+
+    async def mark_activity(self, session_id: str) -> None:
+        async with self._lock:
+            session = self._sessions.get(session_id)
+            if session is not None:
+                session.last_activity_at = datetime.now(UTC)
+
+    async def release(self, session_id: str) -> None:
+        async with self._lock:
+            self._sessions.pop(session_id, None)
+
+    def idle_remaining_seconds(self, session: TerminalSession) -> float:
+        deadline = session.last_activity_at + timedelta(seconds=self.idle_timeout_seconds)
+        return max(0.0, (deadline - datetime.now(UTC)).total_seconds())
+
+    def lifetime_remaining_seconds(self, session: TerminalSession) -> float:
+        deadline = session.created_at + timedelta(seconds=self.max_lifetime_seconds)
+        return max(0.0, (deadline - datetime.now(UTC)).total_seconds())
+
+    @staticmethod
+    def _hash_ticket(ticket: str) -> str:
+        return hashlib.sha256(ticket.encode()).hexdigest()
+
+    def _cleanup_locked(self, now: datetime) -> None:
+        expired: list[str] = []
+        for session_id, session in self._sessions.items():
+            lifetime_deadline = session.created_at + timedelta(
+                seconds=self.max_lifetime_seconds
+            )
+            if now > session.expires_at and not session.consumed:
+                expired.append(session_id)
+            elif now > lifetime_deadline:
+                expired.append(session_id)
+        for session_id in expired:
+            self._sessions.pop(session_id, None)
+
+
+terminal_session_manager = TerminalSessionManager()
+
+
+def _endpoint_credential_url(base_url: str, endpoint_id: int) -> str:
+    return (
+        f"{base_url.rstrip('/')}"
+        f"/api/plugins/proxbox/ssh-credentials/by-endpoint/{int(endpoint_id)}/credentials/"
+    )
+
+
+def _urlopen_kwargs(config: object, url: str, timeout: float) -> dict[str, object]:
+    parsed = urllib.parse.urlsplit(url)
+    kwargs: dict[str, object] = {"timeout": timeout}
+    if parsed.scheme.lower() == "https" and getattr(config, "ssl_verify", True) is False:
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        kwargs["context"] = ctx
+    return kwargs
+
+
+def _coerce_endpoint_credential(
+    endpoint_id: int,
+    requested_host: str | None,
+    payload: dict[str, Any],
+) -> TerminalCredential:
+    host = str(payload.get("host") or requested_host or "").strip()
+    username = str(payload.get("username") or payload.get("ssh_username") or "").strip()
+    fingerprint = str(
+        payload.get("known_host_fingerprint")
+        or payload.get("ssh_known_host_fingerprint")
+        or ""
+    ).strip()
+    if not host:
+        raise TerminalCredentialError(
+            f"SSH credential for endpoint {endpoint_id} is missing host"
+        )
+    if not username:
+        raise TerminalCredentialError(
+            f"SSH credential for endpoint {endpoint_id} is missing username"
+        )
+    if not fingerprint:
+        raise TerminalCredentialError(
+            f"SSH credential for endpoint {endpoint_id} is missing known_host_fingerprint"
+        )
+    try:
+        port = int(payload.get("port") or payload.get("ssh_port") or 22)
+    except (TypeError, ValueError) as exc:
+        raise TerminalCredentialError(
+            f"SSH credential for endpoint {endpoint_id} has invalid port"
+        ) from exc
+    password = payload.get("password") or payload.get("ssh_password") or None
+    private_key = payload.get("private_key") or payload.get("ssh_private_key") or None
+    return TerminalCredential(
+        target_type="endpoint",
+        target_id=int(payload.get("endpoint_id") or endpoint_id),
+        host=host,
+        port=port,
+        username=username,
+        known_host_fingerprint=fingerprint,
+        password=password,
+        private_key=private_key,
+        display=f"{username}@{host}:{port}",
+    )
+
+
+def _fetch_endpoint_credential(
+    netbox_session: "Api",
+    endpoint_id: int,
+    host: str | None,
+    *,
+    timeout: float = 10.0,
+) -> TerminalCredential:
+    config = netbox_session.client.config
+    base_url = (config.base_url or "").rstrip("/")
+    if not base_url:
+        raise TerminalCredentialError("NetBox base_url is not configured")
+
+    auth = authorization_header_value(config)
+    if not auth:
+        raise TerminalCredentialError("NetBox auth header could not be built")
+
+    url = _endpoint_credential_url(base_url, endpoint_id)
+    req = urllib.request.Request(
+        url,
+        headers={"Authorization": auth, "Accept": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, **_urlopen_kwargs(config, url, timeout)) as resp:
+            if resp.status != 200:
+                raise TerminalCredentialError(
+                    f"Endpoint SSH credential fetch returned HTTP {resp.status}"
+                )
+            body = resp.read()
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            raise TerminalCredentialError(
+                f"No SSH credential registered for endpoint {endpoint_id}"
+            ) from exc
+        raise TerminalCredentialError(
+            f"Endpoint SSH credential fetch failed: HTTP {exc.code}"
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise TerminalCredentialError(
+            f"Endpoint SSH credential fetch failed: {exc.reason!s}"
+        ) from exc
+
+    try:
+        payload = json.loads(body.decode())
+    except json.JSONDecodeError as exc:
+        raise TerminalCredentialError(
+            f"Endpoint SSH credential fetch for {endpoint_id} returned invalid JSON"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise TerminalCredentialError(
+            f"Endpoint SSH credential fetch for {endpoint_id} returned non-object payload"
+        )
+    return _coerce_endpoint_credential(endpoint_id, host, payload)
+
+
+async def fetch_terminal_credential(
+    netbox_session: "Api",
+    session: TerminalSession,
+) -> TerminalCredential:
+    """Resolve node or endpoint SSH credential material from netbox-proxbox."""
+    if session.target_type == "node":
+        if session.node_id is None or not session.host:
+            raise TerminalCredentialError("Node terminal target requires node_id and host")
+        try:
+            cred = await asyncio.to_thread(
+                fetch_credential,
+                netbox_session,
+                session.node_id,
+                session.host,
+            )
+        except HardwareDiscoveryError as exc:
+            raise TerminalCredentialError(str(exc)) from exc
+        return TerminalCredential(
+            target_type="node",
+            target_id=cred.node_id,
+            host=cred.host,
+            port=cred.port,
+            username=cred.username,
+            known_host_fingerprint=cred.known_host_fingerprint,
+            password=cred.password,
+            private_key=cred.private_key,
+            display=f"{cred.username}@{cred.host}:{cred.port}",
+        )
+
+    return await asyncio.to_thread(
+        _fetch_endpoint_credential,
+        netbox_session,
+        session.endpoint_id,
+        session.host,
+    )
+
+
+def _canonical_fingerprint(value: str) -> str:
+    text = value.strip()
+    if text.lower().startswith("sha256:"):
+        text = text.split(":", 1)[1]
+    return f"SHA256:{text.rstrip('=')}"
+
+
+def _fingerprint_from_key(key: object) -> str:
+    getter = getattr(key, "get_fingerprint", None)
+    if not callable(getter):
+        raise TerminalCredentialError("SSH server key does not expose a fingerprint")
+    for algorithm in ("sha256", "SHA256"):
+        try:
+            value = getter(algorithm)
+        except TypeError:
+            continue
+        if value:
+            return _canonical_fingerprint(str(value))
+    value = getter()
+    if not value:
+        raise TerminalCredentialError("SSH server key fingerprint is empty")
+    return _canonical_fingerprint(str(value))
+
+
+def _load_asyncssh() -> Any:
+    return importlib.import_module("asyncssh")
+
+
+def _pinned_client_factory(asyncssh_module: Any, expected_fingerprint: str) -> object:
+    expected = _canonical_fingerprint(expected_fingerprint)
+
+    class PinnedHostKeyClient(asyncssh_module.SSHClient):  # type: ignore[misc]
+        def validate_host_public_key(self, host, addr, port, key):  # noqa: ANN001
+            actual = _fingerprint_from_key(key)
+            return secrets.compare_digest(expected, actual)
+
+    return PinnedHostKeyClient
+
+
+async def _maybe_drain(writer: object) -> None:
+    drain = getattr(writer, "drain", None)
+    if not callable(drain):
+        return
+    result = drain()
+    if inspect.isawaitable(result):
+        await result
+
+
+async def _send_json_safe(websocket: WebSocket, payload: dict[str, object]) -> None:
+    try:
+        await websocket.send_json(payload)
+    except Exception:  # noqa: BLE001
+        return
+
+
+async def _pump_process_output(
+    websocket: WebSocket,
+    process: object,
+    session: TerminalSession,
+    manager: TerminalSessionManager,
+) -> None:
+    stdout = getattr(process, "stdout", None)
+    if stdout is None:
+        return
+    while True:
+        chunk = await stdout.read(4096)
+        if not chunk:
+            return
+        if isinstance(chunk, bytes):
+            chunk = chunk.decode("utf-8", errors="replace")
+        await manager.mark_activity(session.session_id)
+        await _send_json_safe(websocket, {"type": "output", "data": str(chunk)})
+
+
+async def _resize_process(process: object, cols: int, rows: int) -> None:
+    resize = getattr(process, "change_terminal_size", None)
+    if not callable(resize):
+        return
+    result = resize(cols, rows, 0, 0)
+    if inspect.isawaitable(result):
+        await result
+
+
+async def _read_terminal_message(
+    websocket: WebSocket,
+    session: TerminalSession,
+    manager: TerminalSessionManager,
+) -> dict | None:
+    timeout = min(
+        manager.idle_remaining_seconds(session),
+        manager.lifetime_remaining_seconds(session),
+    )
+    if timeout <= 0:
+        await _send_json_safe(
+            websocket,
+            {"type": "error", "message": "SSH terminal session timed out"},
+        )
+        return None
+    try:
+        message = await asyncio.wait_for(websocket.receive_json(), timeout=timeout)
+    except TimeoutError:
+        await _send_json_safe(
+            websocket,
+            {"type": "error", "message": "SSH terminal session timed out"},
+        )
+        return None
+    except WebSocketDisconnect:
+        return None
+    if not isinstance(message, dict):
+        await _send_json_safe(
+            websocket,
+            {"type": "error", "message": "Invalid SSH terminal message"},
+        )
+        return {}
+    return message
+
+
+async def _handle_resize_message(
+    websocket: WebSocket,
+    process: object,
+    session: TerminalSession,
+    message: dict,
+) -> None:
+    try:
+        cols = max(20, min(400, int(message.get("cols") or session.cols)))
+        rows = max(5, min(200, int(message.get("rows") or session.rows)))
+    except (TypeError, ValueError):
+        await _send_json_safe(
+            websocket,
+            {"type": "error", "message": "Invalid terminal size"},
+        )
+        return
+    session.cols = cols
+    session.rows = rows
+    await _resize_process(process, cols, rows)
+
+
+async def _handle_terminal_message(
+    websocket: WebSocket,
+    process: object,
+    session: TerminalSession,
+    message: dict,
+) -> bool:
+    message_type = message.get("type")
+    if message_type == "input":
+        stdin = getattr(process, "stdin", None)
+        if stdin is not None:
+            stdin.write(str(message.get("data", "")))
+            await _maybe_drain(stdin)
+        return True
+    if message_type == "resize":
+        await _handle_resize_message(websocket, process, session, message)
+        return True
+    if message_type == "close":
+        return False
+    await _send_json_safe(
+        websocket,
+        {"type": "error", "message": f"Unsupported message type: {message_type}"},
+    )
+    return True
+
+
+async def _pump_websocket_input(
+    websocket: WebSocket,
+    process: object,
+    session: TerminalSession,
+    manager: TerminalSessionManager,
+) -> None:
+    while True:
+        message = await _read_terminal_message(websocket, session, manager)
+        if message is None:
+            return
+        if not message:
+            continue
+        await manager.mark_activity(session.session_id)
+        keep_running = await _handle_terminal_message(
+            websocket,
+            process,
+            session,
+            message,
+        )
+        if not keep_running:
+            return
+
+
+async def _close_process(process: object) -> int | None:
+    terminate = getattr(process, "terminate", None)
+    if callable(terminate):
+        terminate()
+    wait = getattr(process, "wait", None)
+    if not callable(wait):
+        return None
+    try:
+        status = await asyncio.wait_for(wait(), timeout=5)
+    except TimeoutError:
+        kill = getattr(process, "kill", None)
+        if callable(kill):
+            kill()
+        return None
+    try:
+        return int(status) if status is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+async def connect_and_relay(
+    websocket: WebSocket,
+    session: TerminalSession,
+    credential: TerminalCredential,
+    *,
+    manager: TerminalSessionManager = terminal_session_manager,
+) -> None:
+    """Open an AsyncSSH PTY and relay terminal frames until either side closes."""
+    if not (credential.password or credential.private_key):
+        raise TerminalCredentialError("SSH credential has no password or private key")
+
+    asyncssh = _load_asyncssh()
+    client_keys = None
+    if credential.private_key:
+        try:
+            client_keys = [asyncssh.import_private_key(credential.private_key)]
+        except Exception as exc:  # noqa: BLE001
+            raise TerminalCredentialError("SSH private key could not be loaded") from exc
+
+    conn = await asyncssh.connect(
+        credential.host,
+        port=credential.port,
+        username=credential.username,
+        password=credential.password or None,
+        client_keys=client_keys,
+        known_hosts=b"",
+        server_host_key_algs="default",
+        client_factory=_pinned_client_factory(
+            asyncssh,
+            credential.known_host_fingerprint,
+        ),
+    )
+
+    async with conn:
+        process = await conn.create_process(
+            term_type="xterm-256color",
+            term_size=(session.cols, session.rows, 0, 0),
+            encoding="utf-8",
+            errors="replace",
+        )
+        await _send_json_safe(
+            websocket,
+            {
+                "type": "ready",
+                "session_id": session.session_id,
+                "target": credential.display,
+            },
+        )
+        output_task = asyncio.create_task(
+            _pump_process_output(websocket, process, session, manager)
+        )
+        input_task = asyncio.create_task(
+            _pump_websocket_input(websocket, process, session, manager)
+        )
+        done, pending = await asyncio.wait(
+            {output_task, input_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        for task in done:
+            error = task.exception()
+            if error is not None:
+                raise error
+        status = await _close_process(process)
+        await _send_json_safe(websocket, {"type": "exit", "status": status})

--- a/proxbox_api/services/ssh_terminal.py
+++ b/proxbox_api/services/ssh_terminal.py
@@ -90,15 +90,9 @@ class TerminalSessionManager:
     """In-memory one-time ticket store for SSH terminal handoff."""
 
     def __init__(self) -> None:
-        self.ticket_ttl_seconds = _env_int(
-            "PROXBOX_SSH_TERMINAL_TICKET_TTL_SECONDS", 60
-        )
-        self.idle_timeout_seconds = _env_int(
-            "PROXBOX_SSH_TERMINAL_IDLE_TIMEOUT_SECONDS", 900
-        )
-        self.max_lifetime_seconds = _env_int(
-            "PROXBOX_SSH_TERMINAL_MAX_LIFETIME_SECONDS", 7200
-        )
+        self.ticket_ttl_seconds = _env_int("PROXBOX_SSH_TERMINAL_TICKET_TTL_SECONDS", 60)
+        self.idle_timeout_seconds = _env_int("PROXBOX_SSH_TERMINAL_IDLE_TIMEOUT_SECONDS", 900)
+        self.max_lifetime_seconds = _env_int("PROXBOX_SSH_TERMINAL_MAX_LIFETIME_SECONDS", 7200)
         self.max_sessions = _env_int("PROXBOX_SSH_TERMINAL_MAX_SESSIONS", 10)
         self._sessions: dict[str, TerminalSession] = {}
         self._lock = asyncio.Lock()
@@ -184,9 +178,7 @@ class TerminalSessionManager:
     def _cleanup_locked(self, now: datetime) -> None:
         expired: list[str] = []
         for session_id, session in self._sessions.items():
-            lifetime_deadline = session.created_at + timedelta(
-                seconds=self.max_lifetime_seconds
-            )
+            lifetime_deadline = session.created_at + timedelta(seconds=self.max_lifetime_seconds)
             if now > session.expires_at and not session.consumed:
                 expired.append(session_id)
             elif now > lifetime_deadline:
@@ -224,14 +216,10 @@ def _coerce_endpoint_credential(
     host = str(payload.get("host") or requested_host or "").strip()
     username = str(payload.get("username") or payload.get("ssh_username") or "").strip()
     fingerprint = str(
-        payload.get("known_host_fingerprint")
-        or payload.get("ssh_known_host_fingerprint")
-        or ""
+        payload.get("known_host_fingerprint") or payload.get("ssh_known_host_fingerprint") or ""
     ).strip()
     if not host:
-        raise TerminalCredentialError(
-            f"SSH credential for endpoint {endpoint_id} is missing host"
-        )
+        raise TerminalCredentialError(f"SSH credential for endpoint {endpoint_id} is missing host")
     if not username:
         raise TerminalCredentialError(
             f"SSH credential for endpoint {endpoint_id} is missing username"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "aiosqlite>=0.20.0,<1.0.0",
     "cryptography>=43.0.0,<50.0.0",
     "bcrypt>=5.0.0,<6.0.0",
+    "asyncssh>=2.20.0,<3.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_ssh_terminal.py
+++ b/tests/test_ssh_terminal.py
@@ -1,0 +1,161 @@
+"""Tests for SSH terminal tickets and WebSocket handoff."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from proxbox_api.services.ssh_terminal import (
+    TerminalCredential,
+    TerminalSessionError,
+    TerminalSessionManager,
+    terminal_session_manager,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_terminal_sessions():
+    terminal_session_manager._sessions.clear()
+    yield
+    terminal_session_manager._sessions.clear()
+
+
+@pytest.mark.asyncio
+async def test_terminal_session_ticket_is_one_time() -> None:
+    manager = TerminalSessionManager()
+    session, ticket = await manager.create_session(
+        target_type="node",
+        endpoint_id=1,
+        node_id=2,
+        host="10.0.0.2",
+        actor="alice",
+        cols=120,
+        rows=32,
+    )
+
+    consumed = await manager.consume_ticket(session.session_id, ticket)
+
+    assert consumed.session_id == session.session_id
+    assert consumed.consumed is True
+    with pytest.raises(TerminalSessionError, match="already been used"):
+        await manager.consume_ticket(session.session_id, ticket)
+
+
+def test_create_ssh_terminal_session_requires_backend_api_key(test_client) -> None:
+    response = test_client.post(
+        "/ssh/sessions",
+        json={
+            "target_type": "node",
+            "endpoint_id": 1,
+            "node_id": 2,
+            "host": "10.0.0.2",
+        },
+    )
+
+    assert response.status_code == 401
+
+
+def test_create_ssh_terminal_session_returns_browser_ticket(auth_test_client) -> None:
+    response = auth_test_client.post(
+        "/ssh/sessions",
+        json={
+            "target_type": "node",
+            "endpoint_id": 1,
+            "node_id": 2,
+            "host": "10.0.0.2",
+            "cols": 100,
+            "rows": 30,
+        },
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["ticket"]
+    assert payload["websocket_path"] == f"/ssh/sessions/{payload['session_id']}/ws"
+    assert "X-Proxbox-API-Key" not in payload
+
+
+def test_asyncssh_relay_pins_host_key_instead_of_disabling_validation() -> None:
+    source = Path("proxbox_api/services/ssh_terminal.py").read_text()
+    assert "known_hosts=b\"\"" in source
+    assert 'server_host_key_algs="default"' in source
+    assert "known_hosts=None" not in source
+    assert "validate_host_public_key" in source
+
+
+def test_ssh_terminal_websocket_rejects_invalid_ticket(auth_test_client) -> None:
+    created = auth_test_client.post(
+        "/ssh/sessions",
+        json={
+            "target_type": "node",
+            "endpoint_id": 1,
+            "node_id": 2,
+            "host": "10.0.0.2",
+        },
+    ).json()
+
+    with auth_test_client.websocket_connect(created["websocket_path"]) as websocket:
+        websocket.send_json({"type": "auth", "ticket": "wrong"})
+        frame = websocket.receive_json()
+
+    assert frame["type"] == "error"
+    assert "Invalid SSH terminal ticket" in frame["message"]
+
+
+def test_ssh_terminal_websocket_uses_ticket_without_backend_api_key(
+    monkeypatch,
+    auth_test_client,
+) -> None:
+    created = auth_test_client.post(
+        "/ssh/sessions",
+        json={
+            "target_type": "node",
+            "endpoint_id": 1,
+            "node_id": 2,
+            "host": "10.0.0.2",
+        },
+    ).json()
+
+    async def fake_fetch_terminal_credential(netbox_session, session):
+        return TerminalCredential(
+            target_type="node",
+            target_id=session.node_id or 0,
+            host=session.host or "10.0.0.2",
+            port=22,
+            username="proxbox",
+            known_host_fingerprint="SHA256:abcdefghijklmnopqrstuvwxyz12345678901234567",
+            password="secret",
+            display="proxbox@10.0.0.2:22",
+        )
+
+    async def fake_connect_and_relay(websocket, session, credential):
+        await websocket.send_json(
+            {
+                "type": "ready",
+                "session_id": session.session_id,
+                "target": credential.display,
+            }
+        )
+        message = await websocket.receive_json()
+        assert message == {"type": "close"}
+        await websocket.send_json({"type": "exit", "status": 0})
+
+    monkeypatch.setattr(
+        "proxbox_api.routes.ssh_terminal.fetch_terminal_credential",
+        fake_fetch_terminal_credential,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.routes.ssh_terminal.connect_and_relay",
+        fake_connect_and_relay,
+    )
+
+    with auth_test_client.websocket_connect(created["websocket_path"]) as websocket:
+        websocket.send_json({"type": "auth", "ticket": created["ticket"]})
+        ready = websocket.receive_json()
+        websocket.send_json({"type": "close"})
+        exit_frame = websocket.receive_json()
+
+    assert ready["type"] == "ready"
+    assert ready["target"] == "proxbox@10.0.0.2:22"
+    assert exit_frame == {"type": "exit", "status": 0}

--- a/tests/test_ssh_terminal.py
+++ b/tests/test_ssh_terminal.py
@@ -78,7 +78,7 @@ def test_create_ssh_terminal_session_returns_browser_ticket(auth_test_client) ->
 
 def test_asyncssh_relay_pins_host_key_instead_of_disabling_validation() -> None:
     source = Path("proxbox_api/services/ssh_terminal.py").read_text()
-    assert "known_hosts=b\"\"" in source
+    assert 'known_hosts=b""' in source
     assert 'server_host_key_algs="default"' in source
     assert "known_hosts=None" not in source
     assert "validate_host_public_key" in source

--- a/uv.lock
+++ b/uv.lock
@@ -166,6 +166,19 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncssh"
+version = "2.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/fd/c34fe7e30838b4b9cc91903da26a62c6d33b673c731b3d951fcd70ab1889/asyncssh-2.23.0.tar.gz", hash = "sha256:8c54760953c1f2cf282591bcba5c8c70efc48d645bbf26bd2307a9c66a0ed1a7", size = 542154, upload-time = "2026-05-09T03:15:01.856Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/b5/b1a3979f4840d1271ca8e0978dbccfb18ad2d33b4ece85cf77122fb46e5f/asyncssh-2.23.0-py3-none-any.whl", hash = "sha256:14108bfdaae17457f0c1841e883ad934271bbfdd46458aa4c4d0973451940ad0", size = 375687, upload-time = "2026-05-09T03:15:00.221Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1510,6 +1523,7 @@ version = "0.0.15"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
+    { name = "asyncssh" },
     { name = "bcrypt" },
     { name = "cryptography" },
     { name = "fastapi", extra = ["standard"] },
@@ -1562,6 +1576,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0,<1.0.0" },
+    { name = "asyncssh", specifier = ">=2.20.0,<3.0.0" },
     { name = "bcrypt", specifier = ">=5.0.0,<6.0.0" },
     { name = "cryptography", specifier = ">=43.0.0,<50.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = "==0.136.1" },


### PR DESCRIPTION
## Summary
- add /ssh/sessions ticket creation and /ssh/sessions/{session_id}/ws WebSocket relay
- resolve per-node credentials from existing NodeSSHCredential endpoint or endpoint fallback credentials from netbox-proxbox
- bridge xterm-style terminal frames to an AsyncSSH PTY with pinned SHA-256 host-key validation

## Tests
- uv run --extra test ruff check proxbox_api/services/ssh_terminal.py proxbox_api/routes/ssh_terminal.py tests/test_ssh_terminal.py
- uv run --extra test pytest tests/test_ssh_terminal.py

Closes #193