### PR TITLE
Add Gitea provisioner recipe to image factory

### DIFF
--- a/proxbox_api/packer_templates/provisioners/gitea.sh
+++ b/proxbox_api/packer_templates/provisioners/gitea.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env sh
+set -eu
+
+GITEA_VERSION="1.23.7"
+
+if [ "$(id -u)" -eq 0 ]; then
+  SUDO=""
+else
+  SUDO="sudo"
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+$SUDO apt-get update
+$SUDO apt-get install -y --no-install-recommends \
+  ca-certificates \
+  cloud-init \
+  curl \
+  git \
+  qemu-guest-agent \
+  sqlite3 \
+  sudo
+
+$SUDO adduser --system --shell /bin/bash --gecos 'Gitea' \
+  --group --disabled-password --home /home/git git || true
+
+$SUDO mkdir -p /var/lib/gitea/{custom,data,log}
+$SUDO chown -R git:git /var/lib/gitea
+$SUDO chmod -R 750 /var/lib/gitea
+$SUDO mkdir -p /etc/gitea
+$SUDO chown root:git /etc/gitea
+$SUDO chmod 770 /etc/gitea
+
+$SUDO curl -fsSL -o /usr/local/bin/gitea \
+  "https://dl.gitea.com/gitea/${GITEA_VERSION}/gitea-${GITEA_VERSION}-linux-amd64"
+$SUDO chmod +x /usr/local/bin/gitea
+
+cat <<'UNIT' | $SUDO tee /etc/systemd/system/gitea.service >/dev/null
+[Unit]
+Description=Gitea (Git with a cup of tea)
+After=syslog.target network.target
+
+[Service]
+RestartSec=2s
+Type=simple
+User=git
+Group=git
+WorkingDirectory=/var/lib/gitea
+ExecStart=/usr/local/bin/gitea web --config /etc/gitea/app.ini
+Restart=always
+Environment=USER=git HOME=/home/git GITEA_WORK_DIR=/var/lib/gitea
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+$SUDO systemctl daemon-reload
+$SUDO systemctl enable gitea >/dev/null 2>&1 || true
+$SUDO systemctl enable qemu-guest-agent >/dev/null 2>&1 || true
+
+$SUDO cloud-init clean --logs --machine-id >/dev/null 2>&1 || true
+$SUDO truncate -s 0 /etc/machine-id || true
+$SUDO rm -f /var/lib/dbus/machine-id
+$SUDO ln -sf /etc/machine-id /var/lib/dbus/machine-id
+
+$SUDO rm -f /root/.bash_history
+for history_file in /home/*/.bash_history; do
+  [ -e "$history_file" ] || continue
+  $SUDO rm -f "$history_file"
+done
+
+$SUDO find /var/log -type f -exec truncate -s 0 {} \; >/dev/null 2>&1 || true
+history -c >/dev/null 2>&1 || true

--- a/proxbox_api/services/image_factory/renderer.py
+++ b/proxbox_api/services/image_factory/renderer.py
@@ -53,6 +53,7 @@ ALLOWED_PROVISIONER_RECIPES = {
     "debian-base": "debian-base.sh",
     "docker-host": "docker-host.sh",
     "qemu-agent": "qemu-agent.sh",
+    "gitea": "gitea.sh",
 }
 
 

--- a/tests/cloud/test_image_factory_contract.py
+++ b/tests/cloud/test_image_factory_contract.py
@@ -310,6 +310,30 @@ async def test_validate_endpoint_does_not_invoke_build(authenticated_client, db_
     assert FakePackerRunner.instances[-1].build_called is False
 
 
+async def test_gitea_recipe_creates_build(authenticated_client, db_session):
+    endpoint_id = _make_endpoint(db_session)
+
+    response = await authenticated_client.post(
+        "/cloud/image-factory/builds",
+        json=_request_payload(endpoint_id, provisioner_recipe="gitea"),
+    )
+
+    assert response.status_code == 201, response.text
+    assert response.json()["status"] == "queued"
+
+
+def test_gitea_recipe_renders_provisioner(tmp_path):
+    from proxbox_api.services.image_factory.renderer import render_packer_workdir
+
+    request = PackerImageBuildRequest(**_request_payload(1, provisioner_recipe="gitea"))
+    rendered = render_packer_workdir(request=request, workdir=tmp_path)
+    assert rendered.provisioner_path.exists()
+    content = rendered.provisioner_path.read_text()
+    assert "GITEA_VERSION" in content
+    assert "/usr/local/bin/gitea" in content
+    assert "gitea.service" in content
+
+
 @pytest.mark.skipif(not shutil.which("packer"), reason="packer binary is not installed")
 def test_bundled_hcl_packer_validate_smoke(tmp_path):
     endpoint_id = 1


### PR DESCRIPTION
## Summary

- New Packer provisioner recipe `gitea.sh` that installs the official Gitea binary (v1.23.7) with a systemd service unit on Ubuntu 24.04
- Registered `"gitea": "gitea.sh"` in `ALLOWED_PROVISIONER_RECIPES` whitelist
- Added two test cases: HTTP build request and direct workdir rendering

## What the provisioner does

1. Installs prerequisites (git, curl, sqlite3, cloud-init, qemu-guest-agent)
2. Creates a `git` system user with `/home/git`
3. Sets up directories: `/var/lib/gitea/{custom,data,log}`, `/etc/gitea`
4. Downloads the Gitea binary from `dl.gitea.com`
5. Writes a systemd service file for `gitea.service`
6. Enables the service for first boot
7. Runs standard cloud-init cleanup

## Usage

```json
POST /cloud/image-factory/builds
{
  "provisioner_recipe": "gitea",
  "os_family": "ubuntu",
  "os_release": "24.04",
  ...
}
```

Or via NetBox: create a `PackerTemplate` with `packer_template_ref="gitea"`.

## Test plan

- [x] Shell syntax validation (`sh -n gitea.sh`)
- [x] Python compile check on `renderer.py`
- [x] `test_gitea_recipe_creates_build` — HTTP 201 with gitea recipe
- [x] `test_gitea_recipe_renders_provisioner` — workdir renders with correct script content
- [x] All 11 image factory contract tests pass

Closes #208