### PR TITLE
Read reconciliation engine from NetBox settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,10 +192,6 @@ the `netbox-proxbox` side, do all five — the existing fields in
 - `PROXBOX_ENCRYPTION_KEY_FILE`: optional override for the local key file path used when neither the env var nor the plugin settings provide a key. Defaults to `<repo_root>/data/encryption.key`.
 - `PROXBOX_ALLOW_PLAINTEXT_CREDENTIALS`: legacy opt-in flag for plaintext credential storage. No longer required for startup; kept for compatibility with operators who scripted it.
 - `PROXBOX_LOG_LEVEL`: console log verbosity (default `INFO`). Valid values: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` (case-insensitive). Controls only the console handler; the in-memory buffer always receives DEBUG+ and the rotating file handler always writes WARNING+. Setting `DEBUG` also enables full `netbox_sdk.client` per-request tracing which is suppressed at all other levels to prevent INFO-level flooding.
-- `PROXBOX_RECONCILIATION_ENGINE`: VM operation-queue engine. Valid values:
-  `python` (default), `compare`, and `rust`. `compare` runs Python and Rust,
-  logs/increments mismatch metrics, and returns Python output. `rust` requires
-  the optional `proxbox-reconcile-rs` native package to be installed.
 - `PROXBOX_RECONCILIATION_COMPARE_STRICT`: when `true`, compare mode raises on
   Rust/Python mismatch. Use this in CI/parity tests, not normal production
   syncs.
@@ -211,6 +207,7 @@ Each maps to a key in `ProxboxPluginSettings` and can be edited from the NetBox 
 | `PROXBOX_NETBOX_MAX_RETRIES` | `netbox_max_retries` | 5 |
 | `PROXBOX_NETBOX_RETRY_DELAY` | `netbox_retry_delay` | 2.0 s |
 | `PROXBOX_VM_SYNC_MAX_CONCURRENCY` | `vm_sync_max_concurrency` | 4 |
+| `PROXBOX_RECONCILIATION_ENGINE` | `reconciliation_engine` | python |
 | `PROXBOX_FETCH_MAX_CONCURRENCY` | `proxbox_fetch_max_concurrency` | 8 |
 | `PROXBOX_PROXMOX_FETCH_CONCURRENCY` | `proxmox_fetch_concurrency` | 8 (4 in task-history) |
 | `PROXBOX_NETBOX_WRITE_CONCURRENCY` | `netbox_write_concurrency` | 8 (4 in task-history/snapshots) |
@@ -324,7 +321,8 @@ Keep FastAPI routes, NetBox/Proxmox clients, SQLite, auth, retries, streaming,
 and dispatch execution in Python. Only pure, synchronous, CPU-bound queue
 construction belongs behind the Rust bridge.
 
-Engine modes:
+Engine modes are selected through `ProxboxPluginSettings.reconciliation_engine`.
+`PROXBOX_RECONCILIATION_ENGINE` remains an immediate env-var override.
 
 - `PROXBOX_RECONCILIATION_ENGINE=python`: default and production-safe path.
 - `PROXBOX_RECONCILIATION_ENGINE=compare`: run both engines, return Python,

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -186,6 +186,7 @@ A handful of variables stay process-level only because they are read before the 
 | `PROXBOX_NETBOX_RETRY_DELAY` | `2.0` | Initial retry delay in seconds for NetBox retries. |
 | `PROXBOX_NETBOX_MAX_CONCURRENT` | `1` | Maximum concurrent NetBox API requests. Keep low (1-2) to avoid exhausting NetBox's PostgreSQL connection pool. |
 | `PROXBOX_VM_SYNC_MAX_CONCURRENCY` | `4` | Maximum number of concurrent VM sync write tasks. |
+| `PROXBOX_RECONCILIATION_ENGINE` | `python` | Optional env override for `ProxboxPluginSettings.reconciliation_engine`. Valid values are `python`, `compare`, and `rust`. |
 | `PROXBOX_NETBOX_WRITE_CONCURRENCY` | `8` (VM sync) / `4` (task-history, snapshots) | Maximum number of concurrent NetBox write operations. Default varies by sync service. |
 | `PROXBOX_PROXMOX_FETCH_CONCURRENCY` | `8` (most paths) / `4` (task-history) | Maximum number of concurrent Proxmox read operations. Default varies by sync service. |
 | `PROXBOX_FETCH_MAX_CONCURRENCY` | `8` | Legacy fetch concurrency override used by some sync entrypoints. |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -243,14 +243,16 @@ uv sync --extra test --group dev
 uv pip install -e proxbox-reconcile-rs
 ```
 
-Enable compare mode first:
+Enable compare mode first from NetBox's `/plugins/proxbox/settings/` page, or use
+the environment override for a one-off process:
 
 ```bash
 PROXBOX_RECONCILIATION_ENGINE=compare uv run fastapi run proxbox_api.main:app
 ```
 
-The production default remains Python. To roll back immediately, unset
-`PROXBOX_RECONCILIATION_ENGINE` or set it to `python`.
+The production default remains Python. To roll back immediately, set
+`reconciliation_engine` back to `python` in NetBox, or unset
+`PROXBOX_RECONCILIATION_ENGINE` if an env override was used.
 
 Start the server:
 

--- a/docs/pt-BR/getting-started/configuration.md
+++ b/docs/pt-BR/getting-started/configuration.md
@@ -168,6 +168,7 @@ Algumas variaveis permanecem somente em nivel de processo porque sao lidas antes
 | `PROXBOX_NETBOX_RETRY_DELAY` | `2.0` | Delay inicial, em segundos, para retries do NetBox. |
 | `PROXBOX_NETBOX_MAX_CONCURRENT` | `1` | Maximo de requisicoes simultaneas ao NetBox. Mantenha baixo (1-2) para evitar agotar o pool de conexoes PostgreSQL do NetBox. |
 | `PROXBOX_VM_SYNC_MAX_CONCURRENCY` | `4` | Maximo de tarefas concorrentes de escrita no sync de VMs. |
+| `PROXBOX_RECONCILIATION_ENGINE` | `python` | Override opcional para `ProxboxPluginSettings.reconciliation_engine`. Valores validos: `python`, `compare` e `rust`. |
 | `PROXBOX_NETBOX_WRITE_CONCURRENCY` | `8` (sync de VM) / `4` (task-history, snapshots) | Maximo de operacoes concorrentes de escrita no NetBox. O padrao varia por servico de sync. |
 | `PROXBOX_PROXMOX_FETCH_CONCURRENCY` | `8` (maioria dos fluxos) / `4` (task-history) | Maximo de operacoes concorrentes de leitura no Proxmox. O padrao varia por servico de sync. |
 | `PROXBOX_FETCH_MAX_CONCURRENCY` | `8` | Override legado de concorrencia usado por alguns entrypoints de sync. |

--- a/docs/pt-BR/getting-started/installation.md
+++ b/docs/pt-BR/getting-started/installation.md
@@ -241,14 +241,16 @@ uv sync --extra test --group dev
 uv pip install -e proxbox-reconcile-rs
 ```
 
-Habilite primeiro o compare mode:
+Habilite primeiro o compare mode pela pagina `/plugins/proxbox/settings/` do
+NetBox ou use a variavel de ambiente para um processo avulso:
 
 ```bash
 PROXBOX_RECONCILIATION_ENGINE=compare uv run fastapi run proxbox_api.main:app
 ```
 
-O padrao de producao continua sendo Python. Para rollback imediato, remova
-`PROXBOX_RECONCILIATION_ENGINE` ou defina `python`.
+O padrao de producao continua sendo Python. Para rollback imediato, volte
+`reconciliation_engine` para `python` no NetBox ou remova `PROXBOX_RECONCILIATION_ENGINE`
+se um override de ambiente foi usado.
 
 Inicie o servidor apos instalar:
 

--- a/docs/pt-BR/sync/reconciliation-architecture.md
+++ b/docs/pt-BR/sync/reconciliation-architecture.md
@@ -79,7 +79,9 @@ continuam no Python. Quando o pacote nativo esta instalado, a ponte Python seria
 Pydantic v2, chama a extensao PyO3 com o GIL liberado, decodifica o resultado e adapta as operacoes
 de volta para as dataclasses usadas pelo dispatch.
 
-Selecao de engine:
+Selecao de engine usa runtime settings. A configuracao normal para operadores e
+`ProxboxPluginSettings.reconciliation_engine` no plugin NetBox; `PROXBOX_RECONCILIATION_ENGINE`
+continua sendo o override por variavel de ambiente.
 
 | Variavel | Valor | Comportamento |
 |----------|-------|----------------|
@@ -174,7 +176,7 @@ sequenceDiagram
 
 - `PROXBOX_VM_SYNC_MAX_CONCURRENCY`: controla concorrencia de preparacao/fetch de VMs no Proxmox.
 - `PROXBOX_NETBOX_WRITE_CONCURRENCY`: define tamanho da janela de batch no dispatch.
-- `PROXBOX_RECONCILIATION_ENGINE`: seleciona `python`, `compare` ou `rust`.
+- `reconciliation_engine` / `PROXBOX_RECONCILIATION_ENGINE`: seleciona `python`, `compare` ou `rust`.
 - `PROXBOX_RECONCILIATION_COMPARE_STRICT`: falha em drift no compare mode quando `true`.
 
 Observacao: tamanho de batch nao implica escrita paralela; as escritas continuam sequenciais para proteger o NetBox em ambiente de instancia unica.
@@ -185,13 +187,13 @@ Rust nao e o engine padrao. O rollout e conservador:
 
 1. Construir e testar wheels de `proxbox-reconcile-rs` no CI.
 2. Publicar `proxbox-reconcile-rs` apenas pelo workflow de release do repositorio.
-3. Manter `PROXBOX_RECONCILIATION_ENGINE=python` como padrao no `proxbox-api`.
-4. Rodar `PROXBOX_RECONCILIATION_ENGINE=compare` em staging por pelo menos duas semanas.
+3. Manter `reconciliation_engine=python` como padrao no `proxbox-api`.
+4. Rodar `reconciliation_engine=compare` em staging por pelo menos duas semanas.
 5. Monitorar `proxbox_reconcile_mismatch_total` e logs de mismatch.
 6. Recomendar `PROXBOX_RECONCILIATION_ENGINE=rust` apenas depois de zero divergencias em syncs reais diversos.
 7. Considerar trocar o padrao apenas em uma release minor futura e somente se benchmarks de wall time do sync completo provarem ganho real.
 
-Rollback e imediato: remova `PROXBOX_RECONCILIATION_ENGINE` ou volte para `python`.
+Rollback e imediato: volte `reconciliation_engine` para `python` no NetBox ou remova `PROXBOX_RECONCILIATION_ENGINE` se um override de ambiente foi usado.
 
 A evidencia atual de benchmark nao justifica tornar Rust o padrao. O caminho Rust completo ficou
 mais lento que Python no benchmark sintetico, e a medicao real mostrou que reconciliacao nao era o

--- a/docs/sync/reconciliation-architecture.md
+++ b/docs/sync/reconciliation-architecture.md
@@ -84,7 +84,9 @@ Those concerns remain in Python. When the native package is installed, the Pytho
 serialize inputs with Pydantic v2, call the PyO3 extension with the GIL released, decode the
 result, and adapt operations back to the Python dataclasses used by dispatch.
 
-Engine selection is controlled by environment variables:
+Engine selection is controlled by runtime settings. The NetBox plugin setting
+`ProxboxPluginSettings.reconciliation_engine` is the normal operator-facing
+control, and `PROXBOX_RECONCILIATION_ENGINE` remains an environment override.
 
 | Variable | Value | Behavior |
 |----------|-------|----------|
@@ -180,7 +182,7 @@ sequenceDiagram
 
 - `PROXBOX_VM_SYNC_MAX_CONCURRENCY`: controls concurrent VM preparation/fetch from Proxmox.
 - `PROXBOX_NETBOX_WRITE_CONCURRENCY`: defines dispatch batch window size.
-- `PROXBOX_RECONCILIATION_ENGINE`: selects `python`, `compare`, or `rust`.
+- `reconciliation_engine` / `PROXBOX_RECONCILIATION_ENGINE`: selects `python`, `compare`, or `rust`.
 - `PROXBOX_RECONCILIATION_COMPARE_STRICT`: raises on compare-mode drift when set to `true`.
 
 Note: batch window size does not imply parallel writes; writes remain sequential to protect NetBox under single-instance operation.
@@ -191,13 +193,13 @@ Rust is not the default engine. Rollout is intentionally conservative:
 
 1. Build and test `proxbox-reconcile-rs` wheels in CI.
 2. Publish `proxbox-reconcile-rs` only through the repository release workflow.
-3. Keep `PROXBOX_RECONCILIATION_ENGINE=python` as the default in `proxbox-api`.
-4. Run `PROXBOX_RECONCILIATION_ENGINE=compare` in staging for at least two weeks.
+3. Keep `reconciliation_engine=python` as the default in `proxbox-api`.
+4. Run `reconciliation_engine=compare` in staging for at least two weeks.
 5. Watch `proxbox_reconcile_mismatch_total` and reconciliation mismatch logs.
 6. Recommend `PROXBOX_RECONCILIATION_ENGINE=rust` only after zero mismatches across diverse real syncs.
 7. Consider a default-engine change only in a later minor release and only after full sync wall-time benchmarks show a real win.
 
-Rollback is immediate: unset `PROXBOX_RECONCILIATION_ENGINE` or set it back to `python`.
+Rollback is immediate: set `reconciliation_engine` back to `python` in NetBox, or unset `PROXBOX_RECONCILIATION_ENGINE` if an env override was used.
 
 Current benchmark evidence does not justify making Rust the default. The full Rust path is slower
 than Python in the synthetic benchmark harness, and live measurement showed reconciliation was not

--- a/proxbox_api/services/sync/reconciliation/CLAUDE.md
+++ b/proxbox_api/services/sync/reconciliation/CLAUDE.md
@@ -37,6 +37,10 @@ or WebSocket code belongs here.
 
 ## Engine Modes
 
+The runtime value is read from `ProxboxPluginSettings.reconciliation_engine`
+through `proxbox_api.runtime_settings.get_str()`. The environment variable
+`PROXBOX_RECONCILIATION_ENGINE` remains the highest-priority override.
+
 - `PROXBOX_RECONCILIATION_ENGINE=python`: default. Always available.
 - `PROXBOX_RECONCILIATION_ENGINE=compare`: run Python and Rust, log/increment
   mismatches, return Python output.

--- a/proxbox_api/services/sync/reconciliation/vm_queue.py
+++ b/proxbox_api/services/sync/reconciliation/vm_queue.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import difflib
 import json
 import logging
-import os
 from typing import Any, Literal
 
 from proxbox_api.proxmox_to_netbox.models import NetBoxVirtualMachineCreateBody
+from proxbox_api.runtime_settings import get_bool, get_str
 from proxbox_api.services.sync.reconciliation.metrics import (
     increment_reconciliation_mismatch_total,
 )
@@ -323,7 +323,11 @@ def _build_vm_operation_queue_with_rust(
 
 
 def _reconciliation_engine() -> Literal["python", "compare", "rust"]:
-    engine = os.getenv(_ENGINE_ENV, "python").strip().lower()
+    engine = get_str(
+        settings_key="reconciliation_engine",
+        env=_ENGINE_ENV,
+        default="python",
+    ).lower()
     if engine not in _VALID_ENGINES:
         valid = ", ".join(sorted(_VALID_ENGINES))
         raise ValueError(f"Invalid {_ENGINE_ENV}={engine!r}; expected one of: {valid}")
@@ -331,7 +335,11 @@ def _reconciliation_engine() -> Literal["python", "compare", "rust"]:
 
 
 def _reconciliation_compare_strict() -> bool:
-    return os.getenv(_COMPARE_STRICT_ENV, "false").strip().lower() == "true"
+    return get_bool(
+        settings_key="reconciliation_compare_strict",
+        env=_COMPARE_STRICT_ENV,
+        default=False,
+    )
 
 
 def _adapt_to_dataclasses(

--- a/proxbox_api/settings_client.py
+++ b/proxbox_api/settings_client.py
@@ -25,6 +25,7 @@ _SETTINGS_CACHE: ProxboxSettingsDict | None = None
 _SETTINGS_CACHE_TIME: float = 0.0
 _SETTINGS_CACHE_TTL: float = 300.0  # 5 minutes
 _FETCHING_SETTINGS: bool = False  # reentrance guard against credential-decryption recursion
+_VALID_RECONCILIATION_ENGINES = {"python", "compare", "rust"}
 
 
 def _coerce_role_id(value: object) -> int | None:
@@ -93,6 +94,7 @@ def get_default_settings() -> ProxboxSettingsDict:
         "bulk_batch_size": 50,
         "bulk_batch_delay_ms": 500,
         "vm_sync_max_concurrency": 4,
+        "reconciliation_engine": "python",
         "custom_fields_request_delay": 0.0,
         "ensure_netbox_objects": True,
         "delete_orphans": False,
@@ -119,6 +121,13 @@ def normalize_backend_log_file_path(value: object) -> str:
     if cleaned.endswith("/"):
         return DEFAULT_LOG_PATH
     return cleaned
+
+
+def _normalize_reconciliation_engine(value: object) -> str:
+    if not isinstance(value, str):
+        return "python"
+    engine = value.strip().lower()
+    return engine if engine in _VALID_RECONCILIATION_ENGINES else "python"
 
 
 def _extract_settings_payload(data: object) -> dict[str, object] | None:
@@ -253,6 +262,9 @@ def fetch_settings_from_netbox(netbox_session: "Api") -> ProxboxSettingsDict | N
             "bulk_batch_size": int(settings.get("bulk_batch_size", 50)),
             "bulk_batch_delay_ms": int(settings.get("bulk_batch_delay_ms", 500)),
             "vm_sync_max_concurrency": int(settings.get("vm_sync_max_concurrency", 4)),
+            "reconciliation_engine": _normalize_reconciliation_engine(
+                settings.get("reconciliation_engine")
+            ),
             "custom_fields_request_delay": float(settings.get("custom_fields_request_delay", 0.0)),
             "ensure_netbox_objects": bool(settings.get("ensure_netbox_objects", True)),
             "delete_orphans": bool(settings.get("delete_orphans", False)),

--- a/proxbox_api/types/structured_dicts.py
+++ b/proxbox_api/types/structured_dicts.py
@@ -33,6 +33,7 @@ class ProxboxSettingsDict(TypedDict):
     bulk_batch_size: int
     bulk_batch_delay_ms: int
     vm_sync_max_concurrency: int
+    reconciliation_engine: NotRequired[str]
     custom_fields_request_delay: float
     ensure_netbox_objects: NotRequired[bool]
     delete_orphans: NotRequired[bool]

--- a/tests/reconciliation/test_vm_queue_engine_modes.py
+++ b/tests/reconciliation/test_vm_queue_engine_modes.py
@@ -7,6 +7,7 @@ import json
 
 import pytest
 
+from proxbox_api import runtime_settings
 from proxbox_api.app.cache_routes import (
     get_cache_metrics_json,
     get_cache_metrics_prometheus,
@@ -29,6 +30,7 @@ from tests.reconciliation.test_vm_queue_python import _prepared_vm, _snapshot_vm
 def _reset_engine_state(monkeypatch):
     monkeypatch.delenv("PROXBOX_RECONCILIATION_ENGINE", raising=False)
     monkeypatch.delenv("PROXBOX_RECONCILIATION_COMPARE_STRICT", raising=False)
+    monkeypatch.setattr(runtime_settings, "_load_settings", lambda: None)
     monkeypatch.setattr(rust_bridge, "_rust_build", None)
     reset_reconciliation_metrics()
 
@@ -76,6 +78,44 @@ def test_compare_mode_returns_python_output_and_records_mismatch(monkeypatch) ->
 
     assert [op.method for op in queue] == ["GET"]
     assert get_reconciliation_metrics()["proxbox_reconcile_mismatch_total"] == 1
+
+
+def test_plugin_settings_can_select_compare_mode(monkeypatch) -> None:
+    monkeypatch.setattr(
+        runtime_settings,
+        "_load_settings",
+        lambda: {"reconciliation_engine": "compare"},
+    )
+    monkeypatch.setattr(rust_bridge, "_rust_build", lambda input_bytes: _rust_output("CREATE"))
+    prepared = [_prepared_vm()]
+    snapshot = [_snapshot_vm()]
+
+    queue = build_vm_operation_queue(prepared, snapshot)
+
+    assert [op.method for op in queue] == ["GET"]
+    assert get_reconciliation_metrics()["proxbox_reconcile_mismatch_total"] == 1
+
+
+def test_engine_env_override_wins_over_plugin_settings(monkeypatch) -> None:
+    calls = 0
+
+    def fake_rust_build(input_bytes: bytes) -> bytes:
+        nonlocal calls
+        calls += 1
+        return _rust_output("UPDATE")
+
+    monkeypatch.setattr(
+        runtime_settings,
+        "_load_settings",
+        lambda: {"reconciliation_engine": "rust"},
+    )
+    monkeypatch.setenv("PROXBOX_RECONCILIATION_ENGINE", "python")
+    monkeypatch.setattr(rust_bridge, "_rust_build", fake_rust_build)
+
+    queue = build_vm_operation_queue([_prepared_vm()], [])
+
+    assert [op.method for op in queue] == ["CREATE"]
+    assert calls == 0
 
 
 def test_compare_mode_strict_raises_on_mismatch(monkeypatch) -> None:

--- a/tests/test_settings_client.py
+++ b/tests/test_settings_client.py
@@ -11,6 +11,7 @@ def test_get_default_settings_exposes_backend_log_file_path():
     assert settings["primary_ip_preference"] == "ipv4"
     assert settings["encryption_key"] == ""
     assert settings["delete_orphans"] is False
+    assert settings["reconciliation_engine"] == "python"
 
 
 def test_fetch_settings_from_netbox_reads_backend_log_file_path(monkeypatch):
@@ -38,6 +39,7 @@ def test_fetch_settings_from_netbox_reads_backend_log_file_path(monkeypatch):
         "explicitly_blocked_ip_ranges": "",
         "encryption_key": "my-plugin-key",
         "delete_orphans": True,
+        "reconciliation_engine": "rust",
     }
 
     mock_response = MagicMock()
@@ -54,6 +56,7 @@ def test_fetch_settings_from_netbox_reads_backend_log_file_path(monkeypatch):
     assert settings["primary_ip_preference"] == "ipv6"
     assert settings["encryption_key"] == "my-plugin-key"
     assert settings["delete_orphans"] is True
+    assert settings["reconciliation_engine"] == "rust"
 
 
 def test_fetch_settings_from_netbox_reads_paginated_settings_response(monkeypatch):
@@ -84,6 +87,7 @@ def test_fetch_settings_from_netbox_reads_paginated_settings_response(monkeypatc
                 "netbox_get_cache_max_entries": 8192,
                 "debug_cache": True,
                 "delete_orphans": True,
+                "reconciliation_engine": "compare",
             }
         ],
     }
@@ -104,6 +108,7 @@ def test_fetch_settings_from_netbox_reads_paginated_settings_response(monkeypatc
     assert settings["netbox_get_cache_max_entries"] == 8192
     assert settings["debug_cache"] is True
     assert settings["delete_orphans"] is True
+    assert settings["reconciliation_engine"] == "compare"
 
 
 def test_delete_orphans_runtime_bool_prefers_env_over_settings(monkeypatch):
@@ -308,6 +313,7 @@ def test_fetch_settings_from_netbox_falls_back_for_invalid_backend_log_file_path
         "allow_private_ips": True,
         "additional_allowed_ip_ranges": "",
         "explicitly_blocked_ip_ranges": "",
+        "reconciliation_engine": "not-valid",
     }
 
     mock_response = MagicMock()
@@ -322,6 +328,7 @@ def test_fetch_settings_from_netbox_falls_back_for_invalid_backend_log_file_path
     assert settings is not None
     assert settings["backend_log_file_path"] == "/var/log/proxbox.log"
     assert settings["primary_ip_preference"] == "ipv4"
+    assert settings["reconciliation_engine"] == "python"
 
 
 def test_get_settings_uses_raw_netbox_session_when_no_session(monkeypatch):


### PR DESCRIPTION
Closes #199

## Summary
- read reconciliation_engine through runtime_settings.get_str
- keep PROXBOX_RECONCILIATION_ENGINE as highest-priority override
- normalize fetched plugin settings values and update TypedDict
- update reconciliation/configuration docs and focused tests

## Verification
- uv run python -m compileall proxbox_api tests
- uv run --extra test pytest tests/test_settings_client.py tests/reconciliation/test_vm_queue_engine_modes.py -q
- uv run ruff check proxbox_api/services/sync/reconciliation/vm_queue.py proxbox_api/settings_client.py proxbox_api/types/structured_dicts.py tests/reconciliation/test_vm_queue_engine_modes.py tests/test_settings_client.py
- uv run ruff format --check proxbox_api/services/sync/reconciliation/vm_queue.py proxbox_api/settings_client.py proxbox_api/types/structured_dicts.py tests/reconciliation/test_vm_queue_engine_modes.py tests/test_settings_client.py
- uv run python -c "import proxbox_api.main"
- uv run python -c "from proxbox_api.proxmox_to_netbox.proxmox_schema import load_proxmox_generated_openapi; assert load_proxmox_generated_openapi().get('paths')"