### PR TITLE
Make reconciliation engine plugin-controlled

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,10 +197,6 @@ the `netbox-proxbox` side, do all five — the existing fields in
 - `PROXBOX_ENCRYPTION_KEY_FILE`: optional override for the local key file path used when neither the env var nor the plugin settings provide a key. Defaults to `<repo_root>/data/encryption.key`.
 - `PROXBOX_ALLOW_PLAINTEXT_CREDENTIALS`: legacy opt-in flag for plaintext credential storage. No longer required for startup; kept for compatibility with operators who scripted it.
 - `PROXBOX_LOG_LEVEL`: console log verbosity (default `INFO`). Valid values: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` (case-insensitive). Controls only the console handler; the in-memory buffer always receives DEBUG+ and the rotating file handler always writes WARNING+. Setting `DEBUG` also enables full `netbox_sdk.client` per-request tracing which is suppressed at all other levels to prevent INFO-level flooding.
-- `PROXBOX_RECONCILIATION_COMPARE_STRICT`: when `true`, compare mode raises on
-  Rust/Python mismatch. Use this in CI/parity tests, not normal production
-  syncs.
-
 ### Plugin-managed (env override optional, defaults shown)
 
 Each maps to a key in `ProxboxPluginSettings` and can be edited from the NetBox plugin settings page.
@@ -212,7 +208,6 @@ Each maps to a key in `ProxboxPluginSettings` and can be edited from the NetBox 
 | `PROXBOX_NETBOX_MAX_RETRIES` | `netbox_max_retries` | 5 |
 | `PROXBOX_NETBOX_RETRY_DELAY` | `netbox_retry_delay` | 2.0 s |
 | `PROXBOX_VM_SYNC_MAX_CONCURRENCY` | `vm_sync_max_concurrency` | 4 |
-| `PROXBOX_RECONCILIATION_ENGINE` | `reconciliation_engine` | python |
 | `PROXBOX_FETCH_MAX_CONCURRENCY` | `proxbox_fetch_max_concurrency` | 8 |
 | `PROXBOX_PROXMOX_FETCH_CONCURRENCY` | `proxmox_fetch_concurrency` | 8 (4 in task-history) |
 | `PROXBOX_NETBOX_WRITE_CONCURRENCY` | `netbox_write_concurrency` | 8 (4 in task-history/snapshots) |
@@ -327,15 +322,16 @@ and dispatch execution in Python. Only pure, synchronous, CPU-bound queue
 construction belongs behind the Rust bridge.
 
 Engine modes are selected through `ProxboxPluginSettings.reconciliation_engine`.
-`PROXBOX_RECONCILIATION_ENGINE` remains an immediate env-var override.
+This selector is intentionally DB-backed through NetBox plugin settings, not a
+backend environment-variable override.
 
-- `PROXBOX_RECONCILIATION_ENGINE=python`: default and production-safe path.
-- `PROXBOX_RECONCILIATION_ENGINE=compare`: run both engines, return Python,
+- `reconciliation_engine=python`: default and production-safe path.
+- `reconciliation_engine=compare`: run both engines, return Python,
   and report mismatches through logs and `proxbox_reconcile_mismatch_total`.
-- `PROXBOX_RECONCILIATION_ENGINE=rust`: return Rust output; requires the
+- `reconciliation_engine=rust`: return Rust output; requires the
   native package and should only be used after compare mode is clean.
-- `PROXBOX_RECONCILIATION_COMPARE_STRICT=true`: raise on mismatch in compare
-  mode, intended for CI and local parity debugging.
+- `reconciliation_compare_strict=true`: raise on mismatch in compare mode,
+  intended for validation and local parity debugging.
 
 When adding future native Rust extensions, use PyO3 as the binding framework:
 

--- a/docs/sync/reconciliation-architecture.md
+++ b/docs/sync/reconciliation-architecture.md
@@ -86,14 +86,14 @@ result, and adapt operations back to the Python dataclasses used by dispatch.
 
 Engine selection is controlled by runtime settings. The NetBox plugin setting
 `ProxboxPluginSettings.reconciliation_engine` is the normal operator-facing
-control, and `PROXBOX_RECONCILIATION_ENGINE` remains an environment override.
+control; backend environment variables do not override this selector.
 
-| Variable | Value | Behavior |
+| Setting | Value | Behavior |
 |----------|-------|----------|
-| `PROXBOX_RECONCILIATION_ENGINE` | `python` | Default. Use Python output only. |
-| `PROXBOX_RECONCILIATION_ENGINE` | `compare` | Run Python and Rust when Rust is installed, log mismatches, return Python output. |
-| `PROXBOX_RECONCILIATION_ENGINE` | `rust` | Return adapted Rust output. |
-| `PROXBOX_RECONCILIATION_COMPARE_STRICT` | `true` | Raise on compare-mode mismatch. Intended for CI. |
+| `reconciliation_engine` | `python` | Default. Use Python output only. |
+| `reconciliation_engine` | `compare` | Run Python and Rust when Rust is installed, log mismatches, return Python output. |
+| `reconciliation_engine` | `rust` | Return adapted Rust output. |
+| `reconciliation_compare_strict` | `true` | Raise on compare-mode mismatch. Intended for validation. |
 
 If the Rust package is not installed, `python` mode works normally and `compare` mode returns
 Python output. `rust` mode requires the native package and fails clearly if it is unavailable.
@@ -182,8 +182,8 @@ sequenceDiagram
 
 - `PROXBOX_VM_SYNC_MAX_CONCURRENCY`: controls concurrent VM preparation/fetch from Proxmox.
 - `PROXBOX_NETBOX_WRITE_CONCURRENCY`: defines dispatch batch window size.
-- `reconciliation_engine` / `PROXBOX_RECONCILIATION_ENGINE`: selects `python`, `compare`, or `rust`.
-- `PROXBOX_RECONCILIATION_COMPARE_STRICT`: raises on compare-mode drift when set to `true`.
+- `reconciliation_engine`: selects `python`, `compare`, or `rust` from ProxboxPluginSettings.
+- `reconciliation_compare_strict`: raises on compare-mode drift when set to `true`.
 
 Note: batch window size does not imply parallel writes; writes remain sequential to protect NetBox under single-instance operation.
 
@@ -196,10 +196,10 @@ Rust is not the default engine. Rollout is intentionally conservative:
 3. Keep `reconciliation_engine=python` as the default in `proxbox-api`.
 4. Run `reconciliation_engine=compare` in staging for at least two weeks.
 5. Watch `proxbox_reconcile_mismatch_total` and reconciliation mismatch logs.
-6. Recommend `PROXBOX_RECONCILIATION_ENGINE=rust` only after zero mismatches across diverse real syncs.
+6. Recommend `reconciliation_engine=rust` only after zero mismatches across diverse real syncs.
 7. Consider a default-engine change only in a later minor release and only after full sync wall-time benchmarks show a real win.
 
-Rollback is immediate: set `reconciliation_engine` back to `python` in NetBox, or unset `PROXBOX_RECONCILIATION_ENGINE` if an env override was used.
+Rollback is immediate: set `reconciliation_engine` back to `python` in NetBox.
 
 Current benchmark evidence does not justify making Rust the default. The full Rust path is slower
 than Python in the synthetic benchmark harness, and live measurement showed reconciliation was not

--- a/proxbox_api/runtime_settings.py
+++ b/proxbox_api/runtime_settings.py
@@ -128,6 +128,34 @@ def get_str(*, settings_key: str, env: str, default: str) -> str:
     return default
 
 
+def get_plugin_bool(*, settings_key: str, default: bool) -> bool:
+    """Resolve a boolean that must be controlled only by ProxboxPluginSettings."""
+    settings = _load_settings()
+    if settings is not None:
+        value = settings.get(settings_key)
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str) and value.strip():
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+        if isinstance(value, (int, float)):
+            return bool(value)
+
+    return default
+
+
+def get_plugin_str(*, settings_key: str, default: str) -> str:
+    """Resolve a string that must be controlled only by ProxboxPluginSettings."""
+    settings = _load_settings()
+    if settings is not None:
+        value = settings.get(settings_key)
+        if value is not None:
+            text = str(value).strip()
+            if text:
+                return text
+
+    return default
+
+
 def _clamp_int(value: int, minimum: int | None, maximum: int | None) -> int:
     if minimum is not None and value < minimum:
         return minimum

--- a/proxbox_api/services/sync/reconciliation/CLAUDE.md
+++ b/proxbox_api/services/sync/reconciliation/CLAUDE.md
@@ -38,15 +38,15 @@ or WebSocket code belongs here.
 ## Engine Modes
 
 The runtime value is read from `ProxboxPluginSettings.reconciliation_engine`
-through `proxbox_api.runtime_settings.get_str()`. The environment variable
-`PROXBOX_RECONCILIATION_ENGINE` remains the highest-priority override.
+through `proxbox_api.runtime_settings.get_plugin_str()`. This engine selector is
+plugin-settings only; backend environment variables must not override it.
 
-- `PROXBOX_RECONCILIATION_ENGINE=python`: default. Always available.
-- `PROXBOX_RECONCILIATION_ENGINE=compare`: run Python and Rust, log/increment
+- `reconciliation_engine=python`: default. Always available.
+- `reconciliation_engine=compare`: run Python and Rust, log/increment
   mismatches, return Python output.
-- `PROXBOX_RECONCILIATION_ENGINE=rust`: return Rust output. Requires
+- `reconciliation_engine=rust`: return Rust output. Requires
   `proxbox-reconcile-rs` to be installed.
-- `PROXBOX_RECONCILIATION_COMPARE_STRICT=true`: raise on mismatch in compare
+- `reconciliation_compare_strict=true`: raise on mismatch in compare
   mode. Use in CI and local parity debugging.
 
 ## Parity Rules
@@ -76,7 +76,5 @@ When the Rust package is installed or changed, run strict parity:
 ```bash
 cargo test --no-default-features --manifest-path proxbox-reconcile-rs/Cargo.toml
 uv pip install -e proxbox-reconcile-rs
-PROXBOX_RECONCILIATION_ENGINE=compare \
-  PROXBOX_RECONCILIATION_COMPARE_STRICT=true \
-  uv run pytest tests/reconciliation -q
+uv run pytest tests/reconciliation -q
 ```

--- a/proxbox_api/services/sync/reconciliation/vm_queue.py
+++ b/proxbox_api/services/sync/reconciliation/vm_queue.py
@@ -8,7 +8,7 @@ import logging
 from typing import Any, Literal
 
 from proxbox_api.proxmox_to_netbox.models import NetBoxVirtualMachineCreateBody
-from proxbox_api.runtime_settings import get_bool, get_str
+from proxbox_api.runtime_settings import get_plugin_bool, get_plugin_str
 from proxbox_api.services.sync.reconciliation.metrics import (
     increment_reconciliation_mismatch_total,
 )
@@ -26,8 +26,6 @@ from proxbox_api.services.sync.vm_helpers import (
 
 logger = logging.getLogger(__name__)
 
-_ENGINE_ENV = "PROXBOX_RECONCILIATION_ENGINE"
-_COMPARE_STRICT_ENV = "PROXBOX_RECONCILIATION_COMPARE_STRICT"
 _VALID_ENGINES = {"python", "compare", "rust"}
 _MAX_DIFF_CHARS = 12000
 
@@ -323,21 +321,22 @@ def _build_vm_operation_queue_with_rust(
 
 
 def _reconciliation_engine() -> Literal["python", "compare", "rust"]:
-    engine = get_str(
+    engine = get_plugin_str(
         settings_key="reconciliation_engine",
-        env=_ENGINE_ENV,
         default="python",
     ).lower()
     if engine not in _VALID_ENGINES:
         valid = ", ".join(sorted(_VALID_ENGINES))
-        raise ValueError(f"Invalid {_ENGINE_ENV}={engine!r}; expected one of: {valid}")
+        raise ValueError(
+            "Invalid ProxboxPluginSettings.reconciliation_engine="
+            f"{engine!r}; expected one of: {valid}"
+        )
     return engine  # type: ignore[return-value]
 
 
 def _reconciliation_compare_strict() -> bool:
-    return get_bool(
+    return get_plugin_bool(
         settings_key="reconciliation_compare_strict",
-        env=_COMPARE_STRICT_ENV,
         default=False,
     )
 

--- a/proxbox_api/settings_client.py
+++ b/proxbox_api/settings_client.py
@@ -95,6 +95,7 @@ def get_default_settings() -> ProxboxSettingsDict:
         "bulk_batch_delay_ms": 500,
         "vm_sync_max_concurrency": 4,
         "reconciliation_engine": "python",
+        "reconciliation_compare_strict": False,
         "custom_fields_request_delay": 0.0,
         "ensure_netbox_objects": True,
         "delete_orphans": False,
@@ -128,6 +129,20 @@ def _normalize_reconciliation_engine(value: object) -> str:
         return "python"
     engine = value.strip().lower()
     return engine if engine in _VALID_RECONCILIATION_ENGINES else "python"
+
+
+def _coerce_bool(value: object, *, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return default
 
 
 def _extract_settings_payload(data: object) -> dict[str, object] | None:
@@ -264,6 +279,10 @@ def fetch_settings_from_netbox(netbox_session: "Api") -> ProxboxSettingsDict | N
             "vm_sync_max_concurrency": int(settings.get("vm_sync_max_concurrency", 4)),
             "reconciliation_engine": _normalize_reconciliation_engine(
                 settings.get("reconciliation_engine")
+            ),
+            "reconciliation_compare_strict": _coerce_bool(
+                settings.get("reconciliation_compare_strict"),
+                default=False,
             ),
             "custom_fields_request_delay": float(settings.get("custom_fields_request_delay", 0.0)),
             "ensure_netbox_objects": bool(settings.get("ensure_netbox_objects", True)),

--- a/proxbox_api/types/structured_dicts.py
+++ b/proxbox_api/types/structured_dicts.py
@@ -34,6 +34,7 @@ class ProxboxSettingsDict(TypedDict):
     bulk_batch_delay_ms: int
     vm_sync_max_concurrency: int
     reconciliation_engine: NotRequired[str]
+    reconciliation_compare_strict: NotRequired[bool]
     custom_fields_request_delay: float
     ensure_netbox_objects: NotRequired[bool]
     delete_orphans: NotRequired[bool]

--- a/tests/reconciliation/test_vm_queue_engine_modes.py
+++ b/tests/reconciliation/test_vm_queue_engine_modes.py
@@ -69,7 +69,11 @@ def test_default_python_mode_does_not_call_available_rust(monkeypatch) -> None:
 
 
 def test_compare_mode_returns_python_output_and_records_mismatch(monkeypatch) -> None:
-    monkeypatch.setenv("PROXBOX_RECONCILIATION_ENGINE", "compare")
+    monkeypatch.setattr(
+        runtime_settings,
+        "_load_settings",
+        lambda: {"reconciliation_engine": "compare"},
+    )
     monkeypatch.setattr(rust_bridge, "_rust_build", lambda input_bytes: _rust_output("CREATE"))
     prepared = [_prepared_vm()]
     snapshot = [_snapshot_vm()]
@@ -96,7 +100,7 @@ def test_plugin_settings_can_select_compare_mode(monkeypatch) -> None:
     assert get_reconciliation_metrics()["proxbox_reconcile_mismatch_total"] == 1
 
 
-def test_engine_env_override_wins_over_plugin_settings(monkeypatch) -> None:
+def test_plugin_settings_engine_wins_over_env(monkeypatch) -> None:
     calls = 0
 
     def fake_rust_build(input_bytes: bytes) -> bytes:
@@ -104,23 +108,31 @@ def test_engine_env_override_wins_over_plugin_settings(monkeypatch) -> None:
         calls += 1
         return _rust_output("UPDATE")
 
+    monkeypatch.setenv("PROXBOX_RECONCILIATION_ENGINE", "python")
     monkeypatch.setattr(
         runtime_settings,
         "_load_settings",
         lambda: {"reconciliation_engine": "rust"},
     )
-    monkeypatch.setenv("PROXBOX_RECONCILIATION_ENGINE", "python")
     monkeypatch.setattr(rust_bridge, "_rust_build", fake_rust_build)
 
     queue = build_vm_operation_queue([_prepared_vm()], [])
 
-    assert [op.method for op in queue] == ["CREATE"]
-    assert calls == 0
+    assert [op.method for op in queue] == ["UPDATE"]
+    assert calls == 1
 
 
 def test_compare_mode_strict_raises_on_mismatch(monkeypatch) -> None:
-    monkeypatch.setenv("PROXBOX_RECONCILIATION_ENGINE", "compare")
-    monkeypatch.setenv("PROXBOX_RECONCILIATION_COMPARE_STRICT", "true")
+    monkeypatch.setenv("PROXBOX_RECONCILIATION_ENGINE", "python")
+    monkeypatch.setenv("PROXBOX_RECONCILIATION_COMPARE_STRICT", "false")
+    monkeypatch.setattr(
+        runtime_settings,
+        "_load_settings",
+        lambda: {
+            "reconciliation_engine": "compare",
+            "reconciliation_compare_strict": True,
+        },
+    )
     monkeypatch.setattr(rust_bridge, "_rust_build", lambda input_bytes: _rust_output("CREATE"))
 
     with pytest.raises(AssertionError, match="Rust/Python reconciliation mismatch"):
@@ -130,7 +142,11 @@ def test_compare_mode_strict_raises_on_mismatch(monkeypatch) -> None:
 
 
 def test_rust_mode_returns_adapted_rust_output_without_running_python(monkeypatch) -> None:
-    monkeypatch.setenv("PROXBOX_RECONCILIATION_ENGINE", "rust")
+    monkeypatch.setattr(
+        runtime_settings,
+        "_load_settings",
+        lambda: {"reconciliation_engine": "rust"},
+    )
     monkeypatch.setattr(rust_bridge, "_rust_build", lambda input_bytes: _rust_output("UPDATE"))
     monkeypatch.setattr(
         vm_queue,
@@ -145,7 +161,11 @@ def test_rust_mode_returns_adapted_rust_output_without_running_python(monkeypatc
 
 
 def test_rust_mode_raises_when_native_extension_is_unavailable(monkeypatch) -> None:
-    monkeypatch.setenv("PROXBOX_RECONCILIATION_ENGINE", "rust")
+    monkeypatch.setattr(
+        runtime_settings,
+        "_load_settings",
+        lambda: {"reconciliation_engine": "rust"},
+    )
 
     with pytest.raises(RuntimeError, match="proxbox-reconcile-rs is not installed"):
         build_vm_operation_queue([_prepared_vm()], [])

--- a/tests/test_settings_client.py
+++ b/tests/test_settings_client.py
@@ -12,6 +12,7 @@ def test_get_default_settings_exposes_backend_log_file_path():
     assert settings["encryption_key"] == ""
     assert settings["delete_orphans"] is False
     assert settings["reconciliation_engine"] == "python"
+    assert settings["reconciliation_compare_strict"] is False
 
 
 def test_fetch_settings_from_netbox_reads_backend_log_file_path(monkeypatch):
@@ -40,6 +41,7 @@ def test_fetch_settings_from_netbox_reads_backend_log_file_path(monkeypatch):
         "encryption_key": "my-plugin-key",
         "delete_orphans": True,
         "reconciliation_engine": "rust",
+        "reconciliation_compare_strict": True,
     }
 
     mock_response = MagicMock()
@@ -57,6 +59,7 @@ def test_fetch_settings_from_netbox_reads_backend_log_file_path(monkeypatch):
     assert settings["encryption_key"] == "my-plugin-key"
     assert settings["delete_orphans"] is True
     assert settings["reconciliation_engine"] == "rust"
+    assert settings["reconciliation_compare_strict"] is True
 
 
 def test_fetch_settings_from_netbox_reads_paginated_settings_response(monkeypatch):
@@ -88,6 +91,7 @@ def test_fetch_settings_from_netbox_reads_paginated_settings_response(monkeypatc
                 "debug_cache": True,
                 "delete_orphans": True,
                 "reconciliation_engine": "compare",
+                "reconciliation_compare_strict": True,
             }
         ],
     }
@@ -109,6 +113,7 @@ def test_fetch_settings_from_netbox_reads_paginated_settings_response(monkeypatc
     assert settings["debug_cache"] is True
     assert settings["delete_orphans"] is True
     assert settings["reconciliation_engine"] == "compare"
+    assert settings["reconciliation_compare_strict"] is True
 
 
 def test_delete_orphans_runtime_bool_prefers_env_over_settings(monkeypatch):
@@ -123,6 +128,34 @@ def test_delete_orphans_runtime_bool_prefers_env_over_settings(monkeypatch):
         runtime_settings.get_bool(
             settings_key="delete_orphans",
             env="PROXBOX_DELETE_ORPHANS",
+            default=False,
+        )
+        is True
+    )
+
+
+def test_plugin_only_runtime_helpers_ignore_env(monkeypatch):
+    monkeypatch.setenv("PROXBOX_RECONCILIATION_ENGINE", "python")
+    monkeypatch.setenv("PROXBOX_RECONCILIATION_COMPARE_STRICT", "false")
+    monkeypatch.setattr(
+        runtime_settings,
+        "_load_settings",
+        lambda: {
+            "reconciliation_engine": "rust",
+            "reconciliation_compare_strict": True,
+        },
+    )
+
+    assert (
+        runtime_settings.get_plugin_str(
+            settings_key="reconciliation_engine",
+            default="python",
+        )
+        == "rust"
+    )
+    assert (
+        runtime_settings.get_plugin_bool(
+            settings_key="reconciliation_compare_strict",
             default=False,
         )
         is True


### PR DESCRIPTION
Closes #205\n\n## Summary\n- makes VM reconciliation engine selection read from ProxboxPluginSettings only\n- adds plugin-only runtime setting helpers for values that must not be env-overridden\n- parses reconciliation_compare_strict from the plugin runtime settings payload\n- updates docs/tests to reflect DB-backed control\n\n## Verification\n- uv run --extra test pytest tests/test_settings_client.py tests/reconciliation/test_vm_queue_engine_modes.py -q\n- live check: rust_available True and engine rust\n- confirmed no PROXBOX_RECONCILIATION_* env vars in the running backend process