### PR TITLE
fix: apply ruff format to cloud catalog route

### DIFF
--- a/proxbox_api/routes/cloud/catalog.py
+++ b/proxbox_api/routes/cloud/catalog.py
@@ -204,8 +204,7 @@ PRODUCT_CATALOG: dict[CloudImageProductType, list[CloudImageVersionEntry]] = {
             os_family="ubuntu",
             os_release="noble",
             image_url=(
-                "https://cloud-images.ubuntu.com/noble/current/"
-                "noble-server-cloudimg-amd64.img"
+                "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
             ),
             os_codename="noble",
             notes="Proxmox VM template pre-configured as a Firecracker microVM host.",


### PR DESCRIPTION
## Summary
- Applies `ruff format` to `proxbox_api/routes/cloud/catalog.py` — joins a URL string literal that fits on one line
- Fixes the CI `Ruff (lint + format check)` step that has been failing on `main`

## Test plan
- [x] `ruff check .` passes
- [x] `ruff format --check .` passes (430 files already formatted)