### PR TITLE
Fix VM reimport after NetBox deletion

### DIFF
--- a/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
+++ b/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
@@ -23,6 +23,7 @@ from proxbox_api.exception import ProxboxException
 from proxbox_api.logger import logger
 from proxbox_api.netbox_compat import VirtualMachine
 from proxbox_api.netbox_rest import (
+    clear_rest_get_cache_for_path,
     rest_create_async,
     rest_first_async,
     rest_list_async,
@@ -178,8 +179,15 @@ async def _resolve_vm_dns_name(
         return None
 
 
-async def _load_netbox_virtual_machine_snapshot(nb: object) -> list[dict[str, object]]:
+async def _load_netbox_virtual_machine_snapshot(
+    nb: object,
+    *,
+    fresh: bool = False,
+) -> list[dict[str, object]]:
     """Fetch all NetBox virtual machines once and keep them in-memory for comparison."""
+
+    if fresh:
+        clear_rest_get_cache_for_path(nb, "/api/virtualization/virtual-machines/")
 
     page_size = 200
     offset = 0
@@ -493,6 +501,7 @@ async def _dispatch_vm_operation_queue(
                         nb,
                         "/api/virtualization/virtual-machines/",
                         operation.prepared.desired_payload,
+                        lookup=operation.prepared.lookup,
                     )
                     resolved_records[key] = _to_mapping(created)
                 except ProxboxException:
@@ -997,6 +1006,7 @@ async def _create_virtual_machine_by_netbox_id(
     overwrite_vm_description: bool | None = None,
     overwrite_vm_custom_fields: bool | None = None,
     overwrite_flags: SyncOverwriteFlags | None = None,
+    run_id: str | None = None,
 ):
     """Create a single virtual machine by its NetBox ID.
 
@@ -1084,6 +1094,7 @@ async def _create_virtual_machine_by_netbox_id(
         overwrite_vm_description=overwrite_vm_description,
         overwrite_vm_custom_fields=overwrite_vm_custom_fields,
         overwrite_flags=overwrite_flags if overwrite_flags is not None else SyncOverwriteFlags(),
+        run_id=run_id,
     )
 
 
@@ -1694,7 +1705,7 @@ async def create_virtual_machines(  # noqa: C901
         if not prepared_vms:
             return []
 
-        netbox_snapshot = await _load_netbox_virtual_machine_snapshot(nb)
+        netbox_snapshot = await _load_netbox_virtual_machine_snapshot(nb, fresh=True)
         await _resolve_vm_names_pre_pass(prepared_vms, netbox_snapshot, bridge)
         reconciliation_t0 = time.perf_counter()
         operation_queue = _build_vm_operation_queue(
@@ -1733,6 +1744,7 @@ async def create_virtual_machines(  # noqa: C901
                     operation.method,
                 )
                 continue
+            await stamp_vm_last_run_id(nb, vm_record, effective_run_id)
             results.append(vm_record)
 
             vm_id = _relation_id(vm_record.get("id"))
@@ -3348,6 +3360,14 @@ async def create_virtual_machine_by_netbox_id(
         title="Primary IP Preference",
         description="Preferred IP family when choosing VM primary IP (ipv4 or ipv6).",
     ),
+    run_id: str | None = Query(
+        default=None,
+        title="Run ID",
+        description=(
+            "UUID stamped on each touched VM's proxbox_last_run_id custom field. "
+            "When omitted, a fresh UUID is generated."
+        ),
+    ),
     overwrite_flags: ResolvedSyncOverwriteFlagsDep = SyncOverwriteFlags(),
 ):
     return await _create_virtual_machine_by_netbox_id(
@@ -3362,6 +3382,7 @@ async def create_virtual_machine_by_netbox_id(
         ignore_ipv6_link_local_addresses=ignore_ipv6_link_local_addresses,
         primary_ip_preference=primary_ip_preference,
         overwrite_flags=overwrite_flags,
+        run_id=run_id,
     )
 
 
@@ -3452,6 +3473,14 @@ async def create_virtual_machines_stream(
             "Use when a dedicated network-sync stage follows immediately after."
         ),
     ),
+    run_id: str | None = Query(
+        default=None,
+        title="Run ID",
+        description=(
+            "UUID stamped on each touched VM's proxbox_last_run_id custom field. "
+            "When omitted, a fresh UUID is generated."
+        ),
+    ),
     overwrite_flags: ResolvedSyncOverwriteFlagsDep = SyncOverwriteFlags(),
 ):
     (
@@ -3505,6 +3534,7 @@ async def create_virtual_machines_stream(
                     overwrite_vm_custom_fields=overwrite_vm_custom_fields,
                     sync_vm_network=sync_vm_network,
                     overwrite_flags=overwrite_flags,
+                    run_id=run_id,
                 )
             finally:
                 await bridge.close()
@@ -3683,6 +3713,14 @@ async def create_virtual_machine_by_netbox_id_stream(
             "When unset, falls back to overwrite_flags.overwrite_vm_custom_fields."
         ),
     ),
+    run_id: str | None = Query(
+        default=None,
+        title="Run ID",
+        description=(
+            "UUID stamped on each touched VM's proxbox_last_run_id custom field. "
+            "When omitted, a fresh UUID is generated."
+        ),
+    ),
     overwrite_flags: ResolvedSyncOverwriteFlagsDep = SyncOverwriteFlags(),
 ):
     (
@@ -3724,6 +3762,7 @@ async def create_virtual_machine_by_netbox_id_stream(
                     overwrite_vm_description=overwrite_vm_description,
                     overwrite_vm_custom_fields=overwrite_vm_custom_fields,
                     overwrite_flags=overwrite_flags,
+                    run_id=run_id,
                 )
             finally:
                 await bridge.close()

--- a/proxbox_api/services/sync/individual/vm_sync.py
+++ b/proxbox_api/services/sync/individual/vm_sync.py
@@ -9,7 +9,11 @@ from datetime import datetime, timezone
 from proxbox_api.enum.status_mapping import ProxmoxToNetBoxVMStatus
 from proxbox_api.exception import ProxboxException
 from proxbox_api.logger import logger
-from proxbox_api.netbox_rest import rest_list_async, rest_reconcile_async
+from proxbox_api.netbox_rest import (
+    clear_rest_get_cache_for_path,
+    rest_list_async,
+    rest_reconcile_async,
+)
 from proxbox_api.netbox_version import detect_netbox_version, supports_virtual_machine_type
 from proxbox_api.proxmox_to_netbox.models import (
     NetBoxVirtualMachineCreateBody,
@@ -347,6 +351,7 @@ async def sync_vm_individual(
         px_port = getattr(px, "http_port", 8006)
         px_url = f"https://{px_domain}:{px_port}" if px_domain else None
 
+        clear_rest_get_cache_for_path(nb, "/api/virtualization/virtual-machines/")
         existing_vms = await rest_list_async(
             nb,
             "/api/virtualization/virtual-machines/",

--- a/tests/test_qemu_guest_agent_sync.py
+++ b/tests/test_qemu_guest_agent_sync.py
@@ -191,12 +191,17 @@ def test_vm_sync_fetches_tag_color_map_once_per_cluster_under_concurrency(monkey
         resolved_color_maps.append(color_map)
         return [201]
 
-    async def _fake_rest_create(_nb, _path, payload):
+    async def _fake_rest_create(_nb, _path, payload, **_kwargs):
         vmid = int(payload["custom_fields"]["proxmox_vm_id"])
         return {"id": 1000 + vmid, **payload}
 
     async def _fake_task_history(**_kwargs):
         return 0
+
+    stamp_calls: list[tuple[int, str]] = []
+
+    async def _fake_stamp(_nb, vm_record, run_id):
+        stamp_calls.append((int(vm_record["id"]), str(run_id)))
 
     monkeypatch.setattr(
         "proxbox_api.routes.virtualization.virtual_machines.sync_vm.fetch_tag_color_map",
@@ -214,6 +219,10 @@ def test_vm_sync_fetches_tag_color_map_once_per_cluster_under_concurrency(monkey
         "proxbox_api.routes.virtualization.virtual_machines.sync_vm.sync_virtual_machine_task_history",
         _fake_task_history,
     )
+    monkeypatch.setattr(
+        "proxbox_api.routes.virtualization.virtual_machines.sync_vm.stamp_vm_last_run_id",
+        _fake_stamp,
+    )
 
     result = asyncio.run(
         create_virtual_machines(
@@ -224,12 +233,19 @@ def test_vm_sync_fetches_tag_color_map_once_per_cluster_under_concurrency(monkey
             custom_fields=data["custom_fields"],
             tag=data["tag"],
             sync_vm_network=False,
+            run_id="issue-519-run",
         )
     )
 
     assert len(result) == 4
     assert len(fetch_calls) == 1
     assert resolved_color_maps == [{"critical": "ff5722"}] * 4
+    assert stamp_calls == [
+        (1100, "issue-519-run"),
+        (1101, "issue-519-run"),
+        (1102, "issue-519-run"),
+        (1103, "issue-519-run"),
+    ]
 
 
 def test_vm_sync_prefers_guest_agent_ip(monkeypatch):

--- a/tests/test_sse_stream_output.py
+++ b/tests/test_sse_stream_output.py
@@ -5,6 +5,11 @@ Verifies that the backend produces SSE events in the correct format
 for the plugin to consume. These tests ensure the SSE contract is maintained.
 """
 
+from types import SimpleNamespace
+
+from proxbox_api.routes.virtualization.virtual_machines import sync_vm
+from proxbox_api.schemas.sync import SyncOverwriteFlags
+
 
 class TestPluginAPIPath:
     """Test paths expected by the plugin."""
@@ -105,3 +110,63 @@ class TestNonStreamEndpoints:
         assert resp.headers.get("content-type", "").startswith("application/json")
         data = resp.json()
         assert isinstance(data, dict)
+
+
+async def test_vms_create_stream_forwards_run_id(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def _fake_create_virtual_machines(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(sync_vm, "create_virtual_machines", _fake_create_virtual_machines)
+
+    response = await sync_vm.create_virtual_machines_stream(
+        netbox_session=SimpleNamespace(),
+        pxs=[],
+        cluster_status=[],
+        cluster_resources=[],
+        custom_fields=[],
+        tag=SimpleNamespace(id=7),
+        sync_vm_network=False,
+        overwrite_flags=SyncOverwriteFlags(),
+        run_id="issue-519-run",
+    )
+
+    async for _chunk in response.body_iterator:
+        pass
+
+    assert captured["run_id"] == "issue-519-run"
+    assert captured["sync_vm_network"] is False
+
+
+async def test_vm_by_id_create_stream_forwards_run_id(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def _fake_create_virtual_machine_by_netbox_id(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(
+        sync_vm,
+        "_create_virtual_machine_by_netbox_id",
+        _fake_create_virtual_machine_by_netbox_id,
+    )
+
+    response = await sync_vm.create_virtual_machine_by_netbox_id_stream(
+        netbox_vm_id=248,
+        netbox_session=SimpleNamespace(),
+        pxs=[],
+        cluster_status=[],
+        cluster_resources=[],
+        custom_fields=[],
+        tag=SimpleNamespace(id=7),
+        overwrite_flags=SyncOverwriteFlags(),
+        run_id="issue-519-run",
+    )
+
+    async for _chunk in response.body_iterator:
+        pass
+
+    assert captured["netbox_vm_id"] == 248
+    assert captured["run_id"] == "issue-519-run"

--- a/tests/test_vm_sync_reconciliation_queue.py
+++ b/tests/test_vm_sync_reconciliation_queue.py
@@ -185,11 +185,13 @@ def test_log_vm_reconciliation_measurement_includes_gate_fields(monkeypatch):
 @pytest.mark.asyncio
 async def test_dispatch_vm_operation_queue_runs_writes_sequentially(monkeypatch):
     calls: list[str] = []
+    create_lookups: list[dict[str, object] | None] = []
 
     monkeypatch.setattr(sync_vm, "resolve_netbox_write_concurrency", lambda: 2)
 
-    async def _fake_create(nb, path, payload):
+    async def _fake_create(nb, path, payload, *, lookup=None):
         calls.append(f"create:{payload['custom_fields']['proxmox_vm_id']}")
+        create_lookups.append(lookup)
         vmid = payload["custom_fields"]["proxmox_vm_id"]
         return {"id": 3000 + vmid, **payload}
 
@@ -226,9 +228,32 @@ async def test_dispatch_vm_operation_queue_runs_writes_sequentially(monkeypatch)
     resolved = await sync_vm._dispatch_vm_operation_queue(object(), queue)
 
     assert calls == ["create:201", "patch:4203"]
+    assert create_lookups == [{"cf_proxmox_vm_id": 201, "cluster_id": 1}]
     assert resolved[("cluster-a", 202, "qemu")]["id"] == 4202
     assert resolved[("cluster-a", 201, "qemu")]["id"] == 3201
     assert resolved[("cluster-a", 203, "qemu")]["id"] == 4203
+
+
+@pytest.mark.asyncio
+async def test_load_netbox_virtual_machine_snapshot_can_bypass_stale_cache(monkeypatch):
+    cleared_paths: list[str] = []
+    queries: list[dict[str, object]] = []
+
+    def _fake_clear(nb, path):
+        cleared_paths.append(path)
+
+    async def _fake_list(nb, path, *, query=None):
+        queries.append(dict(query or {}))
+        return [{"id": 55, "name": "vm01", "custom_fields": {"proxmox_vm_id": 101}}]
+
+    monkeypatch.setattr(sync_vm, "clear_rest_get_cache_for_path", _fake_clear)
+    monkeypatch.setattr(sync_vm, "rest_list_async", _fake_list)
+
+    snapshot = await sync_vm._load_netbox_virtual_machine_snapshot(object(), fresh=True)
+
+    assert cleared_paths == ["/api/virtualization/virtual-machines/"]
+    assert queries == [{"limit": 200, "offset": 0}]
+    assert snapshot == [{"id": 55, "name": "vm01", "custom_fields": {"proxmox_vm_id": 101}}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Refs emersonfelipesp/netbox-proxbox#519.

## Summary
- Clear stale NetBox VM GET cache before VM reconciliation snapshots.
- Stamp `proxbox_last_run_id` in the `sync_vm_network=false` VM batch path.
- Forward `run_id` through VM stream routes, including targeted per-VM streams.
- Use VM lookup data for idempotent create retries.

## Tests
- `uv run ruff check proxbox_api/routes/virtualization/virtual_machines/sync_vm.py proxbox_api/services/sync/individual/vm_sync.py tests/test_vm_sync_reconciliation_queue.py tests/test_qemu_guest_agent_sync.py tests/test_sse_stream_output.py`
- `uv run pytest tests/test_vm_sync_reconciliation_queue.py tests/test_qemu_guest_agent_sync.py tests/test_sse_stream_output.py tests/test_session_and_helpers.py tests/test_proxbox_last_run_id_stamp.py tests/test_api_routes.py -q`

## Note
The broad `uv run pytest -q` suite was started but stopped because it was still progressing through long-running integration coverage after the targeted regression suite passed.
