### PR TITLE
Support firewall intent path mapping

### DIFF
--- a/proxbox_api/services/firewall_intent.py
+++ b/proxbox_api/services/firewall_intent.py
@@ -68,6 +68,17 @@ def _path_for(payload: FirewallIntentPayload) -> tuple[str, str, bool, str]:  # 
         return method, f"{base}/{payload.pos}", zone == "vnet", _unsupported_reason(zone)
 
     if action.startswith("firewall.ipset."):
+        if action.startswith("firewall.ipset.entry."):
+            if not payload.name:
+                raise ValueError(f"{action} requires name")
+            base = f"{_scoped_base(payload, zone, 'ipset')}/{payload.name}"
+            if action.endswith(".create"):
+                return "post", base, False, "firewall_write_not_supported"
+            if not payload.cidr:
+                raise ValueError(f"{action} requires cidr")
+            method = "put" if action.endswith(".update") else "delete"
+            return method, f"{base}/{payload.cidr}", False, "firewall_write_not_supported"
+
         base = _scoped_base(payload, zone, "ipset")
         if action.endswith(".create"):
             return "post", base, False, "firewall_write_not_supported"
@@ -75,15 +86,14 @@ def _path_for(payload: FirewallIntentPayload) -> tuple[str, str, bool, str]:  # 
             raise ValueError(f"{action} requires name")
         return "delete", f"{base}/{payload.name}", False, "firewall_write_not_supported"
 
-    if action == "firewall.alias.upsert":
+    if action.startswith("firewall.alias."):
         if not payload.name:
-            raise ValueError("firewall.alias.upsert requires name")
-        return (
-            "put",
-            f"{_scoped_base(payload, zone, 'aliases')}/{payload.name}",
-            False,
-            ("firewall_write_not_supported"),
-        )
+            raise ValueError(f"{action} requires name")
+        base = _scoped_base(payload, zone, "aliases")
+        if action.endswith(".create"):
+            return "post", base, False, "firewall_write_not_supported"
+        method = "delete" if action.endswith(".delete") else "put"
+        return method, f"{base}/{payload.name}", False, "firewall_write_not_supported"
 
     if action == "firewall.options.update":
         return "put", _scoped_base(payload, zone, "options"), False, "firewall_write_not_supported"

--- a/tests/test_firewall_intent.py
+++ b/tests/test_firewall_intent.py
@@ -44,6 +44,74 @@ def test_firewall_options_update_supports_node_zone():
     assert reason == "firewall_write_not_supported"
 
 
+def test_firewall_ipset_entry_update_maps_to_entry_path():
+    payload = FirewallIntentPayload(
+        action="firewall.ipset.entry.update",
+        zone="datacenter",
+        name="mgmt",
+        cidr="10.0.0.0/8",
+        body={"comment": "management"},
+    )
+
+    method, path, probe, reason = firewall_intent._path_for(payload)
+
+    assert method == "put"
+    assert path == "cluster/firewall/ipset/mgmt/10.0.0.0/8"
+    assert probe is False
+    assert reason == "firewall_write_not_supported"
+
+
+def test_firewall_alias_create_maps_to_collection_post():
+    payload = FirewallIntentPayload(
+        action="firewall.alias.create",
+        zone="vm_qemu",
+        node="pve-a",
+        vmid=101,
+        name="web",
+        body={"name": "web", "cidr": "10.0.0.10"},
+    )
+
+    method, path, probe, reason = firewall_intent._path_for(payload)
+
+    assert method == "post"
+    assert path == "nodes/pve-a/qemu/101/firewall/aliases"
+    assert probe is False
+    assert reason == "firewall_write_not_supported"
+
+
+def test_firewall_alias_update_maps_to_named_put():
+    payload = FirewallIntentPayload(
+        action="firewall.alias.update",
+        zone="datacenter",
+        name="web",
+        body={"cidr": "10.0.0.11"},
+    )
+
+    method, path, probe, reason = firewall_intent._path_for(payload)
+
+    assert method == "put"
+    assert path == "cluster/firewall/aliases/web"
+    assert probe is False
+    assert reason == "firewall_write_not_supported"
+
+
+def test_firewall_alias_delete_maps_to_named_delete():
+    payload = FirewallIntentPayload(
+        action="firewall.alias.delete",
+        zone="vm_lxc",
+        node="pve-a",
+        vmid=102,
+        name="web",
+    )
+
+    method, path, probe, reason = firewall_intent._path_for(payload)
+
+    assert method == "delete"
+    assert path == "nodes/pve-a/lxc/102/firewall/aliases/web"
+    assert probe is False
+    assert reason == "firewall_write_not_supported"
+
+
 def test_vm_zone_rejects_mismatched_vm_type():
     payload = FirewallIntentPayload(
         action="firewall.rule.create",


### PR DESCRIPTION
Closes emersonfelipesp/netbox-proxbox#476

## Summary
- Map firewall intent IP set entry actions to Proxmox write paths.
- Map firewall alias create/update/delete actions to collection and named write paths.
- Add focused path mapping tests for IP set entries and aliases.

## Verification
- rtk ruff check .
- rtk ruff format --check .
- uv run python -m compileall proxbox_api tests
- uv run python -c "import proxbox_api.main"
- uv run python -c "from proxbox_api.proxmox_to_netbox.proxmox_schema import load_proxmox_generated_openapi; assert load_proxmox_generated_openapi().get('paths')"
- uv run ty check proxbox_api/types proxbox_api/utils/retry.py proxbox_api/schemas/sync.py
- uv run --extra test python -m pytest tests/test_firewall_intent.py -q
- uv run --extra test python -m pytest tests -q -n auto