### PR TITLE
Ceph v2: Proxmox-backed write executor

### DIFF
--- a/proxbox_api/ceph/CLAUDE.md
+++ b/proxbox_api/ceph/CLAUDE.md
@@ -28,7 +28,8 @@ Both routers are mounted in `proxbox_api/app/factory.py` (`/ceph` and `/ceph/v2`
 | `v2_schemas.py` | Pydantic contract: `DesiredObject`/`DesiredStateBundle`, `PlanRequest`/`PlanResponse`, `ProviderOperation`, `ValidationResult`/`ValidationResponse`, `ApplyRequest`, `ReconcileRequest`, `OperationRun`, `ProviderCapabilities`/`CapabilitiesResponse`, `MetricsResponse`, `SSEEvent`. Requests expose a `branch_schema_id` property = `netbox_branch_schema_id or source_branch_schema_id`. |
 | `v2_engine.py` | Plan/apply engine: `validate_payload`, `build_plan`, `remember_plan`/`get_plan` (in-process plan store), `apply_plan`, `reconcile_provider`, `record_to_operation_run`, `redact_secrets`. Deterministic ordered plans, capability-aware (unsupported ops are **blocked with a reason**, never silently skipped), destructive-op confirmation gating, idempotent re-apply (`completed_run_for_plan`), and run persistence. |
 | `v2_providers/base.py` | `CephProviderAdapter` ABC (`capabilities`, `read_state`, `diff`, `plan`, `apply`, `reconcile`, `metrics`) + `CephCapabilityUnsupported`. |
-| `v2_providers/proxmox.py` | `ProxmoxCephProviderAdapter` — read-only today (writes raise `CephCapabilityUnsupported`; enabled by proxmox-sdk #12). |
+| `v2_providers/proxmox.py` | `ProxmoxCephProviderAdapter` — reads/diffs/plans **and applies** PVE-managed Ceph writes. `apply()` resolves a per-node `CephClient` and dispatches through `proxmox_writer`. Write capability is guarded: `capabilities().apply` and the write `operation_kinds` are `True` only when the installed proxmox-sdk ships `CephWrite` (`cephwrite_importable()`), so an older pin degrades cleanly instead of silently no-op'ing. |
+| `v2_providers/proxmox_writer.py` | `(kind, action) -> CephWrite` mapping (#224): `execute_operation()`, `resolve_node()`, `operation_kinds()`, `cephwrite_importable()`. Supports pool create/update/delete, flag set/unset, OSD create/delete/in/out, MON/MGR/MDS create/delete, CephFS create. Destructive ops thread `confirm_destructive` into `CephWrite(confirm_destroy=)`. `filesystem:delete` and `crush_rule:*` are reported unsupported (no silent gaps). Returns `{upid, operation_id, result, target_ref, ...}`; the engine harvests `upid`. |
 | `v2_providers/__init__.py` | Adapter registry: `adapter_for_provider(provider, pxs)`, `provider_names()`. Stub adapters for `dashboard` (#98), `rgw_admin` (#12), `rbd` (#12), `prometheus` (#94), `external` (#97). |
 | `v2_routes.py` | FastAPI router for all `/ceph/v2/*` endpoints (thin; delegates to the engine). |
 
@@ -58,9 +59,11 @@ Persistence: `CephOperationRunRecord` (SQLModel, `ceph_operation_run` table in
 - **Thread the branch id.** Pass `netbox_branch_schema_id` through
   plan/apply/reconcile so branch-aware NetBox staging stays consistent.
 - v2 is additive; do not change v1 `/ceph` behavior.
-- The Proxmox adapter is read-only until proxmox-sdk #12 lands write-capable
-  Ceph clients; Dashboard/RGW/RBD/Prometheus/external adapters arrive with
-  #98/#12/#94/#97.
+- The Proxmox adapter now executes PVE Ceph writes through `proxmox_writer` +
+  proxmox-sdk `CephWrite` (#12 part 1 / #224). Live execution requires the
+  proxbox-api `proxmox-sdk` pin to include `CephWrite`; until that pin bump the
+  adapter advertises `apply=False` and blocks writes with a clear reason.
+  Dashboard/RGW/RBD/Prometheus/external adapters arrive with #98/#12/#94/#97.
 
 ## Tests
 
@@ -68,3 +71,8 @@ Persistence: `CephOperationRunRecord` (SQLModel, `ceph_operation_run` table in
 build/get/404, happy-path apply, destructive-confirmation gating,
 capability-blocked apply, idempotent re-apply, operation lookup/404, SSE shape,
 reconcile, metrics (fake adapter; no live cluster).
+
+`tests/ceph/test_v2_proxmox_writer.py` — the `(kind, action) -> CephWrite`
+mapping, destructive-confirmation threading, node resolution, UPID surfacing,
+capability gating, and `ProxmoxCephProviderAdapter.apply()` integration (fake
+`CephWrite`; no live cluster).

--- a/proxbox_api/ceph/v2_providers/proxmox.py
+++ b/proxbox_api/ceph/v2_providers/proxmox.py
@@ -8,6 +8,12 @@ from fastapi import HTTPException
 
 from proxbox_api.ceph.routes import _client_for, _node_names, _session_host, _session_name
 from proxbox_api.ceph.v2_providers.base import CephCapabilityUnsupported, CephProviderAdapter
+from proxbox_api.ceph.v2_providers.proxmox_writer import (
+    cephwrite_importable,
+    execute_operation,
+    operation_kinds,
+    resolve_node,
+)
 from proxbox_api.ceph.v2_schemas import (
     DesiredObject,
     DesiredStateBundle,
@@ -88,27 +94,42 @@ class ProxmoxCephProviderAdapter(CephProviderAdapter):
         self._pxs = list(pxs or [])
 
     async def capabilities(self) -> ProviderCapabilities:
+        writes = cephwrite_importable()
+        kinds: dict[str, bool] = {
+            "noop": True,
+            "pool:noop": True,
+            "osd:noop": True,
+            "filesystem:noop": True,
+            "crush_rule:noop": True,
+            "flag:noop": True,
+        }
+        kinds.update(operation_kinds(writes))
+        if writes:
+            notes = [
+                "Proxmox Ceph v2 adapter reads, plans, and applies PVE-managed Ceph "
+                "writes (pools, flags, OSD/MON/MGR/MDS lifecycle, CephFS) through the "
+                "proxmox-sdk CephWrite helpers. Destructive operations require "
+                "confirm_destructive."
+            ]
+        else:
+            notes = [
+                "Proxmox Ceph v2 adapter reads and plans from PVE Ceph state. Write "
+                "execution is unavailable: the installed proxmox-sdk does not ship the "
+                "CephWrite domain. Pin proxmox-sdk to a release that includes it to "
+                "enable Proxmox-backed Ceph writes."
+            ]
         return ProviderCapabilities(
             provider=self.provider,
             supported=True,
             read_state=True,
             diff=True,
             plan=True,
-            apply=False,
+            apply=writes,
             reconcile=True,
             metrics=True,
-            operation_kinds={
-                "noop": True,
-                "pool:noop": True,
-                "osd:noop": True,
-                "filesystem:noop": True,
-                "crush_rule:noop": True,
-                "flag:noop": True,
-            },
-            notes=[
-                "Proxmox Ceph v2 adapter currently reads and plans from PVE Ceph state. "
-                "Write operations are blocked until guarded write support is implemented."
-            ],
+            operation_kinds=kinds,
+            destructive_operations=writes,
+            notes=notes,
         )
 
     async def read_state(self, scope: dict[str, Any]) -> dict[str, Any]:  # noqa: ARG002
@@ -254,7 +275,7 @@ class ProxmoxCephProviderAdapter(CephProviderAdapter):
         self,
         operation: ProviderOperation,
         *,
-        confirm_destructive: bool,  # noqa: ARG002
+        confirm_destructive: bool,
     ) -> dict[str, Any]:
         if operation.action == "noop":
             return {
@@ -262,9 +283,22 @@ class ProxmoxCephProviderAdapter(CephProviderAdapter):
                 "result": "noop",
                 "target_ref": operation.target_ref,
             }
-        raise CephCapabilityUnsupported(
-            "Proxmox Ceph writes are not enabled in the v2 adapter yet; "
-            f"blocked {operation.action} {operation.kind} {operation.target_ref}."
+        if not self._pxs:
+            raise CephCapabilityUnsupported(
+                "No Proxmox session is available to apply Ceph write operations."
+            )
+        px = self._pxs[0]
+        client = _client_for(px)
+        write = getattr(client, "write", None)
+        if write is None:
+            raise CephCapabilityUnsupported(
+                "The installed proxmox-sdk does not expose Ceph write support; "
+                "upgrade to a release that ships the CephWrite domain to enable "
+                "Proxmox-backed Ceph writes."
+            )
+        node = resolve_node(operation, _node_names(px))
+        return await execute_operation(
+            write, operation, node, confirm_destructive=confirm_destructive
         )
 
     async def reconcile(self, scope: dict[str, Any]) -> dict[str, Any]:

--- a/proxbox_api/ceph/v2_providers/proxmox_writer.py
+++ b/proxbox_api/ceph/v2_providers/proxmox_writer.py
@@ -1,0 +1,217 @@
+"""Map Ceph v2 ProviderOperations to ``proxmox_sdk.ceph.CephWrite`` calls.
+
+The Ceph v2 plan/apply engine (see ``proxbox_api/ceph/v2_engine.py``) hands the
+provider adapter one :class:`ProviderOperation` at a time and harvests a Proxmox
+task UPID from the returned dict.  This module owns the deterministic mapping
+from ``(kind, action)`` to a guarded ``CephWrite`` helper so the
+``ProxmoxCephProviderAdapter`` stays small and the mapping is unit-testable with
+an injected fake.
+
+Writes are only available when the installed ``proxmox-sdk`` ships the
+``CephWrite`` domain.  When it does not (older pin), the adapter reports
+``apply=False`` via :func:`cephwrite_importable` and never silently no-ops a
+real write request.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+from proxbox_api.ceph.v2_providers.base import CephCapabilityUnsupported
+from proxbox_api.ceph.v2_schemas import ProviderOperation
+
+# Capability map: ``operation_kind`` -> supported by the Proxmox write adapter.
+# ``True`` entries light up once ``CephWrite`` is importable; ``False`` entries
+# are surfaced as explicitly-unsupported so the plan engine never hides a gap.
+WRITE_OPERATION_KINDS: dict[str, bool] = {
+    "pool:create": True,
+    "pool:update": True,
+    "pool:delete": True,
+    "flag:create": True,
+    "flag:update": True,
+    "flag:delete": True,
+    "osd:create": True,
+    "osd:delete": True,
+    "osd:update": True,
+    "mon:create": True,
+    "mon:delete": True,
+    "mgr:create": True,
+    "mgr:delete": True,
+    "mds:create": True,
+    "mds:delete": True,
+    "filesystem:create": True,
+    "noop": True,
+    # Not yet exposed by PVE CephWrite — reported, never silently dropped.
+    "filesystem:update": False,
+    "filesystem:delete": False,
+    "crush_rule:create": False,
+    "crush_rule:update": False,
+    "crush_rule:delete": False,
+}
+
+# Control keys consumed by the executor itself, never forwarded as write params.
+_CONTROL_KEYS = frozenset({"node", "name", "target_ref", "confirm_destroy", "confirm_destructive"})
+
+
+def cephwrite_importable() -> bool:
+    """Return ``True`` when the installed ``proxmox-sdk`` exposes ``CephWrite``."""
+    try:
+        from proxmox_sdk.ceph import CephWrite  # noqa: F401,PLC0415
+    except Exception:  # noqa: BLE001 - any import failure means writes unavailable
+        return False
+    return True
+
+
+def operation_kinds(writes_enabled: bool) -> dict[str, bool]:
+    """Resolve the advertised ``operation_kinds`` map given write availability."""
+    return {
+        key: bool(supported and writes_enabled) for key, supported in WRITE_OPERATION_KINDS.items()
+    }
+
+
+def resolve_node(operation: ProviderOperation, node_names: list[str]) -> str:
+    """Pick the Proxmox node for a write: explicit payload node, else first node."""
+    node = None
+    if isinstance(operation.after_summary, dict):
+        node = operation.after_summary.get("node")
+    if not node and node_names:
+        node = node_names[0]
+    if not node:
+        raise CephCapabilityUnsupported(
+            "No Proxmox node available to apply the Ceph write operation."
+        )
+    return str(node)
+
+
+def _params(payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in (payload or {}).items()
+        if key not in _CONTROL_KEYS and value is not None
+    }
+
+
+def _filtered(method: Any, payload: dict[str, Any]) -> dict[str, Any]:
+    """Keep only kwargs the bound ``CephWrite`` method accepts (or all if **kwargs)."""
+    sig = inspect.signature(method)
+    if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()):
+        return dict(payload)
+    accepted = {
+        name
+        for name, p in sig.parameters.items()
+        if p.kind in (inspect.Parameter.KEYWORD_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    }
+    return {key: value for key, value in payload.items() if key in accepted}
+
+
+def _result(operation: ProviderOperation, upid: Any, result: str) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "operation_id": operation.id,
+        "result": result,
+        "target_ref": operation.target_ref,
+        "action": operation.action,
+        "kind": operation.kind,
+    }
+    if upid is not None:
+        out["upid"] = upid if isinstance(upid, str) else str(upid)
+    return out
+
+
+def _gap(kind: str, action: str, detail: str | None = None) -> CephCapabilityUnsupported:
+    suffix = f" {detail}" if detail else ""
+    return CephCapabilityUnsupported(
+        f"Proxmox Ceph write adapter does not support {kind}:{action}.{suffix}"
+    )
+
+
+async def execute_operation(
+    write: Any,
+    operation: ProviderOperation,
+    node: str,
+    *,
+    confirm_destructive: bool,
+) -> dict[str, Any]:
+    """Execute one planned operation through ``CephWrite`` and return a result dict.
+
+    The returned dict carries ``upid`` (when the provider yields a task id) which
+    the engine harvests into the operation run's ``provider_task_refs``.
+    """
+    kind = operation.kind
+    action = operation.action
+    target = operation.target_ref or ""
+    payload = _params(operation.after_summary)
+    op_key = "noop" if action == "noop" else f"{kind}:{action}"
+
+    if WRITE_OPERATION_KINDS.get(op_key) is False:
+        raise _gap(kind, action)
+
+    if action == "noop":
+        return _result(operation, None, "noop")
+
+    upid = await _dispatch(write, kind, action, node, target, payload, confirm_destructive)
+    return _result(operation, upid, "applied")
+
+
+async def _dispatch(  # noqa: C901, PLR0911, PLR0912 - explicit kind/action table
+    write: Any,
+    kind: str,
+    action: str,
+    node: str,
+    target: str,
+    payload: dict[str, Any],
+    confirm: bool,
+) -> Any:
+    if kind == "pool":
+        if action == "create":
+            return await write.pool_create(node, target, **_filtered(write.pool_create, payload))
+        if action == "update":
+            return await write.pool_set(node, target, **_filtered(write.pool_set, payload))
+        if action == "delete":
+            return await write.pool_delete(
+                node, target, confirm_destroy=confirm, **_filtered(write.pool_delete, payload)
+            )
+    elif kind == "flag":
+        if action in ("create", "update"):
+            return await write.flag_set(target)
+        if action == "delete":
+            return await write.flag_unset(target)
+    elif kind == "osd":
+        if action == "create":
+            dev = payload.get("dev")
+            if not dev:
+                raise _gap(kind, action, "osd create requires payload 'dev' (device path).")
+            rest = {key: value for key, value in payload.items() if key != "dev"}
+            return await write.osd_create(node, dev, **_filtered(write.osd_create, rest))
+        if action == "delete":
+            return await write.osd_delete(
+                node, target, confirm_destroy=confirm, **_filtered(write.osd_delete, payload)
+            )
+        if action == "update":
+            state = payload.get("in")
+            if state is True:
+                return await write.osd_in(node, target)
+            if state is False:
+                return await write.osd_out(node, target)
+            raise _gap(kind, action, "osd update requires payload {'in': true|false}.")
+    elif kind == "mon":
+        if action == "create":
+            return await write.mon_create(node, target, **_filtered(write.mon_create, payload))
+        if action == "delete":
+            return await write.mon_delete(node, target, confirm_destroy=confirm)
+    elif kind == "mgr":
+        if action == "create":
+            return await write.mgr_create(node, target)
+        if action == "delete":
+            return await write.mgr_delete(node, target, confirm_destroy=confirm)
+    elif kind == "mds":
+        if action == "create":
+            return await write.mds_create(node, target, **_filtered(write.mds_create, payload))
+        if action == "delete":
+            return await write.mds_delete(node, target, confirm_destroy=confirm)
+    elif kind == "filesystem":
+        if action == "create":
+            return await write.cephfs_create(
+                node, target, **_filtered(write.cephfs_create, payload)
+            )
+    raise _gap(kind, action)

--- a/tests/ceph/test_v2_proxmox_writer.py
+++ b/tests/ceph/test_v2_proxmox_writer.py
@@ -1,0 +1,331 @@
+"""Unit tests for the Proxmox-backed Ceph v2 write executor (issue #224).
+
+Covers the ``(kind, action) -> CephWrite`` mapping, destructive-confirmation
+threading, node resolution, UPID surfacing, capability gating, and the
+``ProxmoxCephProviderAdapter.apply()`` integration — all with an injected fake
+``CephWrite`` so no live Proxmox/Ceph cluster is required.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from proxbox_api.ceph.v2_providers import proxmox as proxmox_adapter
+from proxbox_api.ceph.v2_providers.base import CephCapabilityUnsupported
+from proxbox_api.ceph.v2_providers.proxmox import ProxmoxCephProviderAdapter
+from proxbox_api.ceph.v2_providers.proxmox_writer import (
+    execute_operation,
+    operation_kinds,
+    resolve_node,
+)
+from proxbox_api.ceph.v2_schemas import ProviderOperation
+
+
+class _FakeWrite:
+    """Records CephWrite calls and enforces destructive confirmation."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    def _record(self, name: str, *args: Any, **kwargs: Any) -> str:
+        self.calls.append((name, args, kwargs))
+        return f"UPID:{name}"
+
+    async def pool_create(self, node: str, name: str, **kwargs: Any) -> str:
+        return self._record("pool_create", node, name, **kwargs)
+
+    async def pool_set(self, node: str, name: str, **kwargs: Any) -> str:
+        return self._record("pool_set", node, name, **kwargs)
+
+    async def pool_delete(
+        self, node: str, name: str, *, confirm_destroy: bool = False, **kwargs: Any
+    ) -> str:
+        if not confirm_destroy:
+            raise ValueError("pool_delete is destructive; pass confirm_destroy=True")
+        return self._record("pool_delete", node, name, confirm_destroy=confirm_destroy, **kwargs)
+
+    async def flag_set(self, flag: str) -> str:
+        return self._record("flag_set", flag)
+
+    async def flag_unset(self, flag: str) -> str:
+        return self._record("flag_unset", flag)
+
+    async def osd_create(self, node: str, dev: str, **kwargs: Any) -> str:
+        return self._record("osd_create", node, dev, **kwargs)
+
+    async def osd_delete(
+        self, node: str, osdid: Any, *, confirm_destroy: bool = False, **kwargs: Any
+    ) -> str:
+        if not confirm_destroy:
+            raise ValueError("osd_delete is destructive; pass confirm_destroy=True")
+        return self._record("osd_delete", node, osdid, confirm_destroy=confirm_destroy, **kwargs)
+
+    async def osd_in(self, node: str, osdid: Any) -> str:
+        return self._record("osd_in", node, osdid)
+
+    async def osd_out(self, node: str, osdid: Any) -> str:
+        return self._record("osd_out", node, osdid)
+
+    async def mon_create(self, node: str, monid: str, **kwargs: Any) -> str:
+        return self._record("mon_create", node, monid, **kwargs)
+
+    async def mon_delete(self, node: str, monid: str, *, confirm_destroy: bool = False) -> str:
+        if not confirm_destroy:
+            raise ValueError("mon_delete is destructive")
+        return self._record("mon_delete", node, monid, confirm_destroy=confirm_destroy)
+
+    async def mgr_create(self, node: str, mgr_id: str) -> str:
+        return self._record("mgr_create", node, mgr_id)
+
+    async def mgr_delete(self, node: str, mgr_id: str, *, confirm_destroy: bool = False) -> str:
+        if not confirm_destroy:
+            raise ValueError("mgr_delete is destructive")
+        return self._record("mgr_delete", node, mgr_id, confirm_destroy=confirm_destroy)
+
+    async def mds_create(self, node: str, name: str, **kwargs: Any) -> str:
+        return self._record("mds_create", node, name, **kwargs)
+
+    async def mds_delete(self, node: str, name: str, *, confirm_destroy: bool = False) -> str:
+        if not confirm_destroy:
+            raise ValueError("mds_delete is destructive")
+        return self._record("mds_delete", node, name, confirm_destroy=confirm_destroy)
+
+    async def cephfs_create(self, node: str, name: str, **kwargs: Any) -> str:
+        return self._record("cephfs_create", node, name, **kwargs)
+
+
+def _op(kind: str, action: str, target: str = "", **after: Any) -> ProviderOperation:
+    return ProviderOperation(
+        id=f"op-{kind}-{action}",
+        provider="proxmox",
+        kind=kind,
+        target_ref=target,
+        action=action,
+        after_summary=after,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# operation_kinds + resolve_node
+# --------------------------------------------------------------------------- #
+
+
+def test_operation_kinds_gated_by_write_availability() -> None:
+    enabled = operation_kinds(True)
+    assert enabled["pool:create"] is True
+    assert enabled["pool:delete"] is True
+    assert enabled["osd:update"] is True
+    # Always-unsupported kinds stay False even when writes are enabled.
+    assert enabled["filesystem:delete"] is False
+    assert enabled["crush_rule:create"] is False
+
+    disabled = operation_kinds(False)
+    assert all(value is False for value in disabled.values())
+
+
+def test_resolve_node_prefers_payload_then_first_node() -> None:
+    assert resolve_node(_op("pool", "create", "p", node="nodeA"), ["node1"]) == "nodeA"
+    assert resolve_node(_op("pool", "create", "p"), ["node1", "node2"]) == "node1"
+    with pytest.raises(CephCapabilityUnsupported):
+        resolve_node(_op("pool", "create", "p"), [])
+
+
+# --------------------------------------------------------------------------- #
+# execute_operation mapping
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_pool_create_update_map_to_write() -> None:
+    write = _FakeWrite()
+    res = await execute_operation(
+        write, _op("pool", "create", "rbd", size=3, pg_num=128), "node1", confirm_destructive=False
+    )
+    assert res["upid"] == "UPID:pool_create"
+    assert res["result"] == "applied"
+    name, args, kwargs = write.calls[0]
+    assert name == "pool_create"
+    assert args == ("node1", "rbd")
+    assert kwargs == {"size": 3, "pg_num": 128}
+
+    await execute_operation(
+        write, _op("pool", "update", "rbd", size=2), "node1", confirm_destructive=False
+    )
+    assert write.calls[1][0] == "pool_set"
+
+
+@pytest.mark.asyncio
+async def test_pool_delete_requires_confirmation() -> None:
+    write = _FakeWrite()
+    op = _op("pool", "delete", "rbd")
+    with pytest.raises(ValueError, match="destructive"):
+        await execute_operation(write, op, "node1", confirm_destructive=False)
+
+    res = await execute_operation(write, op, "node1", confirm_destructive=True)
+    assert res["upid"] == "UPID:pool_delete"
+    assert write.calls[-1][2]["confirm_destroy"] is True
+
+
+@pytest.mark.asyncio
+async def test_flag_set_and_unset() -> None:
+    write = _FakeWrite()
+    await execute_operation(
+        write, _op("flag", "create", "noout"), "node1", confirm_destructive=False
+    )
+    await execute_operation(
+        write, _op("flag", "delete", "noout"), "node1", confirm_destructive=False
+    )
+    assert [c[0] for c in write.calls] == ["flag_set", "flag_unset"]
+    # flag helpers take only the flag name (no node).
+    assert write.calls[0][1] == ("noout",)
+
+
+@pytest.mark.asyncio
+async def test_osd_lifecycle() -> None:
+    write = _FakeWrite()
+    await execute_operation(
+        write, _op("osd", "create", "", dev="/dev/sdb"), "node1", confirm_destructive=False
+    )
+    assert write.calls[-1][0] == "osd_create"
+    assert write.calls[-1][1] == ("node1", "/dev/sdb")
+
+    await execute_operation(
+        write, _op("osd", "update", "5", **{"in": True}), "node1", confirm_destructive=False
+    )
+    assert write.calls[-1][0] == "osd_in"
+    await execute_operation(
+        write, _op("osd", "update", "5", **{"in": False}), "node1", confirm_destructive=False
+    )
+    assert write.calls[-1][0] == "osd_out"
+
+    res = await execute_operation(
+        write, _op("osd", "delete", "5"), "node1", confirm_destructive=True
+    )
+    assert res["upid"] == "UPID:osd_delete"
+
+
+@pytest.mark.asyncio
+async def test_osd_create_without_dev_is_blocked() -> None:
+    write = _FakeWrite()
+    with pytest.raises(CephCapabilityUnsupported, match="dev"):
+        await execute_operation(write, _op("osd", "create", ""), "node1", confirm_destructive=False)
+
+
+@pytest.mark.asyncio
+async def test_osd_update_without_in_flag_is_blocked() -> None:
+    write = _FakeWrite()
+    with pytest.raises(CephCapabilityUnsupported, match="'in'"):
+        await execute_operation(
+            write, _op("osd", "update", "5"), "node1", confirm_destructive=False
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["mon", "mgr", "mds"])
+async def test_mon_mgr_mds_lifecycle(kind: str) -> None:
+    write = _FakeWrite()
+    await execute_operation(write, _op(kind, "create", "x"), "node1", confirm_destructive=False)
+    assert write.calls[-1][0] == f"{kind}_create"
+    with pytest.raises(ValueError, match="destructive"):
+        await execute_operation(write, _op(kind, "delete", "x"), "node1", confirm_destructive=False)
+    res = await execute_operation(
+        write, _op(kind, "delete", "x"), "node1", confirm_destructive=True
+    )
+    assert res["upid"] == f"UPID:{kind}_delete"
+
+
+@pytest.mark.asyncio
+async def test_filesystem_create_and_blocked_delete() -> None:
+    write = _FakeWrite()
+    res = await execute_operation(
+        write, _op("filesystem", "create", "cephfs", pg_num=64), "node1", confirm_destructive=False
+    )
+    assert res["upid"] == "UPID:cephfs_create"
+    with pytest.raises(CephCapabilityUnsupported):
+        await execute_operation(
+            write, _op("filesystem", "delete", "cephfs"), "node1", confirm_destructive=True
+        )
+
+
+@pytest.mark.asyncio
+async def test_crush_rule_is_explicitly_unsupported() -> None:
+    write = _FakeWrite()
+    with pytest.raises(CephCapabilityUnsupported):
+        await execute_operation(
+            write, _op("crush_rule", "create", "r1"), "node1", confirm_destructive=False
+        )
+
+
+@pytest.mark.asyncio
+async def test_noop_returns_without_calling_write() -> None:
+    write = _FakeWrite()
+    res = await execute_operation(
+        write, _op("pool", "noop", "rbd"), "node1", confirm_destructive=False
+    )
+    assert res["result"] == "noop"
+    assert "upid" not in res
+    assert write.calls == []
+
+
+# --------------------------------------------------------------------------- #
+# Adapter integration
+# --------------------------------------------------------------------------- #
+
+
+class _FakeClient:
+    def __init__(self, write: _FakeWrite) -> None:
+        self.write = write
+
+
+@pytest.mark.asyncio
+async def test_adapter_apply_dispatches_through_write(monkeypatch: pytest.MonkeyPatch) -> None:
+    write = _FakeWrite()
+    monkeypatch.setattr(proxmox_adapter, "_client_for", lambda _px: _FakeClient(write))
+    monkeypatch.setattr(proxmox_adapter, "_node_names", lambda _px: ["node1"])
+
+    adapter = ProxmoxCephProviderAdapter([object()])
+    res = await adapter.apply(_op("pool", "create", "rbd", size=3), confirm_destructive=False)
+    assert res["upid"] == "UPID:pool_create"
+    assert write.calls[0][1] == ("node1", "rbd")
+
+
+@pytest.mark.asyncio
+async def test_adapter_apply_without_session_is_blocked() -> None:
+    adapter = ProxmoxCephProviderAdapter([])
+    with pytest.raises(CephCapabilityUnsupported, match="No Proxmox session"):
+        await adapter.apply(_op("pool", "create", "rbd"), confirm_destructive=False)
+
+
+@pytest.mark.asyncio
+async def test_adapter_apply_without_write_support_is_blocked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _NoWriteClient:
+        write = None
+
+    monkeypatch.setattr(proxmox_adapter, "_client_for", lambda _px: _NoWriteClient())
+    monkeypatch.setattr(proxmox_adapter, "_node_names", lambda _px: ["node1"])
+    adapter = ProxmoxCephProviderAdapter([object()])
+    with pytest.raises(CephCapabilityUnsupported, match="CephWrite"):
+        await adapter.apply(_op("pool", "create", "rbd"), confirm_destructive=False)
+
+
+@pytest.mark.asyncio
+async def test_adapter_capabilities_reflect_write_availability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = ProxmoxCephProviderAdapter([])
+
+    monkeypatch.setattr(proxmox_adapter, "cephwrite_importable", lambda: True)
+    caps = await adapter.capabilities()
+    assert caps.apply is True
+    assert caps.destructive_operations is True
+    assert caps.operation_kinds["pool:create"] is True
+
+    monkeypatch.setattr(proxmox_adapter, "cephwrite_importable", lambda: False)
+    caps = await adapter.capabilities()
+    assert caps.apply is False
+    assert caps.destructive_operations is False
+    assert caps.operation_kinds["pool:create"] is False


### PR DESCRIPTION
## Summary
Wires `ProxmoxCephProviderAdapter` to **execute** PVE-managed Ceph writes through the proxmox-sdk `CephWrite` helpers, completing the Proxmox path of the Ceph v2 plan/apply/operation-history flow so NetBox can configure/manage Ceph on a Proxmox cluster.

- New `proxbox_api/ceph/v2_providers/proxmox_writer.py` maps `(kind, action)` → `CephWrite`:
  - pool create/update/delete, flag set/unset, OSD create/delete/in/out, MON/MGR/MDS create/delete, CephFS create.
  - Destructive ops thread `confirm_destructive` into `CephWrite(confirm_destroy=)`.
  - `filesystem:delete` and `crush_rule:*` are reported **unsupported** (no silent gaps).
  - `apply()` returns `{upid, operation_id, result, target_ref, ...}`; the engine harvests `upid` into the operation run's `provider_task_refs`.
- **Guarded capability**: `capabilities().apply` and the write `operation_kinds` are `True` only when the installed proxmox-sdk ships `CephWrite` (`cephwrite_importable()`), so an older pin degrades cleanly instead of silently no-op'ing a real write. Live execution lights up once the proxbox-api `proxmox-sdk` pin is bumped to the release that includes `CephWrite`.
- Node resolution: `operation.after_summary['node']` then first cluster node.

## Tests
`tests/ceph/test_v2_proxmox_writer.py` (18 tests, injected fake `CephWrite`, no live cluster): mapping per `(kind, action)`, destructive-confirmation threading, node resolution, UPID surfacing, capability gating, and `ProxmoxCephProviderAdapter.apply()` integration. `ruff check`/`format --check` clean; import smoke passes.

## Follow-up
- Bump proxbox-api `proxmox-sdk` pin to the release shipping `CephWrite` to enable live execution (separate PR + proxmox-sdk release).

Refs #224, #95; depends on proxmox-sdk `CephWrite` (#98).