### PR TITLE
docs: document Firecracker Cloud support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,16 @@ the `netbox-proxbox` side, do all five — the existing fields in
 See `CLAUDE.md → Environment Variables → Adding a new tunable` for the full keep-list
 and resolution-order details.
 
+## Firecracker Cloud
+
+Firecracker provisioning lives in `proxbox_api/routes/cloud/firecracker.py`,
+`proxbox_api/firecracker_agent/`, and `proxbox_api/schemas/firecracker.py`.
+`nms-backend` resolves NetBox Proxbox host/image inventory and creates the
+`FirecrackerMicroVM` row, then calls this backend at
+`POST /cloud/firecracker/provision` or
+`POST /cloud/firecracker/provision/stream`. This repo owns the host-agent HTTP
+contract only; NetBox inventory remains in `netbox-proxbox`.
+
 ## Primary Guide
 
 - `CLAUDE.md`
@@ -112,6 +122,7 @@ and resolution-order details.
 ### proxbox_api subpackages
 - `proxbox_api/app/CLAUDE.md`
 - `proxbox_api/routes/CLAUDE.md`
+- `proxbox_api/routes/cloud/firecracker.py`
 - `proxbox_api/routes/admin/CLAUDE.md`
 - `proxbox_api/routes/dcim/CLAUDE.md`
 - `proxbox_api/routes/extras/CLAUDE.md`
@@ -128,6 +139,7 @@ and resolution-order details.
 - `proxbox_api/services/sync/individual/CLAUDE.md`
 - `proxbox_api/session/CLAUDE.md`
 - `proxbox_api/schemas/CLAUDE.md`
+- `proxbox_api/schemas/firecracker.py`
 - `proxbox_api/schemas/netbox/CLAUDE.md`
 - `proxbox_api/schemas/netbox/dcim/CLAUDE.md`
 - `proxbox_api/schemas/netbox/extras/CLAUDE.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Submodule layout and cross-repo links: `/root/personal-context/claude-reference/
 
 ## Overview
 
-`proxbox-api` is a FastAPI backend that connects Proxmox inventory and lifecycle data to NetBox objects. It serves REST, SSE, and WebSocket endpoints for discovery, synchronization, endpoint management, and generated Proxmox proxy routes. The same repository also includes a standalone `nextjs-ui/` frontend for endpoint administration.
+`proxbox-api` is a FastAPI backend that connects Proxmox inventory and lifecycle data to NetBox objects. It serves REST, SSE, and WebSocket endpoints for discovery, synchronization, endpoint management, generated Proxmox proxy routes, and Firecracker host-agent provisioning for the NMS Cloud runtime. The same repository also includes a standalone `nextjs-ui/` frontend for endpoint administration.
 
 ### Companion repos (cross-link map)
 
@@ -20,6 +20,9 @@ Submodule layout and cross-repo links: `/root/personal-context/claude-reference/
   (PVE 9.2 SDN models, CPU model, HA arm/disarm views, node-level firewall sync)
   requires `proxbox-api >= 0.0.14`; firewall model scaffolding and intent tag
   helpers require `>= 0.0.13`; HA tab and runtime tunables alone require `>= 0.0.11`.
+  Firecracker Cloud uses the plugin for host pools, host-agent inventory, image
+  templates, and `FirecrackerMicroVM` rows while this backend calls the selected
+  host-agent through `/cloud/firecracker/*`.
 - **Workspace note**:
   `personal-context/claude-reference/proxbox-api.md` (deep-dive index of this
   repo) and `personal-context/claude-reference/netbox-proxbox.md` (deep-dive
@@ -111,6 +114,7 @@ Open the nearest scoped guide for the code you are changing.
 ### Core layers
 
 - API and app composition (`proxbox_api/app/*`, `proxbox_api/main.py`, `proxbox_api/routes/*`): create the FastAPI app, register routers, mount middleware, expose WebSocket and SSE streams, and keep request handlers thin.
+- Firecracker host-agent layer (`proxbox_api/routes/cloud/firecracker.py`, `proxbox_api/firecracker_agent/`, `proxbox_api/schemas/firecracker.py`): validates Cloud provisioning payloads, calls host-agent health/capacity/assets/create/action endpoints, and emits the streaming progress contract consumed by `nms-backend`.
 - Authentication layer (`proxbox_api/auth.py`, `proxbox_api/routes/auth.py`): bcrypt-hashed API key storage, `X-Proxbox-API-Key` header enforcement via `APIKeyAuthMiddleware`, brute-force lockout, and bootstrap flow for first-time key registration.
 - Session and dependency layer (`proxbox_api/session/*`, `proxbox_api/dependencies.py`): create NetBox and Proxmox client sessions from database or plugin configuration.
 - Service layer (`proxbox_api/services/*`): implement synchronization workflows, object reconciliation, and reusable helper logic.
@@ -127,7 +131,8 @@ Open the nearest scoped guide for the code you are changing.
 4. VM sync routes prepare Proxmox/NetBox state, then delegate deterministic VM
    operation-queue reconciliation to `proxbox_api.services.sync.reconciliation`.
 5. Route handlers delegate remaining heavy work to service modules and schemas.
-6. Sync runs emit journal entries, structured logs, and optional WebSocket or SSE progress messages.
+6. Firecracker Cloud routes under `/cloud/firecracker/*` call a selected host-agent VM after `nms-backend` resolves NetBox Proxbox inventory and creates the `FirecrackerMicroVM` row.
+7. Sync and provisioning runs emit journal entries, structured logs, and optional WebSocket or SSE progress messages.
 
 ### Error and data rules
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@
     cached GET layer (60s TTL); concurrency capped by `PROXBOX_NETBOX_MAX_CONCURRENT`.
   - **Read source** — `proxmox-sdk` → `proxmox · REST API` (7.x / 8.x). Async, read-only,
     `mock | real` modes; concurrency capped by `PROXBOX_VM_SYNC_MAX_CONCURRENCY`.
+  - **Firecracker host-agent** — `/cloud/firecracker/provision` and
+    `/cloud/firecracker/provision/stream` call the selected host-agent VM to
+    health-check KVM, read capacity, prepare kernel/rootfs assets, create the
+    micro-VM, and optionally start it. NetBox inventory still lives in
+    `netbox-proxbox`; this service owns the host-agent HTTP contract.
 
 The interactive version of this diagram lives at
 [emersonfelipesp.com/proxbox-api](https://emersonfelipesp.com/proxbox-api).
@@ -58,6 +63,10 @@ The VM reconciliation engine is documented in
 [`docs/sync/reconciliation-architecture.md`](docs/sync/reconciliation-architecture.md).
 Python is the default engine; the optional Rust engine is for compare-mode validation and explicit
 opt-in testing.
+
+Firecracker host-agent provisioning is documented in
+[`docs/operations/firecracker.md`](docs/operations/firecracker.md), including
+the Cloud endpoints, SSE events, request shape, and response shape.
 
 ### Local docs build
 

--- a/docs/api/http-reference.md
+++ b/docs/api/http-reference.md
@@ -31,6 +31,35 @@ All requests except bootstrap endpoints require the `X-Proxbox-API-Key` header. 
 - `GET /admin/logs` - In-memory backend log buffer with optional filters for `level`, `limit`, `offset`, `since`, and `operation_id`.
 - `GET /admin/logs/stream` - SSE real-time log stream. Supports query parameters `level`, `errors_only`, `operation_id`, and `newer_than_id`.
 
+## Cloud Firecracker (`/cloud/firecracker`)
+
+These endpoints are called by `nms-backend` after it resolves the selected
+Firecracker host/image inventory from `netbox-proxbox` and creates the
+`FirecrackerMicroVM` row in NetBox.
+
+- `POST /cloud/firecracker/provision` - Provision a Firecracker micro-VM through one host-agent and return a final JSON response.
+- `POST /cloud/firecracker/provision/stream` - Same provisioning flow as Server-Sent Events. Emits `provision_step` and `terminal_line` events, then a terminal `complete` event.
+
+Provisioning steps:
+
+| Step | Purpose |
+|---|---|
+| `host_agent_health` | Check host-agent reachability, status, Firecracker version, and KVM availability |
+| `capabilities` | Confirm the requested network mode and capacity fit the host |
+| `prepare_assets` | Prepare or verify the kernel and rootfs image bundle on the host |
+| `create_microvm` | Create the Firecracker micro-VM through the host-agent |
+| `start_microvm` | Start the micro-VM when `start_after_provision=true`, otherwise emit `skipped` |
+
+Request fields are defined by `FirecrackerProvisionRequest`: `host_agent_base_url`,
+optional `host_agent_token`, optional `host_id` and `host_pool_id`, `image`,
+optional `netbox_microvm_id`, `microvm_id`, `name`, optional `tenant_id`,
+`network`, `vcpus`, `memory_mib`, `disk_mib`, `ssh_authorized_keys`,
+`metadata`, and `start_after_provision`.
+
+Successful responses return `FirecrackerProvisionResponse` with `ok`,
+`microvm_id`, `instance_ref`, `host_id`, `host_pool_id`, `image_id`, `status`,
+optional `guest_ip`, and optional `detail`.
+
 ## NetBox Routes (`/netbox`)
 
 - `POST /netbox/endpoint` - Create the singleton NetBox endpoint.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -37,6 +37,7 @@ Cache invalidation is precise (not prefix-based): updating `/api/dcim/devices/55
   - `/admin`
   - `/admin/encryption` — encryption key inspection and rotation surface.
   - `/auth` — bootstrap and API-key management.
+  - `/cloud/firecracker/provision` and `/cloud/firecracker/provision/stream` — Firecracker host-agent provisioning for NMS Cloud. These routes health-check the selected host, read capabilities, prepare assets, create the micro-VM, and optionally start it.
   - `/netbox`
   - `/proxmox`
   - `/proxmox/cluster/ha/*` — read-only High-Availability aggregation across configured clusters; see [Cluster HA API](../api/cluster-ha.md).
@@ -49,6 +50,7 @@ Cache invalidation is precise (not prefix-based): updating `/api/dcim/devices/55
 - SQLite-backed endpoint configuration and bootstrap state.
 - NetBox API access via `netbox-sdk` sync and async clients.
 - Proxmox API access via `proxmox-sdk` sync SDK sessions and typed helper wrappers.
+- Firecracker host-agent access via `proxbox_api.firecracker_agent.client.FirecrackerHostAgentClient`.
 - Runtime-generated Proxmox live routes mounted during app lifespan startup.
 
 ## Core Data Models

--- a/docs/operations/firecracker.md
+++ b/docs/operations/firecracker.md
@@ -1,0 +1,78 @@
+# Firecracker Host-Agent Provisioning
+
+`proxbox-api` owns the HTTP contract between NMS Cloud and a Firecracker host-agent. NetBox inventory still lives in `netbox-proxbox`: host pools, hosts, image templates, and `FirecrackerMicroVM` records are resolved before this service is called.
+
+## Flow
+
+```mermaid
+sequenceDiagram
+    participant NMSB as nms-backend
+    participant API as proxbox-api
+    participant Agent as Firecracker host-agent
+
+    NMSB->>API: POST /cloud/firecracker/provision[/stream]
+    API->>Agent: GET /health
+    API->>Agent: GET /capabilities
+    API->>Agent: POST /assets/prepare
+    API->>Agent: POST /microvms
+    API->>Agent: POST /microvms/{microvm_id}/actions/start
+    API-->>NMSB: status, microvm_id, instance_ref, guest_ip
+```
+
+The non-streaming endpoint returns one JSON response. The streaming endpoint forwards progress as Server-Sent Events and finishes with `event: complete`.
+
+## Endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/cloud/firecracker/provision` | Provision a micro-VM through one host-agent and return final JSON |
+| `POST` | `/cloud/firecracker/provision/stream` | Provision a micro-VM and stream progress as SSE |
+
+Both routes require the normal `X-Proxbox-API-Key` middleware. `X-Proxbox-Actor` is optional and is forwarded into the host-agent metadata payload.
+
+## Request Shape
+
+`FirecrackerProvisionRequest` accepts:
+
+| Field | Purpose |
+|---|---|
+| `host_agent_base_url` | Base URL for the selected Firecracker host-agent |
+| `host_agent_token` | Optional bearer token passed to the host-agent |
+| `host_id`, `host_pool_id` | NetBox Proxbox IDs used for traceability |
+| `image` | Kernel/rootfs bundle with URLs, SHA256 digests, architecture, default user, and optional image ID |
+| `netbox_microvm_id` | NetBox `FirecrackerMicroVM` primary key; derives `instance_ref=firecracker:<id>` |
+| `microvm_id` | UUID sent to the host-agent |
+| `name`, `tenant_id` | Cloud instance identity and tenant traceability |
+| `network` | NAT or bridged network request with optional guest IP, gateway, bridge, TAP, and nameservers |
+| `vcpus`, `memory_mib`, `disk_mib` | Requested capacity |
+| `ssh_authorized_keys` | Public keys injected by the host-agent |
+| `metadata` | Extra host-agent metadata; proxbox-api adds actor, tenant, NetBox ID, and instance ref |
+| `start_after_provision` | Starts the micro-VM after creation when true |
+
+## SSE Events
+
+| Event | Payload |
+|---|---|
+| `provision_step` | `{step, label, status}` for `host_agent_health`, `capabilities`, `prepare_assets`, `create_microvm`, and `start_microvm` |
+| `terminal_line` | Human-readable host-agent progress, currently asset preparation paths |
+| `complete` | Final `FirecrackerProvisionResponse` on success, or `{ok:false,error}` on failure |
+
+## Response Shape
+
+Successful responses return:
+
+```json
+{
+  "ok": true,
+  "microvm_id": "6f78d7a3-3d4a-4ab2-8d7a-5f5b8615947d",
+  "instance_ref": "firecracker:42",
+  "host_id": 3,
+  "host_pool_id": 1,
+  "image_id": 7,
+  "status": "running",
+  "guest_ip": "10.10.0.21",
+  "detail": null
+}
+```
+
+`instance_ref` is present when `nms-backend` supplied `netbox_microvm_id`. The value is the Cloud identifier used by NMS detail routes and list rendering.

--- a/docs/pt-BR/operations/firecracker.md
+++ b/docs/pt-BR/operations/firecracker.md
@@ -1,0 +1,46 @@
+# Provisionamento Firecracker via Host-Agent
+
+`proxbox-api` define o contrato HTTP entre o NMS Cloud e um host-agent Firecracker. O inventario do NetBox continua no `netbox-proxbox`: pools, hosts, imagens e registros `FirecrackerMicroVM` sao resolvidos antes desta API ser chamada.
+
+## Fluxo
+
+```mermaid
+sequenceDiagram
+    participant NMSB as nms-backend
+    participant API as proxbox-api
+    participant Agent as Firecracker host-agent
+
+    NMSB->>API: POST /cloud/firecracker/provision[/stream]
+    API->>Agent: GET /health
+    API->>Agent: GET /capabilities
+    API->>Agent: POST /assets/prepare
+    API->>Agent: POST /microvms
+    API->>Agent: POST /microvms/{microvm_id}/actions/start
+    API-->>NMSB: status, microvm_id, instance_ref, guest_ip
+```
+
+O endpoint sem stream retorna JSON final. O endpoint com stream envia Server-Sent Events e termina com `event: complete`.
+
+## Endpoints
+
+| Metodo | Caminho | Finalidade |
+|---|---|---|
+| `POST` | `/cloud/firecracker/provision` | Provisiona uma micro-VM em um host-agent e retorna JSON final |
+| `POST` | `/cloud/firecracker/provision/stream` | Provisiona uma micro-VM e envia progresso por SSE |
+
+Ambos usam o middleware normal `X-Proxbox-API-Key`. `X-Proxbox-Actor` e opcional e entra nos metadados enviados ao host-agent.
+
+## Eventos SSE
+
+| Evento | Payload |
+|---|---|
+| `provision_step` | `{step, label, status}` para `host_agent_health`, `capabilities`, `prepare_assets`, `create_microvm` e `start_microvm` |
+| `terminal_line` | Linha de progresso legivel, hoje usada para caminhos de assets |
+| `complete` | `FirecrackerProvisionResponse` final em sucesso ou `{ok:false,error}` em falha |
+
+## Resposta
+
+Respostas de sucesso incluem `ok`, `microvm_id`, `instance_ref`, `host_id`,
+`host_pool_id`, `image_id`, `status`, `guest_ip` e `detail`. Quando
+`netbox_microvm_id` e informado, `instance_ref` usa o formato
+`firecracker:<id>` e e o identificador usado pelo NMS Cloud.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
       - Scheduler Container: sync/scheduler-container.md
   - Operations:
       - Hardware Discovery: operations/hardware-discovery.md
+      - Firecracker Host-Agent Provisioning: operations/firecracker.md
   - Development:
       - Schema Management: development/schema-management.md
       - Testing: development/testing.md

--- a/proxbox_api/routes/CLAUDE.md
+++ b/proxbox_api/routes/CLAUDE.md
@@ -16,6 +16,7 @@ Top-level namespace for FastAPI route packages.
 ## Current Subpackages
 
 - `admin/`: HTML admin dashboard and backend log buffer routes.
+- `cloud/`: Cloud runtime routes. `cloud/firecracker.py` provisions micro-VMs by calling the selected Firecracker host-agent after NMS backend resolves NetBox Proxbox inventory.
 - `dcim/`: device, interface, VLAN, and IP sync routes.
 - `extras/`: NetBox extras routes used by sync flows.
 - `netbox/`: NetBox endpoint CRUD, status, and OpenAPI routes.

--- a/proxbox_api/schemas/CLAUDE.md
+++ b/proxbox_api/schemas/CLAUDE.md
@@ -17,6 +17,7 @@ Top-level Pydantic schema package for plugin and API contracts.
 
 - `__init__.py`: top-level schema exports and plugin configuration schema.
 - `_base.py`: shared Proxbox base model.
+- `firecracker.py`: Firecracker host-agent, image bundle, network, micro-VM state, metrics, and Cloud provisioning contracts.
 - `proxmox.py`: Pydantic schemas for Proxmox sessions, cluster resources, node payloads, and resource payloads.
 - `stream_messages.py`: typed stream event payload schemas used by SSE and WebSocket progress reporting.
 - `netbox/`: NetBox session, endpoint, and payload schemas.


### PR DESCRIPTION
Closes #197. Parent tracker: N-MultiCloud/nmulticloud-context#16. Summary: documents proxbox-api Firecracker host-agent provisioning, API surface, schemas, and route ownership. Verification: uv run --extra docs mkdocs build --strict.