### PR TITLE
Ceph v2: orchestration API, plan/apply engine, and operation runs

### DIFF
--- a/proxbox_api/app/factory.py
+++ b/proxbox_api/app/factory.py
@@ -489,6 +489,12 @@ def create_app() -> FastAPI:  # noqa: C901
             logger.info("Ceph subpackage unavailable; /ceph/* routes disabled (%s)", exc)
         else:
             app.include_router(ceph_router, prefix="/ceph", tags=["ceph"])
+        try:
+            from proxbox_api.ceph.v2_routes import router as ceph_v2_router  # noqa: PLC0415
+        except ImportError as exc:
+            logger.info("Ceph v2 subpackage unavailable; /ceph/v2/* routes disabled (%s)", exc)
+        else:
+            app.include_router(ceph_v2_router, prefix="/ceph/v2", tags=["ceph-v2"])
 
     if include_pdm:
         try:

--- a/proxbox_api/ceph/CLAUDE.md
+++ b/proxbox_api/ceph/CLAUDE.md
@@ -1,0 +1,70 @@
+# proxbox_api/ceph Directory Guide
+
+## Workspace Context
+
+This file lives at `/root/personal-context/nmulticloud-context/proxbox-api/proxbox_api/ceph/CLAUDE.md` inside the `personal-context` workspace.
+Workspace guidance: `/root/personal-context/CLAUDE.md`.
+Per-repo deep-dive: `/root/personal-context/claude-reference/proxbox-api.md`.
+
+---
+
+## Purpose
+
+Ceph integration surface for `proxbox-api`. Two layers:
+
+- **v1 (`/ceph`)** — read-only reflected inventory of Proxmox-managed Ceph
+  (`routes.py`, `schemas.py`, `client.py`). Status + sync endpoints; every sync
+  route accepts `netbox_branch_schema_id`.
+- **v2 (`/ceph/v2`)** — the NetBox-driven control plane (issue #95). Lets NetBox
+  fully configure Ceph desired-state without direct operator access to Proxmox
+  or external Ceph tooling.
+
+Both routers are mounted in `proxbox_api/app/factory.py` (`/ceph` and `/ceph/v2`).
+
+## v2 Files
+
+| File | Role |
+|------|------|
+| `v2_schemas.py` | Pydantic contract: `DesiredObject`/`DesiredStateBundle`, `PlanRequest`/`PlanResponse`, `ProviderOperation`, `ValidationResult`/`ValidationResponse`, `ApplyRequest`, `ReconcileRequest`, `OperationRun`, `ProviderCapabilities`/`CapabilitiesResponse`, `MetricsResponse`, `SSEEvent`. Requests expose a `branch_schema_id` property = `netbox_branch_schema_id or source_branch_schema_id`. |
+| `v2_engine.py` | Plan/apply engine: `validate_payload`, `build_plan`, `remember_plan`/`get_plan` (in-process plan store), `apply_plan`, `reconcile_provider`, `record_to_operation_run`, `redact_secrets`. Deterministic ordered plans, capability-aware (unsupported ops are **blocked with a reason**, never silently skipped), destructive-op confirmation gating, idempotent re-apply (`completed_run_for_plan`), and run persistence. |
+| `v2_providers/base.py` | `CephProviderAdapter` ABC (`capabilities`, `read_state`, `diff`, `plan`, `apply`, `reconcile`, `metrics`) + `CephCapabilityUnsupported`. |
+| `v2_providers/proxmox.py` | `ProxmoxCephProviderAdapter` — read-only today (writes raise `CephCapabilityUnsupported`; enabled by proxmox-sdk #12). |
+| `v2_providers/__init__.py` | Adapter registry: `adapter_for_provider(provider, pxs)`, `provider_names()`. Stub adapters for `dashboard` (#98), `rgw_admin` (#12), `rbd` (#12), `prometheus` (#94), `external` (#97). |
+| `v2_routes.py` | FastAPI router for all `/ceph/v2/*` endpoints (thin; delegates to the engine). |
+
+## Endpoint Map (`/ceph/v2`)
+
+| Method + Path | Purpose |
+|---|---|
+| `GET /capabilities` | Per-provider capability flags for UI gating |
+| `POST /validate` | Validate a desired object or full bundle |
+| `POST /plans`, `GET /plans/{id}`, `POST /plans/{id}/apply` | Resource-style plan build / inspect / apply |
+| `POST /plan`, `POST /apply` | Flat client-contract aliases the `netbox-ceph` orchestrator calls |
+| `GET /operations/{id}` | Operation run status, task refs, warnings, errors, result |
+| `GET /operations/{id}/events` | SSE operation-progress stream (`text/event-stream`) |
+| `POST /reconcile` | Reconcile provider state back into NetBox summaries |
+| `GET /metrics` | Latest provider metrics for a scope |
+
+Persistence: `CephOperationRunRecord` (SQLModel, `ceph_operation_run` table in
+`proxbox_api/database.py`), created by the standard `SQLModel.metadata.create_all`.
+
+## Rules
+
+- **Secrets never reach NetBox.** Providers resolve real credentials behind the
+  adapter layer; the engine runs `redact_secrets()` on stored/logged payloads.
+  NetBox passes only opaque `credential_ref` pointers.
+- **No silent capability gaps.** Unsupported operations are surfaced as blocked
+  with a reason; destructive operations require explicit confirmation.
+- **Thread the branch id.** Pass `netbox_branch_schema_id` through
+  plan/apply/reconcile so branch-aware NetBox staging stays consistent.
+- v2 is additive; do not change v1 `/ceph` behavior.
+- The Proxmox adapter is read-only until proxmox-sdk #12 lands write-capable
+  Ceph clients; Dashboard/RGW/RBD/Prometheus/external adapters arrive with
+  #98/#12/#94/#97.
+
+## Tests
+
+`tests/ceph/test_v2_orchestration.py` — capabilities, validate, plan
+build/get/404, happy-path apply, destructive-confirmation gating,
+capability-blocked apply, idempotent re-apply, operation lookup/404, SSE shape,
+reconcile, metrics (fake adapter; no live cluster).

--- a/proxbox_api/ceph/v2_engine.py
+++ b/proxbox_api/ceph/v2_engine.py
@@ -1,0 +1,667 @@
+"""Ceph v2 plan/apply engine."""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timezone
+from typing import Any
+from uuid import NAMESPACE_URL, uuid4, uuid5
+
+from pydantic import BaseModel, ValidationError
+from sqlmodel import select
+
+from proxbox_api.ceph.v2_providers.base import CephCapabilityUnsupported, CephProviderAdapter
+from proxbox_api.ceph.v2_schemas import (
+    ApplyRequest,
+    DesiredObject,
+    DesiredStateBundle,
+    OperationRun,
+    PlanRequest,
+    PlanResponse,
+    ProviderCapabilities,
+    ProviderOperation,
+    ReconcileRequest,
+    ValidationResponse,
+    ValidationResult,
+)
+from proxbox_api.database import CephOperationRunRecord
+from proxbox_api.utils.async_compat import maybe_await as _maybe_await
+
+_PLAN_STORE: dict[str, PlanResponse] = {}
+_PLAN_STORE_ORDER: list[str] = []
+_PLAN_STORE_LIMIT = 512
+_SECRET_KEY_FRAGMENTS = ("password", "secret", "token", "private_key", "access_key")
+_DESTRUCTIVE_ACTIONS = {"delete", "destroy", "purge", "remove", "zap"}
+_DESTRUCTIVE_KIND_ACTIONS = {
+    "osd": _DESTRUCTIVE_ACTIONS,
+    "pool": _DESTRUCTIVE_ACTIONS,
+    "rbd": _DESTRUCTIVE_ACTIONS,
+    "rbd_image": _DESTRUCTIVE_ACTIONS,
+    "rgw_bucket": _DESTRUCTIVE_ACTIONS,
+    "crush": _DESTRUCTIVE_ACTIONS,
+    "crush_rule": _DESTRUCTIVE_ACTIONS,
+    "key": _DESTRUCTIVE_ACTIONS,
+    "user": _DESTRUCTIVE_ACTIONS,
+}
+
+
+class CephPlanNotFound(KeyError):
+    """Raised when a plan id is not present in the in-process plan store."""
+
+
+class CephApplyError(RuntimeError):
+    """Route-facing apply error with a persisted run when one was created."""
+
+    def __init__(
+        self,
+        status_code: int,
+        detail: dict[str, Any],
+        run: OperationRun | None = None,
+    ) -> None:
+        super().__init__(str(detail))
+        self.status_code = status_code
+        self.detail = detail
+        self.run = run
+
+
+def utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _dt_from_ts(value: float) -> datetime:
+    return datetime.fromtimestamp(value, timezone.utc)
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        return value.model_dump(mode="json", exclude_none=True)
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, list | tuple | set):
+        return [_jsonable(item) for item in value]
+    try:
+        json.dumps(value)
+    except TypeError:
+        return str(value)
+    return value
+
+
+def redact_secrets(value: Any) -> Any:
+    """Return a JSON-safe copy with secret-bearing fields redacted."""
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="json", exclude_none=True)
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            key_string = str(key)
+            lowered = key_string.lower()
+            if lowered == "credential_ref":
+                redacted[key_string] = _jsonable(item)
+            elif any(fragment in lowered for fragment in _SECRET_KEY_FRAGMENTS):
+                redacted[key_string] = "[REDACTED]"
+            else:
+                redacted[key_string] = redact_secrets(item)
+        return redacted
+    if isinstance(value, list | tuple | set):
+        return [redact_secrets(item) for item in value]
+    return _jsonable(value)
+
+
+def remember_plan(plan: PlanResponse) -> None:
+    _PLAN_STORE[plan.id] = plan
+    _PLAN_STORE_ORDER.append(plan.id)
+    while len(_PLAN_STORE_ORDER) > _PLAN_STORE_LIMIT:
+        old_id = _PLAN_STORE_ORDER.pop(0)
+        _PLAN_STORE.pop(old_id, None)
+
+
+def get_plan(plan_id: str) -> PlanResponse:
+    try:
+        return _PLAN_STORE[plan_id]
+    except KeyError as exc:
+        raise CephPlanNotFound(plan_id) from exc
+
+
+def validation_results_for_request(request: PlanRequest) -> list[ValidationResult]:
+    results: list[ValidationResult] = []
+    for desired in request.desired_state.objects:
+        target = desired.target_ref or desired.name
+        if not target:
+            results.append(
+                ValidationResult(
+                    severity="error",
+                    code="target_ref_required",
+                    message="Desired Ceph objects require target_ref, ref, name, or payload.name.",
+                    target=desired.kind,
+                )
+            )
+    for operation in request.operations:
+        if not operation.target_ref:
+            results.append(
+                ValidationResult(
+                    severity="error",
+                    code="target_ref_required",
+                    message="Provider operations require target_ref, ref, target, or name.",
+                    target=operation.kind,
+                )
+            )
+    return results
+
+
+def validate_payload(payload: dict[str, Any]) -> ValidationResponse:
+    try:
+        if "kind" in payload and "desired_state" not in payload and "objects" not in payload:
+            desired = DesiredObject.model_validate(payload)
+            request = PlanRequest(desired_state=DesiredStateBundle(objects=[desired]))
+        else:
+            request = PlanRequest.model_validate(payload)
+    except ValidationError as exc:
+        return ValidationResponse(
+            valid=False,
+            results=[
+                ValidationResult(
+                    severity="error",
+                    code="schema_validation_failed",
+                    message=str(error.get("msg") or "schema validation failed"),
+                    target=".".join(str(part) for part in error.get("loc", ())) or None,
+                )
+                for error in exc.errors()
+            ],
+        )
+    results = validation_results_for_request(request)
+    return ValidationResponse(
+        valid=not any(result.severity == "error" for result in results), results=results
+    )
+
+
+def _stable_operation_id(operation: ProviderOperation) -> str:
+    payload = operation.model_dump(
+        mode="json",
+        exclude_none=True,
+        exclude={"id", "supported", "blocked_reason"},
+    )
+    serialized = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return str(uuid5(NAMESPACE_URL, serialized))
+
+
+def _normalize_operation(
+    operation: ProviderOperation,
+    capabilities: ProviderCapabilities,
+) -> ProviderOperation:
+    op = operation.model_copy(deep=True)
+    op.provider = capabilities.provider
+    op.kind = op.kind.strip().lower().replace("-", "_")
+    op.action = op.action.strip().lower() or "ensure"
+    op.is_destructive = op.is_destructive or _is_destructive(op)
+    op.id = op.id or _stable_operation_id(op)
+
+    if not op.target_ref:
+        op.supported = False
+        op.blocked_reason = "target_ref is required for Ceph provider operations."
+    elif not capabilities.supported:
+        op.supported = False
+        op.blocked_reason = f"provider {capabilities.provider!r} is not implemented."
+    elif op.supported and not _provider_supports_operation(capabilities, op):
+        op.supported = False
+        op.blocked_reason = (
+            f"provider {capabilities.provider!r} does not support {op.action} for {op.kind}."
+        )
+    elif not op.supported and not op.blocked_reason:
+        op.blocked_reason = "provider operation is marked unsupported."
+    return op
+
+
+def _provider_supports_operation(
+    capabilities: ProviderCapabilities,
+    operation: ProviderOperation,
+) -> bool:
+    if operation.action == "noop":
+        return True
+    keys = (
+        f"{operation.kind}:{operation.action}",
+        f"{operation.kind}:*",
+        operation.action,
+        operation.kind,
+    )
+    for key in keys:
+        if key in capabilities.operation_kinds:
+            return capabilities.operation_kinds[key]
+    return capabilities.apply
+
+
+def _is_destructive(operation: ProviderOperation) -> bool:
+    action = operation.action.strip().lower()
+    kind = operation.kind.strip().lower().replace("-", "_")
+    if action in _DESTRUCTIVE_ACTIONS:
+        return True
+    return action in _DESTRUCTIVE_KIND_ACTIONS.get(kind, set())
+
+
+def _operation_priority(operation: ProviderOperation) -> tuple[int, str, str, str]:
+    action = operation.action
+    priority = {
+        "noop": 0,
+        "create": 10,
+        "ensure": 20,
+        "update": 30,
+        "set": 30,
+        "delete": 90,
+        "destroy": 90,
+        "purge": 90,
+        "remove": 90,
+        "zap": 90,
+    }.get(action, 50)
+    return (priority, operation.kind, operation.target_ref, operation.id or "")
+
+
+def _generic_operations_from_desired(
+    request: PlanRequest,
+    provider: str,
+) -> list[ProviderOperation]:
+    operations: list[ProviderOperation] = []
+    for desired in request.desired_state.objects:
+        target_ref = desired.target_ref or desired.name or ""
+        operations.append(
+            ProviderOperation(
+                provider=provider,
+                kind=desired.kind,
+                target_ref=str(target_ref),
+                action=desired.action,
+                after_summary=desired.payload,
+            )
+        )
+    return operations
+
+
+async def _raw_operations(
+    request: PlanRequest,
+    adapter: CephProviderAdapter,
+    capabilities: ProviderCapabilities,
+) -> tuple[list[ProviderOperation], dict[str, Any]]:
+    if request.operations:
+        return request.operations, {}
+
+    if not capabilities.supported:
+        return _generic_operations_from_desired(request, capabilities.provider), {}
+
+    live = await adapter.read_state(request.scope or request.desired_state.scope)
+    operations = await adapter.diff(request.desired_state, live)
+    return operations, live
+
+
+async def build_plan(
+    request: PlanRequest,
+    adapter: CephProviderAdapter,
+) -> PlanResponse:
+    capabilities = await adapter.capabilities()
+    validations = validation_results_for_request(request)
+    warnings = list(capabilities.notes)
+
+    if any(result.severity == "error" for result in validations):
+        operations: list[ProviderOperation] = []
+        live: dict[str, Any] = {}
+    else:
+        try:
+            operations, live = await _raw_operations(request, adapter, capabilities)
+            if capabilities.supported and capabilities.plan:
+                operations = await adapter.plan(operations)
+        except CephCapabilityUnsupported as exc:
+            warnings.append(str(exc))
+            operations = _generic_operations_from_desired(request, capabilities.provider)
+            live = {}
+
+    normalized = sorted(
+        (_normalize_operation(operation, capabilities) for operation in operations),
+        key=_operation_priority,
+    )
+    blocked_actions = [operation for operation in normalized if not operation.supported]
+    branch_id = request.branch_schema_id
+    plan = PlanResponse(
+        id=str(uuid4()),
+        provider=capabilities.provider,
+        netbox_branch_schema_id=branch_id,
+        source_branch_schema_id=branch_id,
+        operations=normalized,
+        validations=validations,
+        warnings=warnings,
+        blocked_actions=blocked_actions,
+        created_at=utcnow(),
+        live_state_summary=_jsonable(live.get("summary", {})) if isinstance(live, dict) else {},
+        request_summary=redact_secrets(request),
+    )
+    remember_plan(plan)
+    return plan
+
+
+async def _commit_and_refresh(session: object, record: CephOperationRunRecord) -> None:
+    await _maybe_await(session.commit())
+    await _maybe_await(session.refresh(record))
+
+
+async def _create_run(
+    session: object,
+    *,
+    plan: PlanResponse | None,
+    provider: str,
+    actor: str | None,
+    branch_schema_id: str | None,
+    request_summary: dict[str, Any],
+    status: str = "running",
+    warnings: list[str] | None = None,
+    errors: list[str] | None = None,
+    result_summary: dict[str, Any] | None = None,
+) -> CephOperationRunRecord:
+    now = time.time()
+    record = CephOperationRunRecord(
+        id=str(uuid4()),
+        plan_id=plan.id if plan is not None else None,
+        status=status,
+        actor=actor,
+        source_branch_schema_id=branch_schema_id,
+        provider=provider,
+        request_summary=redact_secrets(request_summary),
+        provider_task_refs=[],
+        created_at=now,
+        updated_at=now,
+        warnings=warnings or [],
+        errors=errors or [],
+        result_summary=result_summary or {},
+    )
+    session.add(record)
+    await _commit_and_refresh(session, record)
+    return record
+
+
+async def _update_run(
+    session: object,
+    record: CephOperationRunRecord,
+    *,
+    status: str,
+    provider_task_refs: list[str] | None = None,
+    warnings: list[str] | None = None,
+    errors: list[str] | None = None,
+    result_summary: dict[str, Any] | None = None,
+) -> CephOperationRunRecord:
+    record.status = status
+    record.updated_at = time.time()
+    if provider_task_refs is not None:
+        record.provider_task_refs = list(provider_task_refs)
+    if warnings is not None:
+        record.warnings = list(warnings)
+    if errors is not None:
+        record.errors = list(errors)
+    if result_summary is not None:
+        record.result_summary = redact_secrets(result_summary)
+    session.add(record)
+    await _commit_and_refresh(session, record)
+    return record
+
+
+async def completed_run_for_plan(
+    session: object,
+    plan_id: str,
+) -> OperationRun | None:
+    result = await _maybe_await(
+        session.exec(
+            select(CephOperationRunRecord)
+            .where(CephOperationRunRecord.plan_id == plan_id)
+            .where(CephOperationRunRecord.status == "completed")
+            .order_by(CephOperationRunRecord.created_at.desc())
+        )
+    )
+    record = result.first()
+    if record is None:
+        return None
+    run = record_to_operation_run(record)
+    run.result_summary = {**run.result_summary, "idempotent_replay": True}
+    return run
+
+
+def _confirmation_satisfied(plan: PlanResponse, request: ApplyRequest) -> bool:
+    if request.confirm_destructive:
+        return True
+    return request.confirmation_token in {
+        plan.id,
+        f"confirm:{plan.id}",
+        f"confirm-destructive:{plan.id}",
+    }
+
+
+def _task_refs_from_result(result: dict[str, Any]) -> list[str]:
+    refs: list[str] = []
+    value = result.get("provider_task_ref")
+    if value:
+        refs.append(str(value))
+    values = result.get("provider_task_refs")
+    if isinstance(values, list):
+        refs.extend(str(item) for item in values if item)
+    upid = result.get("upid")
+    if upid:
+        refs.append(str(upid))
+    return refs
+
+
+async def _raise_with_run(
+    session: object,
+    *,
+    plan: PlanResponse,
+    request: ApplyRequest,
+    status_code: int,
+    status: str,
+    reason: str,
+    errors: list[str],
+) -> None:
+    run_record = await _create_run(
+        session,
+        plan=plan,
+        provider=plan.provider,
+        actor=request.actor,
+        branch_schema_id=request.branch_schema_id or plan.source_branch_schema_id,
+        request_summary={
+            "plan_id": plan.id,
+            "reason": reason,
+            "operations": [operation.model_dump(mode="json") for operation in plan.operations],
+        },
+        status=status,
+        warnings=plan.warnings,
+        errors=errors,
+        result_summary={"reason": reason, "applied": 0, "total": len(plan.operations)},
+    )
+    run = record_to_operation_run(run_record)
+    raise CephApplyError(
+        status_code,
+        {
+            "reason": reason,
+            "detail": errors[0] if errors else reason,
+            "operation_run_id": run.id,
+            "plan_id": plan.id,
+        },
+        run,
+    )
+
+
+async def apply_plan(
+    plan: PlanResponse,
+    request: ApplyRequest,
+    adapter: CephProviderAdapter,
+    session: object,
+) -> OperationRun:
+    existing = await completed_run_for_plan(session, plan.id)
+    if existing is not None:
+        return existing
+
+    validation_errors = [item.message for item in plan.validations if item.severity == "error"]
+    if validation_errors:
+        await _raise_with_run(
+            session,
+            plan=plan,
+            request=request,
+            status_code=422,
+            status="failed",
+            reason="plan_validation_failed",
+            errors=validation_errors,
+        )
+
+    blockers = [operation for operation in plan.operations if not operation.supported]
+    if blockers:
+        await _raise_with_run(
+            session,
+            plan=plan,
+            request=request,
+            status_code=409,
+            status="blocked",
+            reason="plan_has_blocked_operations",
+            errors=[
+                operation.blocked_reason or "provider operation is blocked"
+                for operation in blockers
+            ],
+        )
+
+    destructive = [operation for operation in plan.operations if operation.is_destructive]
+    if destructive and not _confirmation_satisfied(plan, request):
+        await _raise_with_run(
+            session,
+            plan=plan,
+            request=request,
+            status_code=409,
+            status="failed",
+            reason="destructive_confirmation_required",
+            errors=[
+                "Destructive Ceph operations require confirm_destructive=true or "
+                f"confirmation_token='confirm-destructive:{plan.id}'."
+            ],
+        )
+
+    run_record = await _create_run(
+        session,
+        plan=plan,
+        provider=plan.provider,
+        actor=request.actor,
+        branch_schema_id=request.branch_schema_id or plan.source_branch_schema_id,
+        request_summary={
+            "plan_id": plan.id,
+            "operations": [operation.model_dump(mode="json") for operation in plan.operations],
+        },
+        warnings=plan.warnings,
+    )
+
+    task_refs: list[str] = []
+    results: list[dict[str, Any]] = []
+    errors: list[str] = []
+    for operation in plan.operations:
+        try:
+            result = await adapter.apply(
+                operation,
+                confirm_destructive=_confirmation_satisfied(plan, request),
+            )
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"{operation.action} {operation.kind} {operation.target_ref}: {exc}")
+            break
+        task_refs.extend(_task_refs_from_result(result))
+        results.append(redact_secrets(result))
+
+    if errors:
+        updated = await _update_run(
+            session,
+            run_record,
+            status="failed",
+            provider_task_refs=task_refs,
+            warnings=plan.warnings,
+            errors=errors,
+            result_summary={
+                "applied": len(results),
+                "total": len(plan.operations),
+                "results": results,
+            },
+        )
+        return record_to_operation_run(updated)
+
+    updated = await _update_run(
+        session,
+        run_record,
+        status="completed",
+        provider_task_refs=task_refs,
+        warnings=plan.warnings,
+        errors=[],
+        result_summary={
+            "applied": len(results),
+            "noop": sum(1 for operation in plan.operations if operation.action == "noop"),
+            "total": len(plan.operations),
+            "destructive": len(destructive),
+            "results": results,
+        },
+    )
+    return record_to_operation_run(updated)
+
+
+async def reconcile_provider(
+    request: ReconcileRequest,
+    adapter: CephProviderAdapter,
+    session: object,
+) -> OperationRun:
+    capabilities = await adapter.capabilities()
+    run_record = await _create_run(
+        session,
+        plan=None,
+        provider=capabilities.provider,
+        actor=request.actor,
+        branch_schema_id=request.branch_schema_id,
+        request_summary={"scope": request.scope, "operation": "reconcile"},
+        warnings=capabilities.notes,
+    )
+    try:
+        result = await adapter.reconcile(request.scope)
+    except Exception as exc:  # noqa: BLE001
+        updated = await _update_run(
+            session,
+            run_record,
+            status="failed",
+            warnings=capabilities.notes,
+            errors=[str(exc)],
+            result_summary={"operation": "reconcile", "result": "failed"},
+        )
+        return record_to_operation_run(updated)
+
+    updated = await _update_run(
+        session,
+        run_record,
+        status="completed",
+        warnings=capabilities.notes,
+        errors=[],
+        result_summary=redact_secrets(result),
+    )
+    return record_to_operation_run(updated)
+
+
+def record_to_operation_run(record: CephOperationRunRecord) -> OperationRun:
+    return OperationRun(
+        id=record.id,
+        plan_id=record.plan_id,
+        status=record.status,  # type: ignore[arg-type]
+        actor=record.actor,
+        source_branch_schema_id=record.source_branch_schema_id,
+        provider=record.provider,
+        request_summary=record.request_summary or {},
+        provider_task_refs=record.provider_task_refs or [],
+        created_at=_dt_from_ts(record.created_at),
+        updated_at=_dt_from_ts(record.updated_at),
+        warnings=record.warnings or [],
+        errors=record.errors or [],
+        result_summary=record.result_summary or {},
+    )
+
+
+__all__ = [
+    "CephApplyError",
+    "CephPlanNotFound",
+    "apply_plan",
+    "build_plan",
+    "completed_run_for_plan",
+    "get_plan",
+    "reconcile_provider",
+    "record_to_operation_run",
+    "redact_secrets",
+    "utcnow",
+    "validate_payload",
+]

--- a/proxbox_api/ceph/v2_providers/__init__.py
+++ b/proxbox_api/ceph/v2_providers/__init__.py
@@ -1,0 +1,49 @@
+"""Ceph v2 provider adapter registry."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from proxbox_api.ceph.v2_providers.base import (
+    CephProviderAdapter,
+    DashboardCephProviderAdapter,
+    ExternalCephProviderAdapter,
+    PrometheusCephProviderAdapter,
+    RBDCephProviderAdapter,
+    RGWAdminCephProviderAdapter,
+)
+from proxbox_api.ceph.v2_providers.proxmox import ProxmoxCephProviderAdapter
+
+ProviderFactory = Callable[[list[object] | None], CephProviderAdapter]
+
+
+def _normalize_provider(provider: str | None) -> str:
+    return (provider or "proxmox").strip().lower().replace("-", "_")
+
+
+_REGISTRY: dict[str, ProviderFactory] = {
+    "proxmox": ProxmoxCephProviderAdapter,
+    "dashboard": DashboardCephProviderAdapter,
+    "rgw_admin": RGWAdminCephProviderAdapter,
+    "rbd": RBDCephProviderAdapter,
+    "prometheus": PrometheusCephProviderAdapter,
+    "external": ExternalCephProviderAdapter,
+}
+
+
+def provider_names() -> list[str]:
+    return sorted(_REGISTRY)
+
+
+def adapter_for_provider(
+    provider: str | None, pxs: list[object] | None = None
+) -> CephProviderAdapter:
+    name = _normalize_provider(provider)
+    factory = _REGISTRY.get(name, ExternalCephProviderAdapter)
+    return factory(pxs)
+
+
+__all__ = [
+    "adapter_for_provider",
+    "provider_names",
+]

--- a/proxbox_api/ceph/v2_providers/base.py
+++ b/proxbox_api/ceph/v2_providers/base.py
@@ -1,0 +1,145 @@
+"""Ceph v2 provider adapter interface and unsupported-provider stubs."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from proxbox_api.ceph.v2_schemas import (
+    DesiredStateBundle,
+    ProviderCapabilities,
+    ProviderOperation,
+)
+
+
+class CephCapabilityUnsupported(RuntimeError):
+    """Raised when a Ceph v2 provider or operation is not implemented yet."""
+
+
+class CephProviderAdapter(ABC):
+    """Provider adapter contract for the Ceph v2 plan/apply engine."""
+
+    provider: str
+
+    @abstractmethod
+    async def capabilities(self) -> ProviderCapabilities:
+        """Return the adapter's supported Ceph v2 capabilities."""
+
+    @abstractmethod
+    async def read_state(self, scope: dict[str, Any]) -> dict[str, Any]:
+        """Read current provider state for the requested scope."""
+
+    @abstractmethod
+    async def diff(
+        self,
+        desired: DesiredStateBundle,
+        live: dict[str, Any],
+    ) -> list[ProviderOperation]:
+        """Compare desired and live state and return raw provider operations."""
+
+    @abstractmethod
+    async def plan(self, operations: list[ProviderOperation]) -> list[ProviderOperation]:
+        """Normalize raw operations into provider-ready plan operations."""
+
+    @abstractmethod
+    async def apply(
+        self,
+        operation: ProviderOperation,
+        *,
+        confirm_destructive: bool,
+    ) -> dict[str, Any]:
+        """Apply one provider operation."""
+
+    @abstractmethod
+    async def reconcile(self, scope: dict[str, Any]) -> dict[str, Any]:
+        """Run provider reconciliation for the requested scope."""
+
+    @abstractmethod
+    async def metrics(self, scope: dict[str, Any]) -> dict[str, Any]:
+        """Return provider metrics for the requested scope."""
+
+
+class UnsupportedCephProviderAdapter(CephProviderAdapter):
+    """Stub adapter for provider integrations tracked by follow-up issues."""
+
+    provider = "unsupported"
+    followup = "follow-up issue"
+
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        pass
+
+    async def capabilities(self) -> ProviderCapabilities:
+        return ProviderCapabilities(
+            provider=self.provider,
+            supported=False,
+            notes=[f"{self.provider} provider is a stub pending {self.followup}."],
+        )
+
+    def _unsupported(self) -> CephCapabilityUnsupported:
+        return CephCapabilityUnsupported(
+            f"Ceph v2 provider {self.provider!r} is not implemented yet; pending {self.followup}."
+        )
+
+    async def read_state(self, scope: dict[str, Any]) -> dict[str, Any]:  # noqa: ARG002
+        raise self._unsupported()
+
+    async def diff(
+        self,
+        desired: DesiredStateBundle,  # noqa: ARG002
+        live: dict[str, Any],  # noqa: ARG002
+    ) -> list[ProviderOperation]:
+        raise self._unsupported()
+
+    async def plan(self, operations: list[ProviderOperation]) -> list[ProviderOperation]:  # noqa: ARG002
+        raise self._unsupported()
+
+    async def apply(
+        self,
+        operation: ProviderOperation,  # noqa: ARG002
+        *,
+        confirm_destructive: bool,  # noqa: ARG002
+    ) -> dict[str, Any]:
+        raise self._unsupported()
+
+    async def reconcile(self, scope: dict[str, Any]) -> dict[str, Any]:  # noqa: ARG002
+        raise self._unsupported()
+
+    async def metrics(self, scope: dict[str, Any]) -> dict[str, Any]:  # noqa: ARG002
+        raise self._unsupported()
+
+
+class DashboardCephProviderAdapter(UnsupportedCephProviderAdapter):
+    provider = "dashboard"
+    followup = "#98"
+
+
+class RGWAdminCephProviderAdapter(UnsupportedCephProviderAdapter):
+    provider = "rgw_admin"
+    followup = "#94"
+
+
+class RBDCephProviderAdapter(UnsupportedCephProviderAdapter):
+    provider = "rbd"
+    followup = "#12"
+
+
+class PrometheusCephProviderAdapter(UnsupportedCephProviderAdapter):
+    provider = "prometheus"
+    followup = "#97"
+
+
+class ExternalCephProviderAdapter(UnsupportedCephProviderAdapter):
+    provider = "external"
+    followup = "external-provider implementation"
+
+
+__all__ = [
+    "CephCapabilityUnsupported",
+    "CephProviderAdapter",
+    "DashboardCephProviderAdapter",
+    "ExternalCephProviderAdapter",
+    "PrometheusCephProviderAdapter",
+    "RBDCephProviderAdapter",
+    "RGWAdminCephProviderAdapter",
+    "UnsupportedCephProviderAdapter",
+]

--- a/proxbox_api/ceph/v2_providers/proxmox.py
+++ b/proxbox_api/ceph/v2_providers/proxmox.py
@@ -1,0 +1,289 @@
+"""Proxmox-backed Ceph v2 provider adapter."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException
+
+from proxbox_api.ceph.routes import _client_for, _node_names, _session_host, _session_name
+from proxbox_api.ceph.v2_providers.base import CephCapabilityUnsupported, CephProviderAdapter
+from proxbox_api.ceph.v2_schemas import (
+    DesiredObject,
+    DesiredStateBundle,
+    ProviderCapabilities,
+    ProviderOperation,
+)
+from proxbox_api.logger import logger
+
+
+def _plain(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(key): _plain(item) for key, item in value.items()}
+    if isinstance(value, list | tuple | set):
+        return [_plain(item) for item in value]
+    if hasattr(value, "model_dump") and callable(value.model_dump):
+        return _plain(value.model_dump(mode="json"))
+    if hasattr(value, "dict") and callable(value.dict):
+        return _plain(value.dict())
+    if hasattr(value, "__dict__") and not isinstance(value, type):
+        return {
+            str(key): _plain(item)
+            for key, item in vars(value).items()
+            if not str(key).startswith("_")
+        }
+    return value
+
+
+def _resource_name(payload: Any) -> str | None:
+    plain = _plain(payload)
+    if not isinstance(plain, dict):
+        return None
+    for key in ("name", "pool", "pool_name", "id", "rule_name", "fs_name"):
+        value = plain.get(key)
+        if value not in (None, ""):
+            return str(value)
+    return None
+
+
+def _normalize_kind(kind: str) -> str:
+    cleaned = kind.strip().lower().replace("-", "_")
+    aliases = {
+        "pools": "pool",
+        "osds": "osd",
+        "cephfs": "filesystem",
+        "fs": "filesystem",
+        "filesystems": "filesystem",
+        "crush_rules": "crush_rule",
+        "rules": "crush_rule",
+    }
+    return aliases.get(cleaned, cleaned)
+
+
+def _desired_target(desired: DesiredObject) -> str:
+    target = desired.target_ref or desired.name
+    if target:
+        return str(target)
+    payload_name = _resource_name(desired.payload)
+    return payload_name or ""
+
+
+def _payload_matches(desired_payload: dict[str, Any], live_summary: dict[str, Any]) -> bool:
+    if not desired_payload:
+        return True
+    for key, value in desired_payload.items():
+        if key not in live_summary:
+            return False
+        if _plain(live_summary[key]) != _plain(value):
+            return False
+    return True
+
+
+class ProxmoxCephProviderAdapter(CephProviderAdapter):
+    """Read-only Ceph v2 adapter backed by resolved Proxmox sessions."""
+
+    provider = "proxmox"
+
+    def __init__(self, pxs: list[object] | None = None) -> None:
+        self._pxs = list(pxs or [])
+
+    async def capabilities(self) -> ProviderCapabilities:
+        return ProviderCapabilities(
+            provider=self.provider,
+            supported=True,
+            read_state=True,
+            diff=True,
+            plan=True,
+            apply=False,
+            reconcile=True,
+            metrics=True,
+            operation_kinds={
+                "noop": True,
+                "pool:noop": True,
+                "osd:noop": True,
+                "filesystem:noop": True,
+                "crush_rule:noop": True,
+                "flag:noop": True,
+            },
+            notes=[
+                "Proxmox Ceph v2 adapter currently reads and plans from PVE Ceph state. "
+                "Write operations are blocked until guarded write support is implemented."
+            ],
+        )
+
+    async def read_state(self, scope: dict[str, Any]) -> dict[str, Any]:  # noqa: ARG002
+        clusters: list[dict[str, Any]] = []
+        resources: list[dict[str, Any]] = []
+        errors: list[str] = []
+
+        for px in self._pxs:
+            cluster = {
+                "provider": self.provider,
+                "name": _session_name(px),
+                "host": _session_host(px),
+                "nodes": _node_names(px),
+                "status": None,
+                "metadata": None,
+                "flags": [],
+                "errors": [],
+            }
+            try:
+                client = _client_for(px)
+            except HTTPException as exc:
+                message = str(exc.detail)
+                cluster["errors"].append(message)
+                errors.append(message)
+                clusters.append(cluster)
+                continue
+
+            try:
+                cluster["status"] = _plain(await client.cluster.status())
+                cluster["metadata"] = _plain(await client.cluster.metadata())
+                cluster["flags"] = _plain(await client.cluster.flags())
+                for flag in cluster["flags"]:
+                    name = _resource_name(flag)
+                    if name:
+                        resources.append(
+                            {
+                                "kind": "flag",
+                                "target_ref": name,
+                                "summary": _plain(flag),
+                                "cluster": cluster["name"],
+                            }
+                        )
+
+                for node in cluster["nodes"]:
+                    await self._read_node_resources(client, node, cluster["name"], resources)
+            except Exception as exc:  # noqa: BLE001
+                message = f"{type(exc).__name__}: {exc}"
+                cluster["errors"].append(message)
+                errors.append(message)
+                logger.info("Ceph v2 state read failed for %s: %s", cluster["name"], exc)
+            clusters.append(cluster)
+
+        return {
+            "provider": self.provider,
+            "clusters": clusters,
+            "resources": resources,
+            "errors": errors,
+            "summary": {
+                "clusters": len(clusters),
+                "resources": len(resources),
+                "errors": len(errors),
+            },
+        }
+
+    async def _read_node_resources(
+        self,
+        client: object,
+        node: str,
+        cluster_name: str,
+        resources: list[dict[str, Any]],
+    ) -> None:
+        node_specs = (
+            ("osd", client.nodes.osds),
+            ("pool", client.nodes.pools),
+            ("filesystem", client.nodes.filesystems),
+            ("crush_rule", client.nodes.rules),
+        )
+        for kind, reader in node_specs:
+            for item in _plain(await reader(node)):
+                name = _resource_name(item)
+                if name is None:
+                    continue
+                resources.append(
+                    {
+                        "kind": kind,
+                        "target_ref": name,
+                        "summary": _plain(item),
+                        "cluster": cluster_name,
+                        "node": node,
+                    }
+                )
+
+    async def diff(
+        self,
+        desired: DesiredStateBundle,
+        live: dict[str, Any],
+    ) -> list[ProviderOperation]:
+        live_index = {
+            (
+                _normalize_kind(str(item.get("kind", ""))),
+                str(item.get("target_ref") or ""),
+            ): item
+            for item in live.get("resources", [])
+            if isinstance(item, dict)
+        }
+
+        operations: list[ProviderOperation] = []
+        for desired_object in desired.objects:
+            kind = _normalize_kind(desired_object.kind)
+            target_ref = _desired_target(desired_object)
+            action = desired_object.action.strip().lower() or "ensure"
+            live_item = live_index.get((kind, target_ref))
+            before_summary = (
+                _plain(live_item.get("summary", {})) if isinstance(live_item, dict) else {}
+            )
+            after_summary = _plain(desired_object.payload)
+
+            if action in {"delete", "destroy", "remove", "purge"}:
+                planned_action = "delete"
+            elif live_item is None:
+                planned_action = "create"
+            elif _payload_matches(desired_object.payload, before_summary):
+                planned_action = "noop"
+            else:
+                planned_action = "update"
+
+            operations.append(
+                ProviderOperation(
+                    provider=self.provider,
+                    kind=kind,
+                    target_ref=target_ref,
+                    action=planned_action,
+                    before_summary=before_summary,
+                    after_summary={} if planned_action == "delete" else after_summary,
+                )
+            )
+        return operations
+
+    async def plan(self, operations: list[ProviderOperation]) -> list[ProviderOperation]:
+        return operations
+
+    async def apply(
+        self,
+        operation: ProviderOperation,
+        *,
+        confirm_destructive: bool,  # noqa: ARG002
+    ) -> dict[str, Any]:
+        if operation.action == "noop":
+            return {
+                "operation_id": operation.id,
+                "result": "noop",
+                "target_ref": operation.target_ref,
+            }
+        raise CephCapabilityUnsupported(
+            "Proxmox Ceph writes are not enabled in the v2 adapter yet; "
+            f"blocked {operation.action} {operation.kind} {operation.target_ref}."
+        )
+
+    async def reconcile(self, scope: dict[str, Any]) -> dict[str, Any]:
+        live = await self.read_state(scope)
+        return {
+            "result": "read_only_reconcile",
+            "summary": live.get("summary", {}),
+            "errors": live.get("errors", []),
+        }
+
+    async def metrics(self, scope: dict[str, Any]) -> dict[str, Any]:
+        live = await self.read_state(scope)
+        summary = live.get("summary", {})
+        return {
+            "scope": scope,
+            "clusters": summary.get("clusters", 0),
+            "resources": summary.get("resources", 0),
+            "errors": summary.get("errors", 0),
+        }
+
+
+__all__ = ["ProxmoxCephProviderAdapter"]

--- a/proxbox_api/ceph/v2_routes.py
+++ b/proxbox_api/ceph/v2_routes.py
@@ -1,0 +1,276 @@
+"""Ceph v2 control-plane routes mounted under ``/ceph/v2``.
+
+These endpoints let NetBox drive Ceph desired-state without direct operator
+access to Proxmox or external Ceph tooling. The surface satisfies both:
+
+* the resource-style API from issue #95 (``/plans``, ``/plans/{id}``,
+  ``/plans/{id}/apply``, ``/operations/{id}``, ``/operations/{id}/events``,
+  ``/validate``, ``/reconcile``, ``/capabilities``, ``/metrics``); and
+* the flat client contract the ``netbox-ceph`` orchestrator already calls
+  (``/plan``, ``/apply``, ``/reconcile``, ``/capabilities``, ``/metrics``).
+
+Request handlers stay thin: planning, applying, validation, capability gating,
+destructive-confirmation enforcement, idempotency, and persistence all live in
+:mod:`proxbox_api.ceph.v2_engine`. Secrets never reach NetBox; provider
+credentials are resolved behind the adapter layer and redacted at the engine
+boundary.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Header, HTTPException, Query
+from fastapi.responses import StreamingResponse
+
+from proxbox_api.ceph.v2_engine import (
+    CephApplyError,
+    CephPlanNotFound,
+    apply_plan,
+    build_plan,
+    get_plan,
+    reconcile_provider,
+    record_to_operation_run,
+    remember_plan,
+    validate_payload,
+)
+from proxbox_api.ceph.v2_providers import adapter_for_provider, provider_names
+from proxbox_api.ceph.v2_schemas import (
+    ApplyRequest,
+    CapabilitiesResponse,
+    MetricsResponse,
+    OperationRun,
+    PlanRequest,
+    PlanResponse,
+    ReconcileRequest,
+    SSEEvent,
+    ValidationResponse,
+)
+from proxbox_api.database import AsyncDatabaseSessionDep, CephOperationRunRecord
+from proxbox_api.logger import logger
+from proxbox_api.session.proxmox import ProxmoxSessionsDep
+
+router = APIRouter()
+
+ActorHeader = Annotated[str | None, Header(alias="X-Proxbox-Actor")]
+
+
+def _with_actor(model: Any, actor: str | None) -> None:
+    """Prefer an explicit body actor, else fall back to the request header."""
+
+    if actor and getattr(model, "actor", None) in (None, ""):
+        model.actor = actor
+
+
+@router.get("/capabilities", response_model=CapabilitiesResponse)
+async def ceph_v2_capabilities(
+    pxs: ProxmoxSessionsDep,
+    provider: Annotated[str | None, Query()] = None,
+) -> CapabilitiesResponse:
+    """Expose per-provider capability flags so the NetBox UI can gate controls."""
+
+    names = [provider] if provider else provider_names()
+    providers = []
+    for name in names:
+        adapter = adapter_for_provider(name, list(pxs))
+        providers.append(await adapter.capabilities())
+    return CapabilitiesResponse(providers=providers)
+
+
+@router.post("/validate", response_model=ValidationResponse)
+async def ceph_v2_validate(payload: dict[str, Any]) -> ValidationResponse:
+    """Validate a single desired object or a full desired-state bundle."""
+
+    return validate_payload(payload)
+
+
+async def _build_and_remember(request: PlanRequest, pxs: ProxmoxSessionsDep) -> PlanResponse:
+    adapter = adapter_for_provider(request.provider, list(pxs))
+    plan = await build_plan(request, adapter)
+    remember_plan(plan)
+    return plan
+
+
+@router.post("/plans", response_model=PlanResponse)
+async def ceph_v2_create_plan(
+    request: PlanRequest,
+    pxs: ProxmoxSessionsDep,
+    actor: ActorHeader = None,
+) -> PlanResponse:
+    """Build a plan from NetBox desired state and current provider state."""
+
+    _with_actor(request, actor)
+    return await _build_and_remember(request, pxs)
+
+
+@router.get("/plans/{plan_id}", response_model=PlanResponse)
+async def ceph_v2_get_plan(plan_id: str) -> PlanResponse:
+    """Inspect a previously built plan: diff, validations, warnings, blocked actions."""
+
+    try:
+        return get_plan(plan_id)
+    except CephPlanNotFound as exc:
+        raise HTTPException(status_code=404, detail=f"Plan {plan_id!r} not found.") from exc
+
+
+@router.post("/plans/{plan_id}/apply", response_model=OperationRun)
+async def ceph_v2_apply_plan(
+    plan_id: str,
+    request: ApplyRequest,
+    pxs: ProxmoxSessionsDep,
+    session: AsyncDatabaseSessionDep,
+    actor: ActorHeader = None,
+) -> OperationRun:
+    """Execute a validated plan, gated on destructive confirmation."""
+
+    _with_actor(request, actor)
+    try:
+        plan = get_plan(plan_id)
+    except CephPlanNotFound as exc:
+        raise HTTPException(status_code=404, detail=f"Plan {plan_id!r} not found.") from exc
+    adapter = adapter_for_provider(plan.provider, list(pxs))
+    try:
+        return await apply_plan(plan, request, adapter, session)
+    except CephApplyError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+
+@router.post("/plan", response_model=PlanResponse)
+async def ceph_v2_plan_compat(
+    request: PlanRequest,
+    pxs: ProxmoxSessionsDep,
+    actor: ActorHeader = None,
+) -> PlanResponse:
+    """Flat client-contract alias for ``POST /plans`` (netbox-ceph orchestrator)."""
+
+    _with_actor(request, actor)
+    return await _build_and_remember(request, pxs)
+
+
+@router.post("/apply", response_model=OperationRun)
+async def ceph_v2_apply_compat(
+    request: ApplyRequest,
+    pxs: ProxmoxSessionsDep,
+    session: AsyncDatabaseSessionDep,
+    actor: ActorHeader = None,
+) -> OperationRun:
+    """Flat client-contract path: build a plan from the payload, then apply it."""
+
+    _with_actor(request, actor)
+    plan_request = PlanRequest(
+        provider=request.provider,
+        desired_state=request.desired_state or None,  # type: ignore[arg-type]
+        operations=request.operations,
+        scope=request.scope,
+        actor=request.actor,
+        netbox_branch_schema_id=request.netbox_branch_schema_id,
+        source_branch_schema_id=request.source_branch_schema_id,
+        request_id=request.request_id,
+    )
+    plan = await _build_and_remember(plan_request, pxs)
+    if request.plan_id is None:
+        request.plan_id = plan.id
+    adapter = adapter_for_provider(plan.provider, list(pxs))
+    try:
+        return await apply_plan(plan, request, adapter, session)
+    except CephApplyError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+
+async def _load_operation(session: AsyncDatabaseSessionDep, operation_id: str) -> OperationRun:
+    record = await session.get(CephOperationRunRecord, operation_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"Operation {operation_id!r} not found.")
+    return record_to_operation_run(record)
+
+
+@router.get("/operations/{operation_id}", response_model=OperationRun)
+async def ceph_v2_operation(
+    operation_id: str,
+    session: AsyncDatabaseSessionDep,
+) -> OperationRun:
+    """Retrieve operation status, provider task refs, warnings, errors, results."""
+
+    return await _load_operation(session, operation_id)
+
+
+@router.get("/operations/{operation_id}/events")
+async def ceph_v2_operation_events(
+    operation_id: str,
+    session: AsyncDatabaseSessionDep,
+) -> StreamingResponse:
+    """Stream operation progress as Server-Sent Events.
+
+    Operations are applied synchronously, so by the time a client subscribes the
+    run is already persisted. The stream replays the run's recorded lifecycle as
+    a deterministic, well-typed event sequence the NetBox UI can render.
+    """
+
+    run = await _load_operation(session, operation_id)
+
+    async def event_stream() -> Any:
+        sequence = 0
+        for event_name, message in (
+            ("accepted", "Operation accepted."),
+            (run.status, f"Operation {run.status}."),
+        ):
+            frame = SSEEvent(
+                event=str(event_name),
+                operation_id=run.id,
+                status=run.status,
+                message=message,
+                sequence=sequence,
+                timestamp=run.updated_at,
+                data={
+                    "provider": run.provider,
+                    "provider_task_refs": run.provider_task_refs,
+                    "warnings": run.warnings,
+                    "errors": run.errors,
+                    "result_summary": run.result_summary,
+                },
+            )
+            sequence += 1
+            yield f"data: {json.dumps(json.loads(frame.model_dump_json()))}\n\n"
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+@router.post("/reconcile", response_model=OperationRun)
+async def ceph_v2_reconcile(
+    request: ReconcileRequest,
+    pxs: ProxmoxSessionsDep,
+    session: AsyncDatabaseSessionDep,
+    actor: ActorHeader = None,
+) -> OperationRun:
+    """Reconcile provider state back into NetBox inventory/current-state summaries."""
+
+    _with_actor(request, actor)
+    adapter = adapter_for_provider(request.provider, list(pxs))
+    return await reconcile_provider(request, adapter, session)
+
+
+@router.get("/metrics", response_model=MetricsResponse)
+async def ceph_v2_metrics(
+    pxs: ProxmoxSessionsDep,
+    provider: Annotated[str, Query()] = "proxmox",
+    object_ref: Annotated[str | None, Query()] = None,
+) -> MetricsResponse:
+    """Return the latest provider metrics for the requested scope."""
+
+    adapter = adapter_for_provider(provider, list(pxs))
+    scope: dict[str, Any] = {}
+    if object_ref:
+        scope["object_ref"] = object_ref
+    warnings: list[str] = []
+    try:
+        metrics = await adapter.metrics(scope)
+    except Exception as exc:  # noqa: BLE001 - surface adapter gaps as a warning, not a 500
+        logger.warning("Ceph v2 metrics unavailable for provider %s: %s", provider, exc)
+        metrics = {}
+        warnings.append(str(exc))
+    return MetricsResponse(provider=provider, scope=scope, metrics=metrics, warnings=warnings)

--- a/proxbox_api/ceph/v2_schemas.py
+++ b/proxbox_api/ceph/v2_schemas.py
@@ -1,0 +1,360 @@
+"""Ceph v2 desired-state orchestration API schemas."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+ProviderName = Literal["proxmox", "dashboard", "rgw_admin", "rbd", "prometheus", "external"]
+ValidationSeverity = Literal["info", "warning", "error"]
+OperationStatus = Literal["pending", "running", "completed", "failed", "blocked", "cancelled"]
+
+
+_BUNDLE_KIND_KEYS = {
+    "pools": "pool",
+    "pool": "pool",
+    "osds": "osd",
+    "osd": "osd",
+    "filesystems": "filesystem",
+    "filesystems_cephfs": "filesystem",
+    "rbd_images": "rbd_image",
+    "rbd": "rbd_image",
+    "rgw_buckets": "rgw_bucket",
+    "buckets": "rgw_bucket",
+    "crush_rules": "crush_rule",
+    "crush": "crush_rule",
+    "keys": "key",
+    "users": "user",
+}
+
+
+class DesiredObject(BaseModel):
+    """One NetBox desired-state object for Ceph orchestration."""
+
+    model_config = ConfigDict(extra="allow")
+
+    kind: str = Field(..., min_length=1)
+    target_ref: str | None = None
+    name: str | None = None
+    action: str = "ensure"
+    payload: dict[str, Any] = Field(default_factory=dict)
+    provider: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_common_fields(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        values = dict(data)
+        if values.get("target_ref") is None:
+            values["target_ref"] = values.get("ref") or values.get("slug") or values.get("id")
+        if values.get("name") is None and isinstance(values.get("payload"), dict):
+            values["name"] = values["payload"].get("name")
+        if values.get("target_ref") is None:
+            values["target_ref"] = values.get("name")
+        if not isinstance(values.get("payload"), dict):
+            spec = values.get("spec")
+            values["payload"] = dict(spec) if isinstance(spec, dict) else {}
+        if values.get("target_ref") is None and isinstance(values.get("payload"), dict):
+            payload = values["payload"]
+            values["target_ref"] = (
+                payload.get("target_ref") or payload.get("ref") or payload.get("name")
+            )
+        return values
+
+
+class DesiredStateBundle(BaseModel):
+    """A desired-state bundle sent by NetBox."""
+
+    model_config = ConfigDict(extra="allow")
+
+    objects: list[DesiredObject] = Field(default_factory=list)
+    scope: dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_bundle(cls, data: Any) -> Any:
+        if data is None:
+            return {}
+        if isinstance(data, list):
+            return {"objects": data}
+        if not isinstance(data, dict):
+            return data
+        values = dict(data)
+        if "objects" in values:
+            return values
+
+        objects: list[dict[str, Any]] = []
+        for key, kind in _BUNDLE_KIND_KEYS.items():
+            raw_items = values.get(key)
+            if not isinstance(raw_items, list):
+                continue
+            for raw_item in raw_items:
+                if isinstance(raw_item, dict):
+                    item = dict(raw_item)
+                    item.setdefault("kind", kind)
+                    item.setdefault("payload", raw_item)
+                    objects.append(item)
+        if objects:
+            values["objects"] = objects
+        return values
+
+
+class ValidationResult(BaseModel):
+    """One validation message for a desired object, bundle, or provider operation."""
+
+    severity: ValidationSeverity
+    code: str
+    message: str
+    target: str | None = None
+
+
+class ValidationResponse(BaseModel):
+    valid: bool
+    results: list[ValidationResult] = Field(default_factory=list)
+
+
+class ProviderOperation(BaseModel):
+    """One intended provider operation in a deterministic Ceph v2 plan."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str | None = None
+    provider: str = "proxmox"
+    kind: str = Field(..., min_length=1)
+    target_ref: str = ""
+    action: str = "ensure"
+    is_destructive: bool = False
+    supported: bool = True
+    blocked_reason: str | None = None
+    before_summary: dict[str, Any] = Field(default_factory=dict)
+    after_summary: dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_operation(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        values = dict(data)
+        if values.get("target_ref") is None:
+            values["target_ref"] = values.get("ref") or values.get("target") or values.get("name")
+        if "before_summary" not in values and isinstance(values.get("before"), dict):
+            values["before_summary"] = values["before"]
+        if "after_summary" not in values:
+            after = values.get("after") or values.get("payload") or values.get("spec")
+            if isinstance(after, dict):
+                values["after_summary"] = after
+        return values
+
+
+class PlanRequest(BaseModel):
+    """Build a Ceph v2 plan from NetBox desired state and provider state."""
+
+    model_config = ConfigDict(extra="allow")
+
+    provider: str = "proxmox"
+    desired_state: DesiredStateBundle = Field(default_factory=DesiredStateBundle)
+    operations: list[ProviderOperation] = Field(default_factory=list)
+    scope: dict[str, Any] = Field(default_factory=dict)
+    actor: str | None = None
+    netbox_branch_schema_id: str | None = None
+    source_branch_schema_id: str | None = None
+    request_id: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_request(cls, data: Any) -> Any:
+        if data is None:
+            return {}
+        if not isinstance(data, dict):
+            return data
+        values = dict(data)
+
+        if "operation" in values and "operations" not in values:
+            values["operations"] = [values["operation"]]
+        elif (
+            "operations" not in values
+            and "kind" in values
+            and ("action" in values or "target_ref" in values or "ref" in values)
+        ):
+            values["operations"] = [values]
+
+        if "desired_state" not in values:
+            if "desired" in values:
+                values["desired_state"] = values["desired"]
+            elif "desired_objects" in values:
+                values["desired_state"] = {"objects": values["desired_objects"]}
+            elif "objects" in values or any(key in values for key in _BUNDLE_KIND_KEYS):
+                values["desired_state"] = values
+
+        if values.get("source_branch_schema_id") is None:
+            values["source_branch_schema_id"] = values.get("netbox_branch_schema_id")
+        return values
+
+    @property
+    def branch_schema_id(self) -> str | None:
+        return self.netbox_branch_schema_id or self.source_branch_schema_id
+
+
+class PlanResponse(BaseModel):
+    """Deterministic Ceph v2 plan response."""
+
+    id: str
+    provider: str
+    netbox_branch_schema_id: str | None = None
+    source_branch_schema_id: str | None = None
+    operations: list[ProviderOperation] = Field(default_factory=list)
+    validations: list[ValidationResult] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    blocked_actions: list[ProviderOperation] = Field(default_factory=list)
+    created_at: datetime
+    live_state_summary: dict[str, Any] = Field(default_factory=dict)
+    request_summary: dict[str, Any] = Field(default_factory=dict)
+
+    @property
+    def valid(self) -> bool:
+        return not any(item.severity == "error" for item in self.validations)
+
+
+class ApplyRequest(BaseModel):
+    """Apply an existing plan or an inline operation payload."""
+
+    model_config = ConfigDict(extra="allow")
+
+    provider: str = "proxmox"
+    plan_id: str | None = None
+    desired_state: DesiredStateBundle | None = None
+    operations: list[ProviderOperation] = Field(default_factory=list)
+    scope: dict[str, Any] = Field(default_factory=dict)
+    actor: str | None = None
+    netbox_branch_schema_id: str | None = None
+    source_branch_schema_id: str | None = None
+    confirm_destructive: bool = False
+    confirmation_token: str | None = None
+    request_id: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_apply(cls, data: Any) -> Any:
+        if data is None:
+            return {}
+        if not isinstance(data, dict):
+            return data
+        values = dict(data)
+        if "operation" in values and "operations" not in values:
+            values["operations"] = [values["operation"]]
+        elif (
+            "operations" not in values
+            and "kind" in values
+            and ("action" in values or "target_ref" in values or "ref" in values)
+        ):
+            values["operations"] = [values]
+        if "desired_state" not in values:
+            if "desired" in values:
+                values["desired_state"] = values["desired"]
+            elif "desired_objects" in values:
+                values["desired_state"] = {"objects": values["desired_objects"]}
+            elif "objects" in values or any(key in values for key in _BUNDLE_KIND_KEYS):
+                values["desired_state"] = values
+        if values.get("source_branch_schema_id") is None:
+            values["source_branch_schema_id"] = values.get("netbox_branch_schema_id")
+        return values
+
+    @property
+    def branch_schema_id(self) -> str | None:
+        return self.netbox_branch_schema_id or self.source_branch_schema_id
+
+
+class ReconcileRequest(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    provider: str = "proxmox"
+    scope: dict[str, Any] = Field(default_factory=dict)
+    actor: str | None = None
+    netbox_branch_schema_id: str | None = None
+    source_branch_schema_id: str | None = None
+
+    @property
+    def branch_schema_id(self) -> str | None:
+        return self.netbox_branch_schema_id or self.source_branch_schema_id
+
+
+class OperationRun(BaseModel):
+    """Persisted Ceph v2 operation run."""
+
+    id: str
+    plan_id: str | None = None
+    status: OperationStatus
+    actor: str | None = None
+    source_branch_schema_id: str | None = None
+    provider: str
+    request_summary: dict[str, Any] = Field(default_factory=dict)
+    provider_task_refs: list[str] = Field(default_factory=list)
+    created_at: datetime
+    updated_at: datetime
+    warnings: list[str] = Field(default_factory=list)
+    errors: list[str] = Field(default_factory=list)
+    result_summary: dict[str, Any] = Field(default_factory=dict)
+
+
+class ProviderCapabilities(BaseModel):
+    """Capability flags for one Ceph provider adapter."""
+
+    provider: str
+    supported: bool
+    read_state: bool = False
+    diff: bool = False
+    plan: bool = False
+    apply: bool = False
+    reconcile: bool = False
+    metrics: bool = False
+    operation_kinds: dict[str, bool] = Field(default_factory=dict)
+    destructive_operations: bool = False
+    notes: list[str] = Field(default_factory=list)
+
+
+class CapabilitiesResponse(BaseModel):
+    providers: list[ProviderCapabilities]
+
+
+class MetricsResponse(BaseModel):
+    provider: str
+    scope: dict[str, Any] = Field(default_factory=dict)
+    metrics: dict[str, Any] = Field(default_factory=dict)
+    warnings: list[str] = Field(default_factory=list)
+
+
+class SSEEvent(BaseModel):
+    """Ceph v2 operation-progress event payload."""
+
+    event: str
+    operation_id: str
+    status: OperationStatus
+    message: str
+    sequence: int
+    timestamp: datetime
+    data: dict[str, Any] = Field(default_factory=dict)
+
+
+__all__ = [
+    "ApplyRequest",
+    "CapabilitiesResponse",
+    "DesiredObject",
+    "DesiredStateBundle",
+    "MetricsResponse",
+    "OperationRun",
+    "PlanRequest",
+    "PlanResponse",
+    "ProviderCapabilities",
+    "ProviderName",
+    "ProviderOperation",
+    "ReconcileRequest",
+    "SSEEvent",
+    "ValidationResponse",
+    "ValidationResult",
+]

--- a/proxbox_api/database.py
+++ b/proxbox_api/database.py
@@ -616,8 +616,12 @@ def _migrate_ceph_operation_run_columns() -> None:
     with engine.begin() as conn:
         for stmt in stmts:
             conn.execute(text(stmt))
-        conn.execute(text(f"UPDATE {table} SET created_at = :now WHERE created_at = 0"), {"now": now})
-        conn.execute(text(f"UPDATE {table} SET updated_at = :now WHERE updated_at = 0"), {"now": now})
+        conn.execute(
+            text(f"UPDATE {table} SET created_at = :now WHERE created_at = 0"), {"now": now}
+        )
+        conn.execute(
+            text(f"UPDATE {table} SET updated_at = :now WHERE updated_at = 0"), {"now": now}
+        )
 
 
 def create_db_and_tables() -> None:

--- a/proxbox_api/database.py
+++ b/proxbox_api/database.py
@@ -236,6 +236,36 @@ class PDMEndpoint(SQLModel, table=True):
         self.token_secret = encrypt_value(value) or value
 
 
+class CephOperationRunRecord(SQLModel, table=True):
+    """Persisted Ceph v2 plan/apply/reconcile run state."""
+
+    __tablename__: ClassVar[str] = "ceph_operation_run"
+    __table_args__ = {"extend_existing": True}
+
+    id: str = Field(primary_key=True)
+    plan_id: str | None = Field(default=None, index=True)
+    status: str = Field(default="pending", index=True)
+    actor: str | None = Field(default=None, index=True)
+    source_branch_schema_id: str | None = Field(default=None, index=True)
+    provider: str = Field(index=True)
+    request_summary: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
+    provider_task_refs: list[str] = Field(
+        default_factory=list,
+        sa_column=Column(JSON, nullable=False),
+    )
+    created_at: float = Field(default_factory=time.time, index=True)
+    updated_at: float = Field(default_factory=time.time, index=True)
+    warnings: list[str] = Field(default_factory=list, sa_column=Column(JSON, nullable=False))
+    errors: list[str] = Field(default_factory=list, sa_column=Column(JSON, nullable=False))
+    result_summary: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
+
+
 class AuthLockout(SQLModel, table=True):
     __table_args__ = {"extend_existing": True}
 
@@ -552,6 +582,44 @@ def _migrate_pdm_endpoint_columns() -> None:
             conn.execute(text(stmt))
 
 
+def _migrate_ceph_operation_run_columns() -> None:
+    table = CephOperationRunRecord.__tablename__
+    try:
+        insp = inspect(engine)
+        if not insp.has_table(table):
+            return
+        existing = {c["name"] for c in insp.get_columns(table)}
+    except Exception:
+        return
+    column_specs: dict[str, str] = {
+        "plan_id": "VARCHAR",
+        "status": "VARCHAR NOT NULL DEFAULT 'pending'",
+        "actor": "VARCHAR",
+        "source_branch_schema_id": "VARCHAR",
+        "provider": "VARCHAR NOT NULL DEFAULT 'proxmox'",
+        "request_summary": "JSON NOT NULL DEFAULT '{}'",
+        "provider_task_refs": "JSON NOT NULL DEFAULT '[]'",
+        "created_at": "REAL NOT NULL DEFAULT 0",
+        "updated_at": "REAL NOT NULL DEFAULT 0",
+        "warnings": "JSON NOT NULL DEFAULT '[]'",
+        "errors": "JSON NOT NULL DEFAULT '[]'",
+        "result_summary": "JSON NOT NULL DEFAULT '{}'",
+    }
+    stmts = [
+        f"ALTER TABLE {table} ADD COLUMN {col} {spec}"
+        for col, spec in column_specs.items()
+        if col not in existing
+    ]
+    if not stmts:
+        return
+    now = time.time()
+    with engine.begin() as conn:
+        for stmt in stmts:
+            conn.execute(text(stmt))
+        conn.execute(text(f"UPDATE {table} SET created_at = :now WHERE created_at = 0"), {"now": now})
+        conn.execute(text(f"UPDATE {table} SET updated_at = :now WHERE updated_at = 0"), {"now": now})
+
+
 def create_db_and_tables() -> None:
     SQLModel.metadata.create_all(engine)
     _migrate_proxmox_endpoint_columns()
@@ -559,6 +627,7 @@ def create_db_and_tables() -> None:
     _migrate_deletion_request_columns()
     _migrate_pbs_endpoint_columns()
     _migrate_pdm_endpoint_columns()
+    _migrate_ceph_operation_run_columns()
 
 
 def get_session() -> Generator[Session, None, None]:

--- a/tests/ceph/test_v2_orchestration.py
+++ b/tests/ceph/test_v2_orchestration.py
@@ -1,0 +1,210 @@
+"""Ceph v2 control-plane (`/ceph/v2/*`) API tests.
+
+Covers the issue #95 acceptance matrix: plan build/inspect, validation,
+apply with destructive-confirmation gating, capability-blocked operations,
+operation tracking, idempotent re-apply, reconcile, metrics, and the SSE
+progress event shape. A fake provider adapter is injected so the suite is
+deterministic and does not require a live Proxmox/Ceph cluster.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from proxbox_api.ceph.v2_schemas import ProviderCapabilities
+from proxbox_api.main import app
+from proxbox_api.session.proxmox_providers import proxmox_sessions_dep
+
+
+class _FakeCephAdapter:
+    """In-memory adapter advertising write capability for deterministic tests."""
+
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        pass
+
+    async def capabilities(self) -> ProviderCapabilities:
+        return ProviderCapabilities(
+            provider="proxmox",
+            supported=True,
+            read_state=True,
+            diff=True,
+            plan=True,
+            apply=True,
+            reconcile=True,
+            metrics=True,
+            destructive_operations=True,
+            operation_kinds={
+                "pool:ensure": True,
+                "pool:delete": True,
+                "rgw_bucket:delete": False,
+            },
+        )
+
+    async def read_state(self, scope: dict[str, Any]) -> dict[str, Any]:  # noqa: ARG002
+        return {"summary": {}}
+
+    async def diff(self, desired: Any, live: Any) -> list[Any]:  # noqa: ARG002
+        return []
+
+    async def plan(self, operations: list[Any]) -> list[Any]:
+        return operations
+
+    async def apply(self, operation: Any, *, confirm_destructive: bool) -> dict[str, Any]:  # noqa: ARG002
+        return {
+            "operation_id": operation.id,
+            "result": "applied",
+            "task_ref": f"task:{operation.target_ref}",
+        }
+
+    async def reconcile(self, scope: dict[str, Any]) -> dict[str, Any]:
+        return {"result": "reconciled", "scope": scope, "summary": {}}
+
+    async def metrics(self, scope: dict[str, Any]) -> dict[str, Any]:
+        return {"scope": scope, "pgs": 128}
+
+
+@pytest.fixture
+def ceph_v2_client(auth_test_client, monkeypatch):
+    """Authenticated client with the fake adapter and empty Proxmox sessions."""
+
+    monkeypatch.setattr(
+        "proxbox_api.ceph.v2_routes.adapter_for_provider",
+        lambda *_a, **_k: _FakeCephAdapter(),
+    )
+    app.dependency_overrides[proxmox_sessions_dep] = lambda: []
+    yield auth_test_client
+    app.dependency_overrides.pop(proxmox_sessions_dep, None)
+
+
+def _ensure_plan_body() -> dict[str, Any]:
+    return {
+        "provider": "proxmox",
+        "operations": [{"kind": "pool", "target_ref": "rbd", "action": "ensure"}],
+        "netbox_branch_schema_id": "branch-123",
+    }
+
+
+def _delete_plan_body() -> dict[str, Any]:
+    return {
+        "provider": "proxmox",
+        "operations": [{"kind": "pool", "target_ref": "rbd", "action": "delete"}],
+    }
+
+
+def test_capabilities_lists_providers(auth_test_client):
+    app.dependency_overrides[proxmox_sessions_dep] = lambda: []
+    try:
+        resp = auth_test_client.get("/ceph/v2/capabilities")
+    finally:
+        app.dependency_overrides.pop(proxmox_sessions_dep, None)
+    assert resp.status_code == 200
+    providers = {p["provider"] for p in resp.json()["providers"]}
+    assert "proxmox" in providers
+
+
+def test_validate_reports_errors_for_bad_payload(ceph_v2_client):
+    resp = ceph_v2_client.post("/ceph/v2/validate", json={"objects": [{"kind": ""}]})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["valid"] is False
+    assert any(r["severity"] == "error" for r in body["results"])
+
+
+def test_plan_build_get_and_missing(ceph_v2_client):
+    created = ceph_v2_client.post("/ceph/v2/plans", json=_ensure_plan_body())
+    assert created.status_code == 200, created.text
+    plan = created.json()
+    assert plan["id"]
+    assert plan["operations"], "plan must contain the requested operation"
+
+    fetched = ceph_v2_client.get(f"/ceph/v2/plans/{plan['id']}")
+    assert fetched.status_code == 200
+    assert fetched.json()["id"] == plan["id"]
+
+    missing = ceph_v2_client.get("/ceph/v2/plans/does-not-exist")
+    assert missing.status_code == 404
+
+
+def test_apply_happy_path_and_operation_lookup(ceph_v2_client):
+    plan = ceph_v2_client.post("/ceph/v2/plans", json=_ensure_plan_body()).json()
+    applied = ceph_v2_client.post(
+        f"/ceph/v2/plans/{plan['id']}/apply", json={"confirm_destructive": False}
+    )
+    assert applied.status_code == 200, applied.text
+    run = applied.json()
+    assert run["status"] == "completed"
+    assert run["source_branch_schema_id"] == "branch-123"
+
+    looked_up = ceph_v2_client.get(f"/ceph/v2/operations/{run['id']}")
+    assert looked_up.status_code == 200
+    assert looked_up.json()["status"] == "completed"
+
+
+def test_apply_destructive_requires_confirmation(ceph_v2_client):
+    plan = ceph_v2_client.post("/ceph/v2/plans", json=_delete_plan_body()).json()
+
+    rejected = ceph_v2_client.post(
+        f"/ceph/v2/plans/{plan['id']}/apply", json={"confirm_destructive": False}
+    )
+    assert rejected.status_code == 409, rejected.text
+
+    confirmed = ceph_v2_client.post(
+        f"/ceph/v2/plans/{plan['id']}/apply", json={"confirm_destructive": True}
+    )
+    assert confirmed.status_code == 200, confirmed.text
+    assert confirmed.json()["status"] == "completed"
+
+
+def test_apply_blocks_unsupported_capability(ceph_v2_client):
+    body = {
+        "provider": "proxmox",
+        "operations": [{"kind": "rgw_bucket", "target_ref": "b1", "action": "delete"}],
+    }
+    plan = ceph_v2_client.post("/ceph/v2/plans", json=body).json()
+    blocked_ops = [op for op in plan["operations"] if not op["supported"]]
+    assert blocked_ops and blocked_ops[0]["blocked_reason"]
+
+    applied = ceph_v2_client.post(
+        f"/ceph/v2/plans/{plan['id']}/apply", json={"confirm_destructive": True}
+    )
+    assert applied.status_code == 409, applied.text
+
+
+def test_apply_is_idempotent(ceph_v2_client):
+    plan = ceph_v2_client.post("/ceph/v2/plans", json=_ensure_plan_body()).json()
+    first = ceph_v2_client.post(f"/ceph/v2/plans/{plan['id']}/apply", json={}).json()
+    second = ceph_v2_client.post(f"/ceph/v2/plans/{plan['id']}/apply", json={}).json()
+    assert first["id"] == second["id"]
+    assert second["status"] == "completed"
+
+
+def test_operation_events_sse_shape(ceph_v2_client):
+    plan = ceph_v2_client.post("/ceph/v2/plans", json=_ensure_plan_body()).json()
+    run = ceph_v2_client.post(f"/ceph/v2/plans/{plan['id']}/apply", json={}).json()
+
+    resp = ceph_v2_client.get(f"/ceph/v2/operations/{run['id']}/events")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    assert "data:" in resp.text
+    assert run["id"] in resp.text
+
+
+def test_operation_missing_returns_404(ceph_v2_client):
+    resp = ceph_v2_client.get("/ceph/v2/operations/no-such-run")
+    assert resp.status_code == 404
+
+
+def test_reconcile_returns_operation_run(ceph_v2_client):
+    resp = ceph_v2_client.post("/ceph/v2/reconcile", json={"provider": "proxmox", "scope": {}})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["provider"] == "proxmox"
+
+
+def test_metrics_returns_payload(ceph_v2_client):
+    resp = ceph_v2_client.get("/ceph/v2/metrics", params={"provider": "proxmox"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["provider"] == "proxmox"
+    assert "pgs" in body["metrics"]


### PR DESCRIPTION
## Summary

Implements the **proxbox-api side of the NetBox-driven Ceph v2 control plane**
(issue #95) — the `/ceph/v2/*` plan/apply engine the `netbox-ceph` plugin's
orchestrator client already targets. NetBox can now build, validate, apply, and
track Ceph desired-state operations without direct Proxmox/Ceph access.

### API surface (`/ceph/v2`)
`GET /capabilities` · `POST /validate` · `POST /plans` · `GET /plans/{id}` ·
`POST /plans/{id}/apply` · `POST /plan` + `POST /apply` (flat client-contract
aliases) · `GET /operations/{id}` · `GET /operations/{id}/events` (SSE) ·
`POST /reconcile` · `GET /metrics`.

### Engine
- Deterministic, ordered plans.
- **Capability-aware**: unsupported operations are **blocked with a reason**,
  never silently skipped.
- **Destructive-op gating**: OSD/pool/RBD/RGW-bucket/CRUSH/user deletions require
  `confirm_destructive` (or a confirmation token) or the apply is rejected.
- **Idempotent** re-apply via `completed_run_for_plan`.
- `netbox_branch_schema_id` threaded through plan/apply/reconcile.
- Secrets redacted at the boundary; NetBox passes only opaque `credential_ref`.

### Providers & persistence
- `CephProviderAdapter` ABC + read-only **Proxmox adapter** + registry.
- Stub adapters (capability=false) for `dashboard` (#98), `rgw_admin`/`rbd`
  (#12), `prometheus` (#94), `external` (#97) — they plug into the same
  interface as those issues land.
- `CephOperationRunRecord` (`ceph_operation_run`) persists actor, branch/schema,
  provider, request summary, provider task refs, timestamps, status, warnings,
  errors, result summary; survives restart.

Additive — v1 `/ceph` routes are unchanged.

## Test plan
- `tests/ceph/test_v2_orchestration.py` (11 tests, all passing): capabilities,
  validate, plan build/get/404, happy-path apply, destructive-confirmation
  gating, capability-blocked apply, idempotent re-apply, operation lookup/404,
  SSE event shape, reconcile, metrics — deterministic via a fake adapter (no
  live cluster).
- `uv run ruff check` clean; `uv run ruff format --check` clean;
  `uv run python -m compileall` clean.

Docs: `proxbox_api/ceph/CLAUDE.md`.

Part of the Ceph v2 epic (emersonfelipesp/netbox-proxbox#431). Implements #95
(engine + Proxmox adapter; remaining provider adapters tracked by
#94/#98/#97/#12). Unblocks the netbox-ceph plan/apply UI.
