### PR TITLE
feat: implement interface batching in VM sync to prevent NetBox overwhelming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,6 +271,8 @@ Each maps to a key in `ProxboxPluginSettings` and can be edited from the NetBox 
 | `PROXBOX_BACKUP_BATCH_DELAY_MS` | `backup_batch_delay_ms` | 200 ms |
 | `PROXBOX_BULK_BATCH_SIZE` | `bulk_batch_size` | 50 |
 | `PROXBOX_BULK_BATCH_DELAY_MS` | `bulk_batch_delay_ms` | 500 ms |
+| `PROXBOX_INTERFACE_BATCH_SIZE` | `interface_batch_size` | 5 |
+| `PROXBOX_INTERFACE_BATCH_DELAY_MS` | `interface_batch_delay_ms` | 100 ms |
 | `PROXBOX_NETBOX_GET_CACHE_TTL` | `netbox_get_cache_ttl` | 60 s (0 = disabled) |
 | `PROXBOX_NETBOX_GET_CACHE_MAX_ENTRIES` | `netbox_get_cache_max_entries` | 4096 |
 | `PROXBOX_NETBOX_GET_CACHE_MAX_BYTES` | `netbox_get_cache_max_bytes` | 52_428_800 (50 MB) |

--- a/proxbox_api/routes/virtualization/virtual_machines/helpers.py
+++ b/proxbox_api/routes/virtualization/virtual_machines/helpers.py
@@ -31,3 +31,23 @@ def resolve_proxmox_fetch_concurrency() -> int:
         default=8,
         minimum=1,
     )
+
+
+def resolve_interface_batch_size() -> int:
+    """Number of VM interfaces synced per batch (prevents NetBox overwhelming)."""
+    return get_int(
+        settings_key="interface_batch_size",
+        env="PROXBOX_INTERFACE_BATCH_SIZE",
+        default=5,
+        minimum=1,
+    )
+
+
+def resolve_interface_batch_delay_ms() -> int:
+    """Milliseconds to wait between interface batches."""
+    return get_int(
+        settings_key="interface_batch_delay_ms",
+        env="PROXBOX_INTERFACE_BATCH_DELAY_MS",
+        default=100,
+        minimum=0,
+    )

--- a/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
+++ b/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
@@ -2141,7 +2141,21 @@ async def create_virtual_machines(  # noqa: C901
                             )
                         )
 
-                interface_results = await asyncio.gather(*interface_tasks, return_exceptions=True)
+                # Batch interface tasks to prevent overwhelming NetBox with concurrent API calls
+                from proxbox_api.routes.virtualization.virtual_machines.helpers import (
+                    resolve_interface_batch_delay_ms,
+                    resolve_interface_batch_size,
+                )
+
+                batch_size = resolve_interface_batch_size()
+                batch_delay_ms = resolve_interface_batch_delay_ms()
+                interface_results = []
+                for i in range(0, len(interface_tasks), batch_size):
+                    batch = interface_tasks[i : i + batch_size]
+                    batch_results = await asyncio.gather(*batch, return_exceptions=True)
+                    interface_results.extend(batch_results)
+                    if i + batch_size < len(interface_tasks) and batch_delay_ms > 0:
+                        await asyncio.sleep(batch_delay_ms / 1000.0)
                 for result in interface_results:
                     if isinstance(result, Exception):
                         error_detail = getattr(result, "detail", str(result))


### PR DESCRIPTION
## Summary

Implements batching of VM interface synchronization tasks to prevent overwhelming NetBox when syncing VMs with 50+ interfaces.

## Changes

- Added resolve_interface_batch_size() and resolve_interface_batch_delay_ms() helper functions
- Replaced unbounded asyncio.gather() with batched loop in sync_vm.py
- Updated CLAUDE.md with new environment variables

## How It Works

Interfaces are now synced in configurable batches (default 5):
- Process 5 interfaces concurrently
- Wait 100ms between batches
- Prevents resource exhaustion while maintaining parallelism

## Test Plan

- Verify batching works with large VM interface counts
- Confirm plugin settings are read correctly
- Check environment variable overrides work
- Validate no regressions in existing interface sync