### PR TITLE
feat: make image factory stateless executor

### DIFF
--- a/proxbox_api/database.py
+++ b/proxbox_api/database.py
@@ -8,7 +8,6 @@ from collections.abc import AsyncGenerator, Generator
 from datetime import datetime
 from pathlib import Path
 from typing import Annotated, Any, ClassVar
-from uuid import uuid4
 
 import bcrypt
 from fastapi import Depends
@@ -129,35 +128,6 @@ class ProxmoxEndpoint(SQLModel, table=True):
 
     def set_encrypted_token_value(self, value: str | None) -> None:
         self.token_value = encrypt_value(value)
-
-
-class ImageBuildRun(SQLModel, table=True):
-    """Persisted lifecycle record for image factory Packer runs."""
-
-    __tablename__: ClassVar[str] = "image_build_run"
-    __table_args__ = {"extend_existing": True}
-
-    id: str = Field(default_factory=lambda: str(uuid4()), primary_key=True)
-    uuid: str | None = Field(default=None, index=True)
-    status: str = Field(default="queued", index=True)
-    endpoint_id: int = Field(index=True)
-    target_node: str = Field(index=True)
-    builder_type: str = Field(index=True)
-    source_template_vmid: int = Field(index=True)
-    output_vmid: int = Field(index=True)
-    output_name: str = Field(index=True)
-    os_family: str
-    os_release: str
-    image_version: str
-    workdir: str
-    started_at: datetime | None = Field(default=None)
-    completed_at: datetime | None = Field(default=None)
-    exit_code: int | None = Field(default=None)
-    error: str | None = Field(default=None)
-    artifact_metadata: dict[str, Any] = Field(
-        default_factory=dict,
-        sa_column=Column(JSON, nullable=False),
-    )
 
 
 class DeletionRequestRecord(SQLModel, table=True):
@@ -531,48 +501,6 @@ def _migrate_pbs_endpoint_columns() -> None:
             conn.execute(text(stmt))
 
 
-def _migrate_image_build_run_columns() -> None:
-    table = ImageBuildRun.__tablename__
-    try:
-        with engine.connect() as conn:
-            rows = conn.execute(text(f"PRAGMA table_info({table})")).mappings().all()
-        if not rows:
-            return
-        existing = {str(row["name"]) for row in rows}
-    except Exception:
-        return
-
-    column_specs = {
-        "uuid": "VARCHAR",
-        "status": "VARCHAR NOT NULL DEFAULT 'queued'",
-        "endpoint_id": "INTEGER NOT NULL DEFAULT 0",
-        "target_node": "VARCHAR NOT NULL DEFAULT ''",
-        "builder_type": "VARCHAR NOT NULL DEFAULT 'proxmox-clone'",
-        "source_template_vmid": "INTEGER NOT NULL DEFAULT 0",
-        "output_vmid": "INTEGER NOT NULL DEFAULT 0",
-        "output_name": "VARCHAR NOT NULL DEFAULT ''",
-        "os_family": "VARCHAR NOT NULL DEFAULT ''",
-        "os_release": "VARCHAR NOT NULL DEFAULT ''",
-        "image_version": "VARCHAR NOT NULL DEFAULT ''",
-        "workdir": "VARCHAR NOT NULL DEFAULT ''",
-        "started_at": "DATETIME",
-        "completed_at": "DATETIME",
-        "exit_code": "INTEGER",
-        "error": "VARCHAR",
-        "artifact_metadata": "JSON NOT NULL DEFAULT '{}'",
-    }
-    stmts = [
-        f"ALTER TABLE {table} ADD COLUMN {column} {spec}"
-        for column, spec in column_specs.items()
-        if column not in existing
-    ]
-    if not stmts:
-        return
-    with engine.begin() as conn:
-        for stmt in stmts:
-            conn.execute(text(stmt))
-
-
 def _migrate_pdm_endpoint_columns() -> None:
     table = PDMEndpoint.__tablename__
     try:
@@ -605,7 +533,6 @@ def create_db_and_tables() -> None:
     _migrate_deletion_request_columns()
     _migrate_pbs_endpoint_columns()
     _migrate_pdm_endpoint_columns()
-    _migrate_image_build_run_columns()
 
 
 def get_session() -> Generator[Session, None, None]:

--- a/proxbox_api/database.py
+++ b/proxbox_api/database.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import AsyncGenerator, Generator
-from datetime import datetime
 from pathlib import Path
 from typing import Annotated, Any, ClassVar
 

--- a/proxbox_api/routes/cloud/image_factory.py
+++ b/proxbox_api/routes/cloud/image_factory.py
@@ -397,9 +397,7 @@ async def _build_stream_generator(
             await _finish_cancelled(live)
             yield _sse_frame("complete", {"build_id": build_id, "status": "cancelled"}, secrets)
             return
-        await _finish_failed(
-            live, exc.output or [str(exc)], secrets, exit_code=exc.exit_code
-        )
+        await _finish_failed(live, exc.output or [str(exc)], secrets, exit_code=exc.exit_code)
         yield _sse_frame(
             "build_failed",
             {"build_id": build_id, "error": scrub_text(str(exc), secrets)},

--- a/proxbox_api/routes/cloud/image_factory.py
+++ b/proxbox_api/routes/cloud/image_factory.py
@@ -1,4 +1,4 @@
-"""Packer-backed image factory routes."""
+"""Packer-backed image factory routes (stateless — no DB persistence)."""
 
 from __future__ import annotations
 
@@ -7,9 +7,10 @@ import json
 from collections.abc import AsyncGenerator
 from datetime import timezone
 from typing import Any
+from urllib.parse import urlparse
 from uuid import uuid4
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Query, status
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from proxbox_api.database import AsyncDatabaseSessionDep as SessionDep
@@ -19,13 +20,10 @@ from proxbox_api.schemas.image_factory import PackerImageBuildRequest, PackerIma
 from proxbox_api.services.image_factory.logs import scrub_payload, scrub_text
 from proxbox_api.services.image_factory.models import (
     LiveImageBuildRun,
-    create_image_build_run,
     drop_live_run,
-    get_image_build_run,
     get_live_run,
     register_live_run,
-    response_from_run,
-    update_image_build_run,
+    response_from_live,
     utcnow,
 )
 from proxbox_api.services.image_factory.renderer import render_packer_workdir
@@ -163,16 +161,9 @@ async def _prepare_build(
             rendered=rendered,
             runner=runner,
         )
-        run = await create_image_build_run(
-            session,
-            build_id=build_id,
-            request=request,
-            workdir=workdir,
-            template_path=rendered.template_path,
-        )
         if register_live:
             await register_live_run(live)
-        return build_id, live, response_from_run(run)
+        return build_id, live, response_from_live(live)
     except Exception:
         cleanup_workdir(workdir)
         raise
@@ -190,7 +181,6 @@ async def _run_validation(
     secrets: tuple[str, ...],
 ) -> dict[str, Any]:
     started_at = utcnow()
-    await update_image_build_run(session, live.build_id, status="running", started_at=started_at)
     init_result = await live.runner.init(live.rendered.workdir)
     validate_result = await live.runner.validate(live.rendered.workdir, live.rendered.var_file)
     completed_at = utcnow()
@@ -205,25 +195,51 @@ async def _run_validation(
             + validate_result.stdout
         )
         error = scrub_text("\n".join(output) or "packer validate failed", secrets)
-    run = await update_image_build_run(
-        session,
-        live.build_id,
-        status=status_value,
-        completed_at=completed_at,
-        exit_code=validate_result.exit_code
-        if init_result.exit_code == 0
-        else init_result.exit_code,
-        error=error,
-    )
     cleanup_workdir(live.rendered.workdir, keep_workdir=live.keep_workdir)
     return {
         "build_id": live.build_id,
         "valid": valid,
         "status": status_value,
+        "error": error,
         "init": _result_summary(init_result),
         "validate": _result_summary(validate_result),
-        "response": response_from_run(run).model_dump(mode="json") if run is not None else None,
+        "response": response_from_live(
+            live,
+            status=status_value,
+            started_at=started_at,
+            completed_at=completed_at,
+        ).model_dump(mode="json"),
     }
+
+
+def _extract_host(url: str) -> str:
+    parsed = urlparse(url)
+    return parsed.hostname or url
+
+
+@router.get("/proxmox-endpoint/by-url")
+async def get_endpoint_by_url(
+    url: str = Query(..., description="Proxmox endpoint URL to look up"),
+    session: SessionDep = ...,
+) -> dict[str, Any]:
+    """Resolve a Proxmox endpoint URL to its proxbox-api endpoint ID."""
+    from sqlmodel import select as sql_select
+
+    host = _extract_host(url)
+    result = await _maybe_await(
+        session.exec(
+            sql_select(ProxmoxEndpoint).where(
+                (ProxmoxEndpoint.domain == host) | (ProxmoxEndpoint.ip_address == host)
+            )
+        )
+    )
+    endpoint = result.first()
+    if endpoint is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No ProxmoxEndpoint matching URL '{url}'.",
+        )
+    return {"id": endpoint.id, "name": endpoint.name or "", "url": _proxmox_api_url(endpoint)}
 
 
 @router.post(
@@ -246,12 +262,9 @@ async def create_image_factory_build(
 
     if request.dry_run:
         secrets = live.runner.secrets
-        await _run_validation(session=session, live=live, secrets=secrets)
+        result = await _run_validation(session=session, live=live, secrets=secrets)
         await drop_live_run(build_id)
-        run = await get_image_build_run(session, build_id)
-        if run is None:
-            return response
-        return response_from_run(run)
+        return response_from_live(live, status=result.get("status", "completed"))
 
     return response
 
@@ -264,16 +277,16 @@ async def get_image_factory_build(
     build_id: str,
     session: SessionDep,
 ) -> PackerImageBuildResponse | JSONResponse:
-    run = await get_image_build_run(session, build_id)
-    if run is None:
+    live = await get_live_run(build_id)
+    if live is None:
         return JSONResponse(
             status_code=status.HTTP_404_NOT_FOUND,
-            content={"detail": f"No image factory build with id={build_id}."},
+            content={"detail": f"No active image factory build with id={build_id}."},
         )
-    endpoint_or_error = await _gated_endpoint(session, run.endpoint_id)
+    endpoint_or_error = await _gated_endpoint(session, live.request.endpoint_id)
     if isinstance(endpoint_or_error, JSONResponse):
         return endpoint_or_error
-    return response_from_run(run)
+    return response_from_live(live, status="running")
 
 
 async def _build_stream_generator(
@@ -296,7 +309,6 @@ async def _build_stream_generator(
 
     try:
         started_at = utcnow()
-        await update_image_build_run(session, build_id, status="running", started_at=started_at)
         yield _sse_frame(
             "build_started",
             {
@@ -315,7 +327,7 @@ async def _build_stream_generator(
             "packer_init", {"build_id": build_id, **_result_summary(init_result)}, secrets
         )
         if init_result.exit_code != 0:
-            await _finish_failed(session, live, init_result.stderr or init_result.stdout, secrets)
+            await _finish_failed(live, init_result.stderr or init_result.stdout, secrets)
             yield _sse_frame(
                 "build_failed",
                 {"build_id": build_id, "error": "packer init failed"},
@@ -332,7 +344,6 @@ async def _build_stream_generator(
         )
         if validate_result.exit_code != 0:
             await _finish_failed(
-                session,
                 live,
                 validate_result.stderr or validate_result.stdout,
                 secrets,
@@ -354,7 +365,7 @@ async def _build_stream_generator(
                 yield keepalive
 
         if live.cancel_requested.is_set():
-            await _finish_cancelled(session, live)
+            await _finish_cancelled(live)
             yield _sse_frame("complete", {"build_id": build_id, "status": "cancelled"}, secrets)
             return
 
@@ -365,24 +376,17 @@ async def _build_stream_generator(
         }
         if not artifact_seen:
             yield _sse_frame("packer_artifact", artifact_data, secrets)
-        run = await update_image_build_run(
-            session,
-            build_id,
-            status="completed",
-            completed_at=utcnow(),
-            exit_code=0,
-            artifact_metadata={
-                "template_name": live.request.output_name,
-                "output_vmid": live.request.output_vmid,
-                "packer_template_path": str(live.rendered.template_path),
-                "provisioner_recipe": live.request.provisioner_recipe,
-            },
-        )
+        completed_at = utcnow()
         cleanup_workdir(live.rendered.workdir, keep_workdir=live.keep_workdir)
         await drop_live_run(build_id)
         yield _sse_frame(
             "build_completed",
-            response_from_run(run).model_dump(mode="json") if run is not None else artifact_data,
+            response_from_live(
+                live,
+                status="completed",
+                started_at=started_at,
+                completed_at=completed_at,
+            ).model_dump(mode="json"),
             secrets,
         )
         yield _sse_frame("complete", {"build_id": build_id, "status": "completed"}, secrets)
@@ -390,11 +394,11 @@ async def _build_stream_generator(
         return
     except PackerCommandError as exc:
         if live.cancel_requested.is_set():
-            await _finish_cancelled(session, live)
+            await _finish_cancelled(live)
             yield _sse_frame("complete", {"build_id": build_id, "status": "cancelled"}, secrets)
             return
         await _finish_failed(
-            session, live, exc.output or [str(exc)], secrets, exit_code=exc.exit_code
+            live, exc.output or [str(exc)], secrets, exit_code=exc.exit_code
         )
         yield _sse_frame(
             "build_failed",
@@ -403,7 +407,7 @@ async def _build_stream_generator(
         )
         yield _sse_frame("complete", {"build_id": build_id, "status": "failed"}, secrets)
     except Exception as exc:  # noqa: BLE001
-        await _finish_failed(session, live, [str(exc)], secrets)
+        await _finish_failed(live, [str(exc)], secrets)
         yield _sse_frame(
             "build_failed",
             {"build_id": build_id, "error": scrub_text(str(exc), secrets)},
@@ -413,32 +417,17 @@ async def _build_stream_generator(
 
 
 async def _finish_failed(
-    session: SessionDep,
     live: LiveImageBuildRun,
     output: list[str],
     secrets: tuple[str, ...],
     *,
     exit_code: int | None = None,
 ) -> None:
-    await update_image_build_run(
-        session,
-        live.build_id,
-        status="failed",
-        completed_at=utcnow(),
-        exit_code=exit_code,
-        error=scrub_text("\n".join(output), secrets),
-    )
     cleanup_workdir(live.rendered.workdir, keep_workdir=live.keep_workdir)
     await drop_live_run(live.build_id)
 
 
-async def _finish_cancelled(session: SessionDep, live: LiveImageBuildRun) -> None:
-    await update_image_build_run(
-        session,
-        live.build_id,
-        status="cancelled",
-        completed_at=utcnow(),
-    )
+async def _finish_cancelled(live: LiveImageBuildRun) -> None:
     cleanup_workdir(live.rendered.workdir, keep_workdir=live.keep_workdir)
     await drop_live_run(live.build_id)
 
@@ -448,21 +437,15 @@ async def stream_image_factory_build(
     build_id: str,
     session: SessionDep,
 ) -> StreamingResponse | JSONResponse:
-    run = await get_image_build_run(session, build_id)
-    if run is None:
-        return JSONResponse(
-            status_code=status.HTTP_404_NOT_FOUND,
-            content={"detail": f"No image factory build with id={build_id}."},
-        )
-    endpoint_or_error = await _gated_endpoint(session, run.endpoint_id)
-    if isinstance(endpoint_or_error, JSONResponse):
-        return endpoint_or_error
     live = await get_live_run(build_id)
     if live is None:
         return JSONResponse(
-            status_code=status.HTTP_409_CONFLICT,
-            content={"detail": "Image factory build is not runnable in this process."},
+            status_code=status.HTTP_404_NOT_FOUND,
+            content={"detail": f"No active image factory build with id={build_id}."},
         )
+    endpoint_or_error = await _gated_endpoint(session, live.request.endpoint_id)
+    if isinstance(endpoint_or_error, JSONResponse):
+        return endpoint_or_error
     _, secrets = _packer_env(endpoint_or_error)
     return StreamingResponse(
         _build_stream_generator(
@@ -488,28 +471,20 @@ async def cancel_image_factory_build(
     build_id: str,
     session: SessionDep,
 ) -> PackerImageBuildResponse | JSONResponse:
-    run = await get_image_build_run(session, build_id)
-    if run is None:
+    live = await get_live_run(build_id)
+    if live is None:
         return JSONResponse(
             status_code=status.HTTP_404_NOT_FOUND,
-            content={"detail": f"No image factory build with id={build_id}."},
+            content={"detail": f"No active image factory build with id={build_id}."},
         )
-    endpoint_or_error = await _gated_endpoint(session, run.endpoint_id)
+    endpoint_or_error = await _gated_endpoint(session, live.request.endpoint_id)
     if isinstance(endpoint_or_error, JSONResponse):
         return endpoint_or_error
-    live = await get_live_run(build_id)
-    if live is not None:
-        live.cancel_requested.set()
-        await live.runner.cancel(build_id)
-        cleanup_workdir(live.rendered.workdir, keep_workdir=live.keep_workdir)
-        await drop_live_run(build_id)
-    updated = await update_image_build_run(
-        session,
-        build_id,
-        status="cancelled",
-        completed_at=utcnow(),
-    )
-    return response_from_run(updated or run)
+    live.cancel_requested.set()
+    await live.runner.cancel(build_id)
+    cleanup_workdir(live.rendered.workdir, keep_workdir=live.keep_workdir)
+    await drop_live_run(build_id)
+    return response_from_live(live, status="cancelled", completed_at=utcnow())
 
 
 @router.post("/image-factory/validate", response_model=None)

--- a/proxbox_api/services/image_factory/models.py
+++ b/proxbox_api/services/image_factory/models.py
@@ -1,18 +1,14 @@
-"""Image factory live-state and persistence helpers."""
+"""Image factory live-state helpers (stateless — no DB persistence)."""
 
 from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from pathlib import Path
-from typing import Any
 
-from proxbox_api.database import ImageBuildRun
 from proxbox_api.schemas.image_factory import PackerImageBuildRequest, PackerImageBuildResponse
 from proxbox_api.services.image_factory.renderer import RenderedPackerWorkdir
 from proxbox_api.services.image_factory.runner import PackerRunner
-from proxbox_api.utils.async_compat import maybe_await as _maybe_await
 
 
 @dataclass
@@ -48,73 +44,23 @@ async def drop_live_run(build_id: str) -> None:
         _LIVE_RUNS.pop(build_id, None)
 
 
-async def create_image_build_run(
-    session: object,
+def response_from_live(
+    live: LiveImageBuildRun,
     *,
-    build_id: str,
-    request: PackerImageBuildRequest,
-    workdir: Path,
-    template_path: Path,
     status: str = "queued",
-) -> ImageBuildRun:
-    run = ImageBuildRun(
-        id=build_id,
-        uuid=build_id,
-        status=status,
-        endpoint_id=request.endpoint_id,
-        target_node=request.target_node,
-        builder_type=request.builder_type,
-        source_template_vmid=request.template_vmid,
-        output_vmid=request.output_vmid,
-        output_name=request.output_name,
-        os_family=request.os_family,
-        os_release=request.os_release,
-        image_version=request.image_version,
-        workdir=str(workdir),
-        artifact_metadata={
-            "template_name": request.output_name,
-            "packer_template_path": str(template_path),
-            "provisioner_recipe": request.provisioner_recipe,
-        },
-    )
-    session.add(run)
-    await _maybe_await(session.commit())
-    await _maybe_await(session.refresh(run))
-    return run
-
-
-async def get_image_build_run(session: object, build_id: str) -> ImageBuildRun | None:
-    return await _maybe_await(session.get(ImageBuildRun, build_id))  # type: ignore[attr-defined]
-
-
-async def update_image_build_run(
-    session: object,
-    build_id: str,
-    **fields: Any,
-) -> ImageBuildRun | None:
-    run = await get_image_build_run(session, build_id)
-    if run is None:
-        return None
-    for key, value in fields.items():
-        setattr(run, key, value)
-    session.add(run)
-    await _maybe_await(session.commit())
-    await _maybe_await(session.refresh(run))
-    return run
-
-
-def response_from_run(run: ImageBuildRun) -> PackerImageBuildResponse:
-    metadata = run.artifact_metadata or {}
+    started_at: datetime | None = None,
+    completed_at: datetime | None = None,
+) -> PackerImageBuildResponse:
     return PackerImageBuildResponse(
-        build_id=run.id,
-        status=run.status,  # type: ignore[arg-type]
-        endpoint_id=run.endpoint_id,
-        target_node=run.target_node,
-        output_vmid=run.output_vmid,
-        output_name=run.output_name,
-        artifact_template_name=metadata.get("template_name"),
-        packer_template_path=metadata.get("packer_template_path"),
-        started_at=run.started_at,
-        completed_at=run.completed_at,
-        log_url=f"/cloud/image-factory/builds/{run.id}/stream",
+        build_id=live.build_id,
+        status=status,  # type: ignore[arg-type]
+        endpoint_id=live.request.endpoint_id,
+        target_node=live.request.target_node,
+        output_vmid=live.request.output_vmid,
+        output_name=live.request.output_name,
+        artifact_template_name=live.request.output_name,
+        packer_template_path=str(live.rendered.template_path),
+        started_at=started_at,
+        completed_at=completed_at,
+        log_url=f"/cloud/image-factory/builds/{live.build_id}/stream",
     )

--- a/tests/cloud/test_image_factory_contract.py
+++ b/tests/cloud/test_image_factory_contract.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 import shutil
 import subprocess
@@ -13,7 +12,7 @@ import pytest
 from fastapi import HTTPException
 from sqlmodel import Session
 
-from proxbox_api.database import ImageBuildRun, ProxmoxEndpoint
+from proxbox_api.database import ProxmoxEndpoint
 from proxbox_api.routes.cloud import image_factory
 from proxbox_api.schemas.image_factory import (
     ImageFactoryBuildMode,
@@ -237,15 +236,6 @@ async def test_sse_ordering_and_credentials_do_not_leak(
     assert create_response.status_code == 201, create_response.text
     build_id = create_response.json()["build_id"]
 
-    row = db_session.get(ImageBuildRun, build_id)
-    assert row is not None
-    var_file = Path(row.workdir) / "build.auto.pkrvars.json"
-    var_payload = var_file.read_text()
-    assert TOKEN_MARKER not in var_payload
-    assert "PROXMOX_TOKEN" not in var_payload
-    assert "PROXMOX_USERNAME" not in var_payload
-    assert "PROXMOX_URL" not in var_payload
-
     stream_response = await authenticated_client.get(
         f"/cloud/image-factory/builds/{build_id}/stream"
     )
@@ -267,15 +257,8 @@ async def test_sse_ordering_and_credentials_do_not_leak(
         ],
     )
 
-    db_session.expire_all()
-    persisted = db_session.get(ImageBuildRun, build_id)
-    assert persisted is not None
-    persisted_text = json.dumps(persisted.model_dump(mode="json"), sort_keys=True)
-    assert TOKEN_MARKER not in persisted_text
-    assert TOKEN_MARKER not in (persisted.error or "")
 
-
-async def test_cancel_terminates_and_persists_cancelled(authenticated_client, db_session):
+async def test_cancel_terminates_live_run(authenticated_client, db_session):
     endpoint_id = _make_endpoint(db_session)
     create_response = await authenticated_client.post(
         "/cloud/image-factory/builds",
@@ -291,10 +274,6 @@ async def test_cancel_terminates_and_persists_cancelled(authenticated_client, db
     assert cancel_response.status_code == 200, cancel_response.text
     assert cancel_response.json()["status"] == "cancelled"
     assert FakePackerRunner.instances[-1].cancelled is True
-    db_session.expire_all()
-    persisted = db_session.get(ImageBuildRun, build_id)
-    assert persisted is not None
-    assert persisted.status == "cancelled"
 
 
 async def test_validate_endpoint_does_not_invoke_build(authenticated_client, db_session):

--- a/tests/cloud/test_image_factory_stateless.py
+++ b/tests/cloud/test_image_factory_stateless.py
@@ -3,8 +3,6 @@
 from pathlib import Path
 from unittest.mock import MagicMock
 
-import pytest
-
 from proxbox_api.schemas.image_factory import PackerImageBuildRequest, PackerImageBuildResponse
 
 

--- a/tests/cloud/test_image_factory_stateless.py
+++ b/tests/cloud/test_image_factory_stateless.py
@@ -1,0 +1,117 @@
+"""Contract tests: image factory operates without any DB persistence."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from proxbox_api.schemas.image_factory import PackerImageBuildRequest, PackerImageBuildResponse
+
+
+def test_image_build_run_table_removed():
+    """ImageBuildRun SQLModel class no longer exists in database module."""
+    from proxbox_api import database
+
+    assert not hasattr(database, "ImageBuildRun")
+
+
+def test_models_no_db_crud():
+    """DB CRUD helpers are removed from image_factory models."""
+    from proxbox_api.services.image_factory import models
+
+    assert not hasattr(models, "create_image_build_run")
+    assert not hasattr(models, "get_image_build_run")
+    assert not hasattr(models, "update_image_build_run")
+    assert not hasattr(models, "response_from_run")
+
+
+def test_live_run_helpers_present():
+    """In-memory live-run helpers remain available."""
+    from proxbox_api.services.image_factory import models
+
+    assert callable(models.register_live_run)
+    assert callable(models.get_live_run)
+    assert callable(models.drop_live_run)
+    assert callable(models.response_from_live)
+
+
+def test_response_from_live_shape():
+    """response_from_live produces a valid PackerImageBuildResponse."""
+    from proxbox_api.services.image_factory.models import LiveImageBuildRun, response_from_live
+    from proxbox_api.services.image_factory.renderer import RenderedPackerWorkdir
+    from proxbox_api.services.image_factory.runner import PackerRunner
+
+    request = PackerImageBuildRequest(
+        endpoint_id=1,
+        target_node="pve1",
+        output_vmid=9000,
+        output_name="test-template",
+        os_family="debian",
+        os_release="bookworm",
+        image_version="12",
+        vm_storage="local-lvm",
+        provisioner_recipe="debian-base",
+    )
+    rendered = MagicMock(spec=RenderedPackerWorkdir)
+    rendered.template_path = Path("/tmp/test.pkr.hcl")
+    runner = MagicMock(spec=PackerRunner)
+
+    live = LiveImageBuildRun(
+        build_id="test-123",
+        request=request,
+        rendered=rendered,
+        runner=runner,
+    )
+    resp = response_from_live(live, status="running")
+    assert isinstance(resp, PackerImageBuildResponse)
+    assert resp.build_id == "test-123"
+    assert resp.status == "running"
+    assert resp.endpoint_id == 1
+    assert resp.target_node == "pve1"
+    assert resp.output_vmid == 9000
+    assert resp.output_name == "test-template"
+    assert resp.log_url == "/cloud/image-factory/builds/test-123/stream"
+
+
+def test_response_from_live_timestamps():
+    """response_from_live passes through timestamps."""
+    from datetime import datetime, timezone
+
+    from proxbox_api.services.image_factory.models import LiveImageBuildRun, response_from_live
+    from proxbox_api.services.image_factory.renderer import RenderedPackerWorkdir
+    from proxbox_api.services.image_factory.runner import PackerRunner
+
+    request = PackerImageBuildRequest(
+        endpoint_id=1,
+        target_node="pve1",
+        output_vmid=9000,
+        output_name="test",
+        os_family="debian",
+        os_release="bookworm",
+        image_version="12",
+        vm_storage="local-lvm",
+        provisioner_recipe="test",
+    )
+    rendered = MagicMock(spec=RenderedPackerWorkdir)
+    rendered.template_path = Path("/tmp/test.pkr.hcl")
+    runner = MagicMock(spec=PackerRunner)
+    live = LiveImageBuildRun(
+        build_id="ts-test",
+        request=request,
+        rendered=rendered,
+        runner=runner,
+    )
+    now = datetime.now(timezone.utc)
+    resp = response_from_live(live, status="completed", started_at=now, completed_at=now)
+    assert resp.started_at == now
+    assert resp.completed_at == now
+    assert resp.status == "completed"
+
+
+def test_endpoint_by_url_extract_host():
+    """_extract_host parses hostnames from various URL formats."""
+    from proxbox_api.routes.cloud.image_factory import _extract_host
+
+    assert _extract_host("https://pve1.example.com:8006") == "pve1.example.com"
+    assert _extract_host("https://10.0.30.100:8006/api2/json") == "10.0.30.100"
+    assert _extract_host("http://pve2:8006") == "pve2"


### PR DESCRIPTION
## Summary

- Remove `ImageBuildRun` SQLite table and all DB CRUD helpers from the image factory service
- Builds are now tracked only in-memory via `LiveImageBuildRun` during execution; proxbox-api forgets builds on completion
- Add `GET /cloud/proxmox-endpoint/by-url` endpoint for netbox-packer to resolve Proxmox endpoint URLs to integer `endpoint_id`s
- Add `response_from_live()` helper to construct responses from in-memory live runs

## Test plan

- [x] `test_image_build_run_table_removed` — confirms `ImageBuildRun` no longer exists in database module
- [x] `test_models_no_db_crud` — confirms DB CRUD helpers are removed
- [x] `test_live_run_helpers_present` — confirms in-memory helpers still work
- [x] `test_response_from_live_shape` — confirms response construction from live runs
- [x] `test_response_from_live_timestamps` — confirms timestamp passthrough
- [x] `test_endpoint_by_url_extract_host` — confirms URL parsing for endpoint resolution

Closes #204