### PR TITLE
Ceph v2: direct Ceph Dashboard API provider (#98)

### DIFF
--- a/proxbox_api/ceph/dashboard_client.py
+++ b/proxbox_api/ceph/dashboard_client.py
@@ -1,0 +1,86 @@
+"""Ceph Dashboard provider client bridge for Ceph v2 (#98).
+
+Wraps the ``proxmox-sdk`` direct Ceph Dashboard client behind a defensive
+import, mirroring the ``cephwrite_importable()`` pattern: the adapter degrades
+cleanly (reports ``available=False``) when the installed ``proxmox-sdk`` pin
+does not yet ship ``proxmox_sdk.ceph.providers`` (added in 0.0.11), instead of
+silently failing. Pin proxmox-sdk to >=0.0.11 to activate the Dashboard path.
+
+The SDK client owns its own HTTP session (the Dashboard API is a standalone
+service, not the PVE API), so no Proxmox endpoint is required — this is what
+lets the Dashboard provider serve external/standalone Ceph clusters.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class DashboardEndpointConfig:
+    """Connection config for a Ceph Dashboard endpoint (secrets decrypted)."""
+
+    base_url: str
+    username: str | None = None
+    password: str | None = None
+    token: str | None = None
+    verify_ssl: bool = True
+    api_version: str = "1.0"
+    timeout: int = 30
+
+
+def dashboard_sdk_importable() -> bool:
+    """Return ``True`` when the installed ``proxmox-sdk`` ships the Dashboard client."""
+    try:
+        from proxmox_sdk.ceph.providers import DashboardCephClient  # noqa: F401,PLC0415
+    except Exception:  # noqa: BLE001 - any import failure means the provider is unavailable
+        return False
+    return True
+
+
+def build_dashboard_client(config: DashboardEndpointConfig, *, transport: Any = None) -> Any:
+    """Construct an SDK ``DashboardCephClient`` from ``config``.
+
+    Raises ``ImportError`` if the SDK Dashboard client is not importable; callers
+    gate on :func:`dashboard_sdk_importable` first.
+    """
+    from proxmox_sdk.ceph.providers import DashboardCephClient  # noqa: PLC0415
+
+    return DashboardCephClient(
+        config.base_url,
+        username=config.username,
+        password=config.password,
+        token=config.token,
+        verify_ssl=config.verify_ssl,
+        api_version=config.api_version,
+        timeout=config.timeout,
+        transport=transport,
+    )
+
+
+async def validate_dashboard_endpoint(
+    config: DashboardEndpointConfig, *, client_factory: Any = None
+) -> tuple[bool, str | None]:
+    """Probe a Ceph Dashboard endpoint. Returns ``(ok, error_message)``.
+
+    Returns ``(False, ...)`` when the SDK Dashboard client is not importable
+    (older proxmox-sdk pin) rather than raising.
+    """
+    if client_factory is None and not dashboard_sdk_importable():
+        return False, "proxmox-sdk>=0.0.11 is required for the Ceph Dashboard provider"
+    client = client_factory(config) if client_factory else build_dashboard_client(config)
+    try:
+        caps = await client.capabilities()
+    except Exception as exc:  # noqa: BLE001 - surface probe failure as an error string
+        return False, f"{type(exc).__name__}: {exc}"
+    finally:
+        close = getattr(client, "close", None)
+        if close is not None:
+            try:
+                await close()
+            except Exception:  # noqa: BLE001 - best-effort cleanup
+                pass
+    available = bool(getattr(caps, "available", False))
+    notes = getattr(caps, "notes", []) or []
+    return available, (None if available else (notes[0] if notes else "dashboard unavailable"))

--- a/proxbox_api/ceph/v2_providers/__init__.py
+++ b/proxbox_api/ceph/v2_providers/__init__.py
@@ -6,11 +6,11 @@ from collections.abc import Callable
 
 from proxbox_api.ceph.v2_providers.base import (
     CephProviderAdapter,
-    DashboardCephProviderAdapter,
     ExternalCephProviderAdapter,
     RBDCephProviderAdapter,
     RGWAdminCephProviderAdapter,
 )
+from proxbox_api.ceph.v2_providers.dashboard import DashboardCephProviderAdapter
 from proxbox_api.ceph.v2_providers.prometheus import PrometheusCephProviderAdapter
 from proxbox_api.ceph.v2_providers.proxmox import ProxmoxCephProviderAdapter
 

--- a/proxbox_api/ceph/v2_providers/base.py
+++ b/proxbox_api/ceph/v2_providers/base.py
@@ -108,11 +108,6 @@ class UnsupportedCephProviderAdapter(CephProviderAdapter):
         raise self._unsupported()
 
 
-class DashboardCephProviderAdapter(UnsupportedCephProviderAdapter):
-    provider = "dashboard"
-    followup = "#98"
-
-
 class RGWAdminCephProviderAdapter(UnsupportedCephProviderAdapter):
     provider = "rgw_admin"
     followup = "#435 / proxmox-sdk#12"
@@ -131,7 +126,6 @@ class ExternalCephProviderAdapter(UnsupportedCephProviderAdapter):
 __all__ = [
     "CephCapabilityUnsupported",
     "CephProviderAdapter",
-    "DashboardCephProviderAdapter",
     "ExternalCephProviderAdapter",
     "RBDCephProviderAdapter",
     "RGWAdminCephProviderAdapter",

--- a/proxbox_api/ceph/v2_providers/dashboard.py
+++ b/proxbox_api/ceph/v2_providers/dashboard.py
@@ -1,0 +1,323 @@
+"""Direct Ceph Dashboard API provider adapter for Ceph v2 (#98).
+
+Reads inventory and applies pool/RBD writes through the Ceph Manager Dashboard
+REST API (via the ``proxmox-sdk`` Dashboard client), with **no Proxmox endpoint
+required** — so it serves Proxmox-managed and external/standalone clusters
+alike. Writes participate in the same plan/apply/operation-run flow as the
+Proxmox provider.
+
+Write capability is guarded by :func:`dashboard_sdk_importable`: an older
+proxmox-sdk pin degrades to ``apply=False`` with a clear reason instead of
+silently no-op'ing. The Dashboard endpoint config is resolved from
+``scope["dashboard_endpoint"]`` (injected by the route, which has DB access) or
+from a config passed to the constructor (tests / composition).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from proxbox_api.ceph.dashboard_client import (
+    DashboardEndpointConfig,
+    build_dashboard_client,
+    dashboard_sdk_importable,
+)
+from proxbox_api.ceph.v2_providers.base import CephCapabilityUnsupported, CephProviderAdapter
+from proxbox_api.ceph.v2_providers.dashboard_writer import (
+    execute_dashboard_operation,
+    operation_kinds,
+)
+from proxbox_api.ceph.v2_schemas import (
+    DesiredObject,
+    DesiredStateBundle,
+    ProviderCapabilities,
+    ProviderOperation,
+)
+from proxbox_api.logger import logger
+
+_DESTRUCTIVE_ACTIONS = {"delete", "destroy", "remove", "purge"}
+
+
+def _plain(value: Any) -> Any:
+    if hasattr(value, "model_dump") and callable(value.model_dump):
+        return value.model_dump(mode="json")
+    if isinstance(value, dict):
+        return {str(k): _plain(v) for k, v in value.items()}
+    if isinstance(value, list | tuple | set):
+        return [_plain(v) for v in value]
+    return value
+
+
+def _normalize_kind(kind: str) -> str:
+    cleaned = kind.strip().lower().replace("-", "_")
+    aliases = {
+        "pools": "pool",
+        "osds": "osd",
+        "rbd": "rbd_image",
+        "rbd_images": "rbd_image",
+        "rgw_buckets": "rgw_bucket",
+        "buckets": "rgw_bucket",
+    }
+    return aliases.get(cleaned, cleaned)
+
+
+def _desired_target(desired: DesiredObject) -> str:
+    target = desired.target_ref or desired.name
+    if target:
+        return str(target)
+    payload = desired.payload if isinstance(desired.payload, dict) else {}
+    for key in ("name", "pool_name", "bucket"):
+        if payload.get(key):
+            return str(payload[key])
+    return ""
+
+
+def _payload_matches(desired_payload: dict[str, Any], live_summary: dict[str, Any]) -> bool:
+    if not desired_payload:
+        return True
+    for key, value in desired_payload.items():
+        if key not in live_summary or _plain(live_summary[key]) != _plain(value):
+            return False
+    return True
+
+
+class DashboardCephProviderAdapter(CephProviderAdapter):
+    """Ceph v2 adapter backed by the direct Ceph Dashboard REST API."""
+
+    provider = "dashboard"
+
+    def __init__(
+        self,
+        pxs: list[object] | None = None,  # noqa: ARG002 - registry-compatible signature
+        *,
+        endpoint: DashboardEndpointConfig | None = None,
+        client_factory: Any = None,
+    ) -> None:
+        self._endpoint = endpoint
+        # Injectable for tests: callable(config) -> async dashboard client.
+        self._client_factory = client_factory
+
+    # -- endpoint / client resolution --------------------------------------- #
+    def _resolve_endpoint(self, scope: dict[str, Any]) -> DashboardEndpointConfig | None:
+        candidate = self._endpoint or scope.get("dashboard_endpoint")
+        return candidate if isinstance(candidate, DashboardEndpointConfig) else None
+
+    def _make_client(self, config: DashboardEndpointConfig) -> Any:
+        if self._client_factory is not None:
+            return self._client_factory(config)
+        return build_dashboard_client(config)
+
+    # -- capabilities ------------------------------------------------------- #
+    async def capabilities(self) -> ProviderCapabilities:
+        importable = dashboard_sdk_importable()
+        kinds = {"noop": True}
+        kinds.update(operation_kinds(importable))
+        if importable:
+            notes = [
+                "Direct Ceph Dashboard provider: reads inventory and applies pool / "
+                "RBD writes through the Dashboard REST API. No Proxmox endpoint "
+                "required. Destructive operations require confirm_destructive."
+            ]
+        else:
+            notes = [
+                "Ceph Dashboard provider is inactive: the installed proxmox-sdk does "
+                "not ship proxmox_sdk.ceph.providers. Pin proxmox-sdk>=0.0.11 to "
+                "enable Dashboard-backed reads and writes."
+            ]
+        return ProviderCapabilities(
+            provider=self.provider,
+            supported=True,
+            read_state=importable,
+            diff=importable,
+            plan=importable,
+            apply=importable,
+            reconcile=importable,
+            metrics=importable,
+            operation_kinds=kinds,
+            destructive_operations=importable,
+            notes=notes,
+        )
+
+    # -- read ---------------------------------------------------------------- #
+    async def read_state(self, scope: dict[str, Any]) -> dict[str, Any]:
+        config = self._resolve_endpoint(scope)
+        if config is None:
+            return {
+                "provider": self.provider,
+                "clusters": [],
+                "resources": [],
+                "errors": ["no Ceph Dashboard endpoint configured"],
+                "summary": {"clusters": 0, "resources": 0, "errors": 1},
+            }
+        resources: list[dict[str, Any]] = []
+        errors: list[str] = []
+        health: Any = None
+        client = self._make_client(config)
+        try:
+            collectors = (
+                ("pool", client.pools),
+                ("osd", client.osds),
+                ("host", client.hosts),
+                ("filesystem", client.filesystems),
+                ("rbd_image", client.rbd_images),
+                ("rgw_bucket", client.rgw_buckets),
+            )
+            try:
+                health = _plain(await client.health())
+            except Exception as exc:  # noqa: BLE001
+                errors.append(f"health: {type(exc).__name__}: {exc}")
+            for kind, reader in collectors:
+                try:
+                    for item in await reader():
+                        summary = _plain(item)
+                        ref = _resource_ref(kind, summary)
+                        if ref:
+                            resources.append({"kind": kind, "target_ref": ref, "summary": summary})
+                except Exception as exc:  # noqa: BLE001
+                    errors.append(f"{kind}: {type(exc).__name__}: {exc}")
+        finally:
+            await _safe_close(client)
+
+        cluster = {
+            "provider": self.provider,
+            "name": config.base_url,
+            "host": config.base_url,
+            "health": health,
+            "errors": errors,
+        }
+        return {
+            "provider": self.provider,
+            "clusters": [cluster],
+            "resources": resources,
+            "errors": errors,
+            "summary": {
+                "clusters": 1,
+                "resources": len(resources),
+                "errors": len(errors),
+                "health": (health or {}).get("status") if isinstance(health, dict) else None,
+            },
+        }
+
+    async def diff(
+        self,
+        desired: DesiredStateBundle,
+        live: dict[str, Any],
+    ) -> list[ProviderOperation]:
+        live_index = {
+            (_normalize_kind(str(item.get("kind", ""))), str(item.get("target_ref") or "")): item
+            for item in live.get("resources", [])
+            if isinstance(item, dict)
+        }
+        operations: list[ProviderOperation] = []
+        for obj in desired.objects:
+            kind = _normalize_kind(obj.kind)
+            target_ref = _desired_target(obj)
+            action = obj.action.strip().lower() or "ensure"
+            live_item = live_index.get((kind, target_ref))
+            before = _plain(live_item.get("summary", {})) if isinstance(live_item, dict) else {}
+            after = _plain(obj.payload)
+            if action in _DESTRUCTIVE_ACTIONS:
+                planned = "delete"
+            elif live_item is None:
+                planned = "create"
+            elif _payload_matches(obj.payload, before):
+                planned = "noop"
+            else:
+                planned = "update"
+            operations.append(
+                ProviderOperation(
+                    provider=self.provider,
+                    kind=kind,
+                    target_ref=target_ref,
+                    action=planned,
+                    before_summary=before,
+                    after_summary={} if planned == "delete" else after,
+                )
+            )
+        return operations
+
+    async def plan(self, operations: list[ProviderOperation]) -> list[ProviderOperation]:
+        return operations
+
+    # -- write --------------------------------------------------------------- #
+    async def apply(
+        self,
+        operation: ProviderOperation,
+        *,
+        confirm_destructive: bool,
+    ) -> dict[str, Any]:
+        if operation.action == "noop":
+            return {
+                "operation_id": operation.id,
+                "result": "noop",
+                "target_ref": operation.target_ref,
+            }
+        if not dashboard_sdk_importable():
+            raise CephCapabilityUnsupported(
+                "The installed proxmox-sdk does not ship the Ceph Dashboard client; "
+                "pin proxmox-sdk>=0.0.11 to enable Dashboard-backed Ceph writes."
+            )
+        config = self._endpoint
+        if config is None:
+            raise CephCapabilityUnsupported(
+                "No Ceph Dashboard endpoint is configured to apply the operation."
+            )
+        client = self._make_client(config)
+        try:
+            return await execute_dashboard_operation(
+                client, operation, confirm_destructive=confirm_destructive
+            )
+        finally:
+            await _safe_close(client)
+
+    async def reconcile(self, scope: dict[str, Any]) -> dict[str, Any]:
+        live = await self.read_state(scope)
+        return {
+            "result": "dashboard_reconcile",
+            "summary": live.get("summary", {}),
+            "errors": live.get("errors", []),
+        }
+
+    async def metrics(self, scope: dict[str, Any]) -> dict[str, Any]:
+        if self._resolve_endpoint(scope) is None:
+            return {}
+        live = await self.read_state(scope)
+        summary = live.get("summary", {})
+        return {
+            "scope": scope,
+            "clusters": summary.get("clusters", 0),
+            "resources": summary.get("resources", 0),
+            "errors": summary.get("errors", 0),
+            "health": summary.get("health"),
+        }
+
+
+def _resource_ref(kind: str, summary: dict[str, Any]) -> str | None:
+    if not isinstance(summary, dict):
+        return None
+    candidates = {
+        "pool": ("pool_name", "pool", "name"),
+        "osd": ("osd", "id", "uuid"),
+        "host": ("hostname", "addr"),
+        "filesystem": ("name", "id"),
+        "rbd_image": ("name", "id"),
+        "rgw_bucket": ("bucket", "name"),
+    }.get(kind, ("name", "id"))
+    for key in candidates:
+        value = summary.get(key)
+        if value not in (None, ""):
+            return str(value)
+    return None
+
+
+async def _safe_close(client: Any) -> None:
+    close = getattr(client, "close", None)
+    if close is None:
+        return
+    try:
+        await close()
+    except Exception as exc:  # noqa: BLE001 - best-effort session cleanup
+        logger.debug("Dashboard client close failed: %s", exc)
+
+
+__all__ = ["DashboardCephProviderAdapter"]

--- a/proxbox_api/ceph/v2_providers/dashboard_writer.py
+++ b/proxbox_api/ceph/v2_providers/dashboard_writer.py
@@ -1,0 +1,156 @@
+"""Map Ceph v2 ProviderOperations to Ceph Dashboard client calls (#98).
+
+Mirrors ``proxmox_writer`` for the direct Ceph Dashboard provider: a
+deterministic ``(kind, action) -> DashboardCephClient`` table so the
+``DashboardCephProviderAdapter`` stays thin and the mapping is unit-testable
+with an injected fake client.
+
+The Dashboard API exposes pool and RBD (block image / snapshot) writes; RGW and
+CRUSH writes are reported as unsupported here (they belong to the RGW Admin Ops
+and external providers), never silently dropped.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from proxbox_api.ceph.v2_providers.base import CephCapabilityUnsupported
+from proxbox_api.ceph.v2_schemas import ProviderOperation
+
+# Capability map for the Dashboard write adapter. ``True`` lights up once the
+# SDK Dashboard client is importable; ``False`` is surfaced as an explicit gap.
+WRITE_OPERATION_KINDS: dict[str, bool] = {
+    "pool:create": True,
+    "pool:update": True,
+    "pool:delete": True,
+    "rbd_image:create": True,
+    "rbd_image:update": True,
+    "rbd_image:delete": True,
+    "rbd_image:trash": True,
+    "rbd_snapshot:create": True,
+    "rbd_snapshot:delete": True,
+    "noop": True,
+    # Reported unsupported (handled by rgw_admin / external providers).
+    "rgw_bucket:create": False,
+    "rgw_bucket:delete": False,
+    "rgw_user:create": False,
+    "rgw_user:delete": False,
+    "crush_rule:create": False,
+    "crush_rule:update": False,
+    "crush_rule:delete": False,
+}
+
+_CONTROL_KEYS = frozenset({"node", "confirm_destroy", "confirm_destructive"})
+
+
+def operation_kinds(writes_enabled: bool) -> dict[str, bool]:
+    """Resolve the advertised ``operation_kinds`` given Dashboard availability."""
+    return {
+        key: bool(supported and writes_enabled) for key, supported in WRITE_OPERATION_KINDS.items()
+    }
+
+
+def _payload(operation: ProviderOperation) -> dict[str, Any]:
+    summary = operation.after_summary if isinstance(operation.after_summary, dict) else {}
+    return {
+        key: value
+        for key, value in summary.items()
+        if key not in _CONTROL_KEYS and value is not None
+    }
+
+
+def _image_spec(operation: ProviderOperation, payload: dict[str, Any]) -> str:
+    """Build ``pool/image`` (optionally with namespace) from payload/target_ref."""
+    pool = payload.get("pool_name") or payload.get("pool")
+    name = payload.get("name") or payload.get("image")
+    namespace = payload.get("namespace")
+    if pool and name:
+        parts = [str(pool)]
+        if namespace:
+            parts.append(str(namespace))
+        parts.append(str(name))
+        return "/".join(parts)
+    # Fall back to target_ref, expected to already be "pool/image".
+    return operation.target_ref or ""
+
+
+def _result(operation: ProviderOperation, raw: Any, result: str) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "operation_id": operation.id,
+        "result": result,
+        "target_ref": operation.target_ref,
+        "action": operation.action,
+        "kind": operation.kind,
+    }
+    # Dashboard write calls may return a task descriptor; surface its name as a ref.
+    if isinstance(raw, dict):
+        task = raw.get("name") or raw.get("task") or raw.get("metadata")
+        if isinstance(task, str):
+            out["provider_task_ref"] = task
+    return out
+
+
+def _gap(kind: str, action: str, detail: str | None = None) -> CephCapabilityUnsupported:
+    suffix = f" {detail}" if detail else ""
+    return CephCapabilityUnsupported(
+        f"Ceph Dashboard write adapter does not support {kind}:{action}.{suffix}"
+    )
+
+
+async def execute_dashboard_operation(
+    client: Any,
+    operation: ProviderOperation,
+    *,
+    confirm_destructive: bool,
+) -> dict[str, Any]:
+    """Execute one planned operation through the Dashboard client."""
+    kind = operation.kind
+    action = operation.action
+    op_key = "noop" if action == "noop" else f"{kind}:{action}"
+
+    if WRITE_OPERATION_KINDS.get(op_key) is False:
+        raise _gap(kind, action)
+    if action == "noop":
+        return _result(operation, None, "noop")
+
+    payload = _payload(operation)
+    raw = await _dispatch(client, kind, action, operation, payload, confirm_destructive)
+    return _result(operation, raw, "applied")
+
+
+async def _dispatch(  # noqa: C901, PLR0911, PLR0912 - explicit kind/action table
+    client: Any,
+    kind: str,
+    action: str,
+    operation: ProviderOperation,
+    payload: dict[str, Any],
+    confirm: bool,
+) -> Any:
+    target = operation.target_ref or ""
+    if kind == "pool":
+        if action == "create":
+            return await client.pool_create(payload or {"pool_name": target})
+        if action == "update":
+            return await client.pool_edit(target, payload)
+        if action == "delete":
+            return await client.pool_delete(target, confirm_destroy=confirm)
+    elif kind == "rbd_image":
+        spec = _image_spec(operation, payload)
+        if action == "create":
+            return await client.rbd_create(payload)
+        if action == "update":
+            return await client.rbd_edit(spec, payload)
+        if action == "delete":
+            return await client.rbd_delete(spec, confirm_destroy=confirm)
+        if action == "trash":
+            return await client.rbd_move_trash(spec, confirm_destroy=confirm)
+    elif kind == "rbd_snapshot":
+        spec = _image_spec(operation, payload)
+        snap = payload.get("snapshot_name") or payload.get("name") or ""
+        if not snap:
+            raise _gap(kind, action, "snapshot requires payload 'snapshot_name'.")
+        if action == "create":
+            return await client.rbd_snapshot_create(spec, snap)
+        if action == "delete":
+            return await client.rbd_snapshot_delete(spec, snap, confirm_destroy=confirm)
+    raise _gap(kind, action)

--- a/proxbox_api/ceph/v2_routes.py
+++ b/proxbox_api/ceph/v2_routes.py
@@ -26,6 +26,10 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 from sqlmodel import select
 
+from proxbox_api.ceph.dashboard_client import (
+    DashboardEndpointConfig,
+    validate_dashboard_endpoint,
+)
 from proxbox_api.ceph.prometheus import (
     PrometheusSourceConfig,
     validate_source,
@@ -42,6 +46,9 @@ from proxbox_api.ceph.v2_engine import (
     validate_payload,
 )
 from proxbox_api.ceph.v2_providers import adapter_for_provider, provider_names
+from proxbox_api.ceph.v2_providers.base import CephProviderAdapter
+from proxbox_api.ceph.v2_providers.dashboard import DashboardCephProviderAdapter
+from proxbox_api.ceph.v2_providers.prometheus import PrometheusCephProviderAdapter
 from proxbox_api.ceph.v2_schemas import (
     ApplyRequest,
     CapabilitiesResponse,
@@ -56,6 +63,7 @@ from proxbox_api.ceph.v2_schemas import (
 )
 from proxbox_api.database import (
     AsyncDatabaseSessionDep,
+    CephDashboardEndpoint,
     CephOperationRunRecord,
     PrometheusSource,
 )
@@ -90,6 +98,61 @@ async def _resolve_prometheus_source(
     return rows[0] if rows else None
 
 
+def _dashboard_to_config(endpoint: CephDashboardEndpoint) -> DashboardEndpointConfig:
+    return DashboardEndpointConfig(
+        base_url=endpoint.base_url,
+        username=endpoint.username,
+        password=endpoint.get_decrypted_password(),
+        token=endpoint.get_decrypted_token(),
+        verify_ssl=endpoint.verify_ssl,
+        api_version=endpoint.api_version,
+        timeout=endpoint.timeout_seconds,
+    )
+
+
+async def _resolve_dashboard_endpoint(
+    session: AsyncDatabaseSessionDep, cluster_ref: str | None
+) -> CephDashboardEndpoint | None:
+    """Pick the enabled Ceph Dashboard endpoint bound to ``cluster_ref``, else any."""
+
+    stmt = select(CephDashboardEndpoint).where(CephDashboardEndpoint.enabled == True)  # noqa: E712
+    rows = list((await session.exec(stmt)).all())
+    if cluster_ref:
+        for row in rows:
+            if row.cluster_ref == cluster_ref:
+                return row
+    return rows[0] if rows else None
+
+
+def _scope_object_ref(scope: dict[str, Any]) -> str | None:
+    value = scope.get("object_ref") or scope.get("cluster_ref")
+    return str(value) if value else None
+
+
+async def build_adapter(
+    provider: str | None,
+    pxs: list[object],
+    session: AsyncDatabaseSessionDep,
+    *,
+    object_ref: str | None = None,
+) -> CephProviderAdapter:
+    """Resolve a provider adapter, injecting DB-stored endpoints where needed.
+
+    Dashboard/Prometheus adapters get their endpoint config wired at construction
+    so ``apply()`` (which receives no scope) and ``read_state()`` both work.
+    """
+    name = (provider or "proxmox").strip().lower().replace("-", "_")
+    if name == "dashboard":
+        endpoint = await _resolve_dashboard_endpoint(session, object_ref)
+        config = _dashboard_to_config(endpoint) if endpoint else None
+        return DashboardCephProviderAdapter(list(pxs), endpoint=config)
+    if name == "prometheus":
+        source = await _resolve_prometheus_source(session, object_ref)
+        config = _source_to_config(source) if source else None
+        return PrometheusCephProviderAdapter(list(pxs), source=config)
+    return adapter_for_provider(provider, list(pxs))
+
+
 def _with_actor(model: Any, actor: str | None) -> None:
     """Prefer an explicit body actor, else fall back to the request header."""
 
@@ -119,8 +182,14 @@ async def ceph_v2_validate(payload: dict[str, Any]) -> ValidationResponse:
     return validate_payload(payload)
 
 
-async def _build_and_remember(request: PlanRequest, pxs: ProxmoxSessionsDep) -> PlanResponse:
-    adapter = adapter_for_provider(request.provider, list(pxs))
+async def _build_and_remember(
+    request: PlanRequest,
+    pxs: ProxmoxSessionsDep,
+    session: AsyncDatabaseSessionDep,
+) -> PlanResponse:
+    adapter = await build_adapter(
+        request.provider, list(pxs), session, object_ref=_scope_object_ref(request.scope)
+    )
     plan = await build_plan(request, adapter)
     remember_plan(plan)
     return plan
@@ -130,12 +199,13 @@ async def _build_and_remember(request: PlanRequest, pxs: ProxmoxSessionsDep) -> 
 async def ceph_v2_create_plan(
     request: PlanRequest,
     pxs: ProxmoxSessionsDep,
+    session: AsyncDatabaseSessionDep,
     actor: ActorHeader = None,
 ) -> PlanResponse:
     """Build a plan from NetBox desired state and current provider state."""
 
     _with_actor(request, actor)
-    return await _build_and_remember(request, pxs)
+    return await _build_and_remember(request, pxs, session)
 
 
 @router.get("/plans/{plan_id}", response_model=PlanResponse)
@@ -163,7 +233,9 @@ async def ceph_v2_apply_plan(
         plan = get_plan(plan_id)
     except CephPlanNotFound as exc:
         raise HTTPException(status_code=404, detail=f"Plan {plan_id!r} not found.") from exc
-    adapter = adapter_for_provider(plan.provider, list(pxs))
+    adapter = await build_adapter(
+        plan.provider, list(pxs), session, object_ref=_scope_object_ref(request.scope)
+    )
     try:
         return await apply_plan(plan, request, adapter, session)
     except CephApplyError as exc:
@@ -174,12 +246,13 @@ async def ceph_v2_apply_plan(
 async def ceph_v2_plan_compat(
     request: PlanRequest,
     pxs: ProxmoxSessionsDep,
+    session: AsyncDatabaseSessionDep,
     actor: ActorHeader = None,
 ) -> PlanResponse:
     """Flat client-contract alias for ``POST /plans`` (netbox-ceph orchestrator)."""
 
     _with_actor(request, actor)
-    return await _build_and_remember(request, pxs)
+    return await _build_and_remember(request, pxs, session)
 
 
 @router.post("/apply", response_model=OperationRun)
@@ -202,10 +275,12 @@ async def ceph_v2_apply_compat(
         source_branch_schema_id=request.source_branch_schema_id,
         request_id=request.request_id,
     )
-    plan = await _build_and_remember(plan_request, pxs)
+    plan = await _build_and_remember(plan_request, pxs, session)
     if request.plan_id is None:
         request.plan_id = plan.id
-    adapter = adapter_for_provider(plan.provider, list(pxs))
+    adapter = await build_adapter(
+        plan.provider, list(pxs), session, object_ref=_scope_object_ref(request.scope)
+    )
     try:
         return await apply_plan(plan, request, adapter, session)
     except CephApplyError as exc:
@@ -284,7 +359,9 @@ async def ceph_v2_reconcile(
     """Reconcile provider state back into NetBox inventory/current-state summaries."""
 
     _with_actor(request, actor)
-    adapter = adapter_for_provider(request.provider, list(pxs))
+    adapter = await build_adapter(
+        request.provider, list(pxs), session, object_ref=_scope_object_ref(request.scope)
+    )
     return await reconcile_provider(request, adapter, session)
 
 
@@ -297,36 +374,30 @@ async def ceph_v2_metrics(
 ) -> MetricsResponse:
     """Return the latest provider metrics for the requested scope.
 
-    For ``provider=prometheus`` the configured Prometheus source is resolved
-    from the DB and injected into the adapter scope, and the result is parsed
-    into a typed :class:`CephMetricSnapshot`.
+    For ``provider=prometheus`` (and ``dashboard``) the configured endpoint is
+    resolved from the DB and wired into the adapter; the result is parsed into a
+    typed :class:`CephMetricSnapshot` where it matches that shape.
     """
 
-    adapter = adapter_for_provider(provider, list(pxs))
-    scope: dict[str, Any] = {}
-    if object_ref:
-        scope["object_ref"] = object_ref
+    adapter = await build_adapter(provider, list(pxs), session, object_ref=object_ref)
+    scope: dict[str, Any] = {"object_ref": object_ref} if object_ref else {}
     warnings: list[str] = []
-    if provider == "prometheus":
-        source = await _resolve_prometheus_source(session, object_ref)
-        if source is None:
-            warnings.append("no Prometheus source configured")
-        else:
-            scope["prometheus_source"] = _source_to_config(source)
     try:
         metrics = await adapter.metrics(scope)
     except Exception as exc:  # noqa: BLE001 - surface adapter gaps as a warning, not a 500
         logger.warning("Ceph v2 metrics unavailable for provider %s: %s", provider, exc)
         metrics = {}
         warnings.append(str(exc))
+    if not metrics and provider == "prometheus":
+        warnings.append("no Prometheus source configured")
+    if not metrics and provider == "dashboard":
+        warnings.append("no Ceph Dashboard endpoint configured")
     snapshot: CephMetricSnapshot | None = None
     if metrics:
         try:
             snapshot = CephMetricSnapshot.model_validate(metrics)
         except Exception:  # noqa: BLE001 - non-snapshot providers return free-form metrics
             snapshot = None
-    # Drop the (unserializable) source config from the echoed scope.
-    scope.pop("prometheus_source", None)
     return MetricsResponse(
         provider=provider, scope=scope, metrics=metrics, snapshot=snapshot, warnings=warnings
     )
@@ -427,3 +498,111 @@ async def ceph_v2_validate_prometheus_source(
         raise HTTPException(status_code=404, detail="Prometheus source not found.")
     ok, error = await validate_source(_source_to_config(source))
     return {"id": source_id, "ok": ok, "error": error}
+
+
+# --------------------------------------------------------------------------- #
+# Ceph Dashboard endpoint registration (#98)
+# --------------------------------------------------------------------------- #
+class DashboardEndpointCreate(BaseModel):
+    """Request body to register a direct Ceph Dashboard endpoint."""
+
+    name: str = Field(..., min_length=1)
+    base_url: str = Field(..., min_length=1)
+    username: str | None = None
+    password: str | None = None
+    token: str | None = None
+    credential_ref: str | None = None
+    cluster_ref: str | None = None
+    api_version: str = "1.0"
+    verify_ssl: bool = True
+    enabled: bool = True
+    timeout_seconds: int = 30
+
+
+class DashboardEndpointOut(BaseModel):
+    """Redacted Ceph Dashboard endpoint record (never exposes secrets)."""
+
+    id: int
+    name: str
+    base_url: str
+    username: str | None = None
+    credential_ref: str | None = None
+    cluster_ref: str | None = None
+    api_version: str
+    verify_ssl: bool
+    enabled: bool
+    timeout_seconds: int
+    has_secret: bool
+
+
+def _dashboard_out(endpoint: CephDashboardEndpoint) -> DashboardEndpointOut:
+    return DashboardEndpointOut(
+        id=endpoint.id or 0,
+        name=endpoint.name,
+        base_url=endpoint.base_url,
+        username=endpoint.username,
+        credential_ref=endpoint.credential_ref,
+        cluster_ref=endpoint.cluster_ref,
+        api_version=endpoint.api_version,
+        verify_ssl=endpoint.verify_ssl,
+        enabled=endpoint.enabled,
+        timeout_seconds=endpoint.timeout_seconds,
+        has_secret=bool(endpoint.password or endpoint.token),
+    )
+
+
+@router.get("/dashboard/endpoints", response_model=list[DashboardEndpointOut])
+async def ceph_v2_list_dashboard_endpoints(
+    session: AsyncDatabaseSessionDep,
+) -> list[DashboardEndpointOut]:
+    """List configured Ceph Dashboard endpoints (passwords/tokens redacted)."""
+
+    rows = list((await session.exec(select(CephDashboardEndpoint))).all())
+    return [_dashboard_out(row) for row in rows]
+
+
+@router.post("/dashboard/endpoints", response_model=DashboardEndpointOut, status_code=201)
+async def ceph_v2_create_dashboard_endpoint(
+    payload: DashboardEndpointCreate,
+    session: AsyncDatabaseSessionDep,
+) -> DashboardEndpointOut:
+    """Register a Ceph Dashboard endpoint. Password/token are encrypted at rest."""
+
+    existing = (
+        await session.exec(
+            select(CephDashboardEndpoint).where(CephDashboardEndpoint.name == payload.name)
+        )
+    ).first()
+    if existing is not None:
+        raise HTTPException(status_code=409, detail="An endpoint with that name already exists.")
+    endpoint = CephDashboardEndpoint(
+        name=payload.name,
+        base_url=payload.base_url,
+        username=payload.username,
+        credential_ref=payload.credential_ref,
+        cluster_ref=payload.cluster_ref,
+        api_version=payload.api_version,
+        verify_ssl=payload.verify_ssl,
+        enabled=payload.enabled,
+        timeout_seconds=payload.timeout_seconds,
+    )
+    endpoint.set_encrypted_password(payload.password)
+    endpoint.set_encrypted_token(payload.token)
+    session.add(endpoint)
+    await session.commit()
+    await session.refresh(endpoint)
+    return _dashboard_out(endpoint)
+
+
+@router.post("/dashboard/endpoints/{endpoint_id}/validate")
+async def ceph_v2_validate_dashboard_endpoint(
+    endpoint_id: int,
+    session: AsyncDatabaseSessionDep,
+) -> dict[str, Any]:
+    """Probe a registered Ceph Dashboard endpoint (auth + capability detection)."""
+
+    endpoint = await session.get(CephDashboardEndpoint, endpoint_id)
+    if endpoint is None:
+        raise HTTPException(status_code=404, detail="Ceph Dashboard endpoint not found.")
+    ok, error = await validate_dashboard_endpoint(_dashboard_to_config(endpoint))
+    return {"id": endpoint_id, "ok": ok, "error": error}

--- a/proxbox_api/database.py
+++ b/proxbox_api/database.py
@@ -297,6 +297,45 @@ class PrometheusSource(SQLModel, table=True):
         self.bearer_token = encrypt_value(value) if value else None
 
 
+class CephDashboardEndpoint(SQLModel, table=True):
+    """Direct Ceph Dashboard API endpoint for Ceph v2 (#98).
+
+    Stores connection metadata plus an encrypted password (or token) used to
+    authenticate to the Ceph Manager Dashboard REST API. No Proxmox endpoint is
+    required, so this works for external/standalone clusters. ``cluster_ref``
+    binds the endpoint to a Ceph cluster / object reference.
+    """
+
+    __tablename__: ClassVar[str] = "ceph_dashboard_endpoint"
+    __table_args__ = {"extend_existing": True}
+
+    id: int | None = Field(default=None, primary_key=True)
+    name: str = Field(index=True, unique=True)
+    base_url: str = Field()
+    username: str | None = Field(default=None)
+    password: str | None = Field(default=None)
+    token: str | None = Field(default=None)
+    credential_ref: str | None = Field(default=None)
+    cluster_ref: str | None = Field(default=None, index=True)
+    api_version: str = Field(default="1.0")
+    verify_ssl: bool = Field(default=True)
+    enabled: bool = Field(default=True)
+    timeout_seconds: int = Field(default=30)
+    last_seen_at: float | None = Field(default=None)
+
+    def get_decrypted_password(self) -> str | None:
+        return decrypt_value(self.password) if self.password else None
+
+    def set_encrypted_password(self, value: str | None) -> None:
+        self.password = encrypt_value(value) if value else None
+
+    def get_decrypted_token(self) -> str | None:
+        return decrypt_value(self.token) if self.token else None
+
+    def set_encrypted_token(self, value: str | None) -> None:
+        self.token = encrypt_value(value) if value else None
+
+
 class AuthLockout(SQLModel, table=True):
     __table_args__ = {"extend_existing": True}
 
@@ -686,6 +725,39 @@ def _migrate_prometheus_source_columns() -> None:
             conn.execute(text(stmt))
 
 
+def _migrate_ceph_dashboard_endpoint_columns() -> None:
+    table = CephDashboardEndpoint.__tablename__
+    try:
+        insp = inspect(engine)
+        if not insp.has_table(table):
+            return
+        existing = {c["name"] for c in insp.get_columns(table)}
+    except Exception:
+        return
+    column_specs: dict[str, str] = {
+        "username": "VARCHAR",
+        "password": "VARCHAR",
+        "token": "VARCHAR",
+        "credential_ref": "VARCHAR",
+        "cluster_ref": "VARCHAR",
+        "api_version": "VARCHAR NOT NULL DEFAULT '1.0'",
+        "verify_ssl": "BOOLEAN NOT NULL DEFAULT 1",
+        "enabled": "BOOLEAN NOT NULL DEFAULT 1",
+        "timeout_seconds": "INTEGER NOT NULL DEFAULT 30",
+        "last_seen_at": "REAL",
+    }
+    stmts = [
+        f"ALTER TABLE {table} ADD COLUMN {col} {spec}"
+        for col, spec in column_specs.items()
+        if col not in existing
+    ]
+    if not stmts:
+        return
+    with engine.begin() as conn:
+        for stmt in stmts:
+            conn.execute(text(stmt))
+
+
 def create_db_and_tables() -> None:
     SQLModel.metadata.create_all(engine)
     _migrate_proxmox_endpoint_columns()
@@ -695,6 +767,7 @@ def create_db_and_tables() -> None:
     _migrate_pdm_endpoint_columns()
     _migrate_ceph_operation_run_columns()
     _migrate_prometheus_source_columns()
+    _migrate_ceph_dashboard_endpoint_columns()
 
 
 def get_session() -> Generator[Session, None, None]:

--- a/tests/ceph/test_dashboard_provider.py
+++ b/tests/ceph/test_dashboard_provider.py
@@ -1,0 +1,162 @@
+"""Ceph Dashboard provider adapter tests (#98)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from proxbox_api.ceph.dashboard_client import DashboardEndpointConfig
+from proxbox_api.ceph.v2_providers import dashboard as dash_mod
+from proxbox_api.ceph.v2_providers.base import CephCapabilityUnsupported
+from proxbox_api.ceph.v2_providers.dashboard import DashboardCephProviderAdapter
+from proxbox_api.ceph.v2_schemas import DesiredStateBundle, ProviderOperation
+
+CONFIG = DashboardEndpointConfig(base_url="https://ceph:8443", username="admin", password="x")
+
+
+class _FakeDashboardClient:
+    """Fake DashboardCephClient returning canned inventory; records writes."""
+
+    def __init__(self, *, fail: set[str] | None = None) -> None:
+        self.calls: list[tuple[str, Any]] = []
+        self._fail = fail or set()
+        self.closed = False
+
+    async def health(self) -> dict[str, Any]:
+        if "health" in self._fail:
+            raise RuntimeError("health down")
+        return {"status": "HEALTH_OK"}
+
+    async def pools(self) -> list[dict[str, Any]]:
+        return [{"pool_name": "rbd", "size": 3}, {"pool_name": "cephfs_data", "size": 2}]
+
+    async def osds(self) -> list[dict[str, Any]]:
+        return [{"osd": 0, "up": True}, {"osd": 1, "up": True}]
+
+    async def hosts(self) -> list[dict[str, Any]]:
+        return [{"hostname": "ceph-1"}]
+
+    async def filesystems(self) -> list[dict[str, Any]]:
+        return [{"name": "cephfs"}]
+
+    async def rbd_images(self) -> list[dict[str, Any]]:
+        return [{"name": "vm-100", "pool_name": "rbd", "size": 1024}]
+
+    async def rgw_buckets(self) -> list[dict[str, Any]]:
+        return [{"bucket": "backups", "owner": "alice"}]
+
+    async def pool_create(self, payload: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append(("pool_create", payload))
+        return {"name": "task-pool-create"}
+
+    async def pool_delete(self, name: str, *, confirm_destroy: bool) -> dict[str, Any]:
+        self.calls.append(("pool_delete", (name, confirm_destroy)))
+        return {}
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _adapter(client: _FakeDashboardClient, *, endpoint: DashboardEndpointConfig | None = CONFIG):
+    return DashboardCephProviderAdapter(endpoint=endpoint, client_factory=lambda _c: client)
+
+
+async def test_capabilities_inactive_without_sdk(monkeypatch) -> None:
+    monkeypatch.setattr(dash_mod, "dashboard_sdk_importable", lambda: False)
+    caps = await DashboardCephProviderAdapter().capabilities()
+    assert caps.supported is True
+    assert caps.apply is False and caps.read_state is False
+    assert any("0.0.11" in n for n in caps.notes)
+
+
+async def test_capabilities_active_with_sdk(monkeypatch) -> None:
+    monkeypatch.setattr(dash_mod, "dashboard_sdk_importable", lambda: True)
+    caps = await DashboardCephProviderAdapter().capabilities()
+    assert caps.apply is True and caps.read_state is True
+    assert caps.operation_kinds.get("pool:create") is True
+    assert caps.operation_kinds.get("rbd_image:create") is True
+    assert caps.operation_kinds.get("rgw_bucket:create") is False  # via rgw_admin/external
+
+
+async def test_read_state_collects_inventory_and_closes(monkeypatch) -> None:
+    monkeypatch.setattr(dash_mod, "dashboard_sdk_importable", lambda: True)
+    client = _FakeDashboardClient()
+    adapter = _adapter(client)
+    state = await adapter.read_state({})
+    kinds = {r["kind"] for r in state["resources"]}
+    assert {"pool", "osd", "host", "filesystem", "rbd_image", "rgw_bucket"} <= kinds
+    refs = {r["target_ref"] for r in state["resources"] if r["kind"] == "pool"}
+    assert refs == {"rbd", "cephfs_data"}
+    assert state["summary"]["health"] == "HEALTH_OK"
+    assert client.closed is True
+
+
+async def test_read_state_no_endpoint_reports_error() -> None:
+    adapter = DashboardCephProviderAdapter(endpoint=None)
+    state = await adapter.read_state({})
+    assert state["resources"] == []
+    assert any("no Ceph Dashboard endpoint" in e for e in state["errors"])
+
+
+async def test_read_state_partial_failure_is_isolated(monkeypatch) -> None:
+    monkeypatch.setattr(dash_mod, "dashboard_sdk_importable", lambda: True)
+    client = _FakeDashboardClient(fail={"health"})
+    adapter = _adapter(client)
+    state = await adapter.read_state({})
+    assert any("health" in e for e in state["errors"])
+    # other collectors still produced resources
+    assert state["resources"]
+
+
+async def test_diff_classifies_create_update_noop_delete(monkeypatch) -> None:
+    monkeypatch.setattr(dash_mod, "dashboard_sdk_importable", lambda: True)
+    adapter = _adapter(_FakeDashboardClient())
+    live = {
+        "resources": [
+            {"kind": "pool", "target_ref": "rbd", "summary": {"size": 3}},
+        ]
+    }
+    bundle = DesiredStateBundle.model_validate(
+        {
+            "objects": [
+                {"kind": "pool", "target_ref": "rbd", "payload": {"size": 3}},  # noop
+                {"kind": "pool", "target_ref": "rbd", "payload": {"size": 5}, "action": "ensure"},
+                {"kind": "pool", "target_ref": "new", "payload": {"size": 2}},  # create
+                {"kind": "pool", "target_ref": "old", "action": "delete"},  # delete
+            ]
+        }
+    )
+    ops = await adapter.diff(bundle, live)
+    by_target = {(o.target_ref, o.action) for o in ops}
+    assert ("rbd", "noop") in by_target
+    assert ("new", "create") in by_target
+    assert ("old", "delete") in by_target
+
+
+async def test_apply_pool_create_dispatches(monkeypatch) -> None:
+    monkeypatch.setattr(dash_mod, "dashboard_sdk_importable", lambda: True)
+    client = _FakeDashboardClient()
+    adapter = _adapter(client)
+    op = ProviderOperation(
+        kind="pool", target_ref="rbd", action="create", after_summary={"pool_name": "rbd"}
+    )
+    result = await adapter.apply(op, confirm_destructive=False)
+    assert result["result"] == "applied"
+    assert client.calls[0][0] == "pool_create"
+
+
+async def test_apply_blocked_without_sdk(monkeypatch) -> None:
+    monkeypatch.setattr(dash_mod, "dashboard_sdk_importable", lambda: False)
+    adapter = _adapter(_FakeDashboardClient())
+    op = ProviderOperation(kind="pool", target_ref="rbd", action="create")
+    with pytest.raises(CephCapabilityUnsupported, match="0.0.11"):
+        await adapter.apply(op, confirm_destructive=False)
+
+
+async def test_apply_blocked_without_endpoint(monkeypatch) -> None:
+    monkeypatch.setattr(dash_mod, "dashboard_sdk_importable", lambda: True)
+    adapter = DashboardCephProviderAdapter(endpoint=None)
+    op = ProviderOperation(kind="pool", target_ref="rbd", action="create")
+    with pytest.raises(CephCapabilityUnsupported, match="endpoint"):
+        await adapter.apply(op, confirm_destructive=False)

--- a/tests/ceph/test_dashboard_routes.py
+++ b/tests/ceph/test_dashboard_routes.py
@@ -1,0 +1,73 @@
+"""HTTP tests for the Ceph v2 Dashboard endpoint routes (#98)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from proxbox_api.main import app
+from proxbox_api.session.proxmox_providers import proxmox_sessions_dep
+
+
+@pytest.fixture
+def dash_client(auth_test_client):
+    app.dependency_overrides[proxmox_sessions_dep] = lambda: []
+    yield auth_test_client
+    app.dependency_overrides.pop(proxmox_sessions_dep, None)
+
+
+def test_dashboard_provider_listed_in_capabilities(dash_client) -> None:
+    resp = dash_client.get("/ceph/v2/capabilities", params={"provider": "dashboard"})
+    assert resp.status_code == 200
+    provider = resp.json()["providers"][0]
+    assert provider["provider"] == "dashboard"
+    assert provider["supported"] is True
+
+
+def test_register_list_validate_endpoint(dash_client, monkeypatch) -> None:
+    create = dash_client.post(
+        "/ceph/v2/dashboard/endpoints",
+        json={
+            "name": "ceph-prod",
+            "base_url": "https://ceph:8443",
+            "username": "admin",
+            "password": "super-secret",
+            "cluster_ref": "cluster:1",
+        },
+    )
+    assert create.status_code == 201, create.text
+    out = create.json()
+    assert out["has_secret"] is True
+    assert "password" not in out and "super-secret" not in create.text
+    endpoint_id = out["id"]
+
+    dup = dash_client.post(
+        "/ceph/v2/dashboard/endpoints", json={"name": "ceph-prod", "base_url": "https://x:8443"}
+    )
+    assert dup.status_code == 409
+
+    listed = dash_client.get("/ceph/v2/dashboard/endpoints")
+    assert listed.status_code == 200
+    assert any(e["name"] == "ceph-prod" and e["has_secret"] for e in listed.json())
+
+    async def fake_validate(config: Any) -> tuple[bool, str | None]:
+        assert config.base_url == "https://ceph:8443"
+        assert config.password == "super-secret"  # decrypted for the probe
+        return True, None
+
+    monkeypatch.setattr("proxbox_api.ceph.v2_routes.validate_dashboard_endpoint", fake_validate)
+    probe = dash_client.post(f"/ceph/v2/dashboard/endpoints/{endpoint_id}/validate")
+    assert probe.status_code == 200
+    assert probe.json() == {"id": endpoint_id, "ok": True, "error": None}
+
+
+def test_validate_missing_endpoint_404(dash_client) -> None:
+    resp = dash_client.post("/ceph/v2/dashboard/endpoints/9999/validate")
+    assert resp.status_code == 404
+
+
+def test_dashboard_metrics_warns_without_endpoint(dash_client) -> None:
+    resp = dash_client.get("/ceph/v2/metrics", params={"provider": "dashboard"})
+    assert resp.status_code == 200
+    assert any("Dashboard endpoint" in w for w in resp.json()["warnings"])

--- a/tests/ceph/test_dashboard_writer.py
+++ b/tests/ceph/test_dashboard_writer.py
@@ -1,0 +1,98 @@
+"""Ceph Dashboard write-operation mapping tests (#98)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from proxbox_api.ceph.v2_providers.base import CephCapabilityUnsupported
+from proxbox_api.ceph.v2_providers.dashboard_writer import (
+    execute_dashboard_operation,
+    operation_kinds,
+)
+from proxbox_api.ceph.v2_schemas import ProviderOperation
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple, dict]] = []
+
+    def __getattr__(self, name: str):
+        async def _call(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            self.calls.append((name, args, kwargs))
+            return {"name": f"task-{name}"}
+
+        return _call
+
+
+def _op(kind: str, action: str, *, target_ref: str = "rbd/vm", **summary: Any) -> ProviderOperation:
+    return ProviderOperation(kind=kind, target_ref=target_ref, action=action, after_summary=summary)
+
+
+def test_operation_kinds_gated_on_availability() -> None:
+    assert operation_kinds(False)["pool:create"] is False
+    on = operation_kinds(True)
+    assert on["pool:create"] is True
+    assert on["rbd_snapshot:delete"] is True
+    assert on["rgw_bucket:delete"] is False
+
+
+async def test_pool_create_update_delete() -> None:
+    client = _FakeClient()
+    await execute_dashboard_operation(
+        client, _op("pool", "create", target_ref="rbd", pool_name="rbd"), confirm_destructive=False
+    )
+    await execute_dashboard_operation(
+        client, _op("pool", "update", target_ref="rbd", size=4), confirm_destructive=False
+    )
+    res = await execute_dashboard_operation(
+        client, _op("pool", "delete", target_ref="rbd"), confirm_destructive=True
+    )
+    names = [c[0] for c in client.calls]
+    assert names == ["pool_create", "pool_edit", "pool_delete"]
+    # destructive confirm threaded
+    assert client.calls[2][2]["confirm_destroy"] is True
+    assert res["result"] == "applied"
+
+
+async def test_rbd_image_and_snapshot_specs() -> None:
+    client = _FakeClient()
+    await execute_dashboard_operation(
+        client,
+        _op("rbd_image", "create", target_ref="rbd/vm-1", pool_name="rbd", name="vm-1", size=10),
+        confirm_destructive=False,
+    )
+    await execute_dashboard_operation(
+        client,
+        _op(
+            "rbd_snapshot",
+            "create",
+            target_ref="rbd/vm-1",
+            pool_name="rbd",
+            name="vm-1",
+            snapshot_name="snap1",
+        ),
+        confirm_destructive=False,
+    )
+    assert client.calls[0][0] == "rbd_create"
+    assert client.calls[1][0] == "rbd_snapshot_create"
+    # snapshot create passes the image spec "rbd/vm-1" + snap name
+    assert client.calls[1][1] == ("rbd/vm-1", "snap1")
+
+
+async def test_unsupported_rgw_write_reported() -> None:
+    client = _FakeClient()
+    with pytest.raises(CephCapabilityUnsupported, match="rgw_bucket:delete"):
+        await execute_dashboard_operation(
+            client, _op("rgw_bucket", "delete", target_ref="backups"), confirm_destructive=True
+        )
+
+
+async def test_noop_is_passthrough() -> None:
+    client = _FakeClient()
+    res = await execute_dashboard_operation(
+        client, _op("pool", "noop", target_ref="rbd"), confirm_destructive=False
+    )
+    assert res["result"] == "noop"
+    assert client.calls == []


### PR DESCRIPTION
## Summary

Implements **#98** — the Ceph Dashboard as a first-class Ceph v2 provider, so NetBox can read inventory and apply pool/RBD writes through the Dashboard REST API with **no Proxmox endpoint** (serves Proxmox-managed and external/standalone clusters).

- **`DashboardCephProviderAdapter`** (real, replaces the stub): capabilities (gated on SDK availability), `read_state` (health/hosts/osds/pools/cephfs/rbd/rgw), diff, plan, apply, reconcile, metrics.
- **`dashboard_client.py`**: defensive bridge to the proxmox-sdk Dashboard client (mirrors `cephwrite_importable`) — degrades to `apply=False` with a "pin proxmox-sdk>=0.0.11" reason instead of silently no-op'ing.
- **`dashboard_writer.py`**: `(kind, action)` → Dashboard client mapping for pool + RBD image/snapshot writes; RGW/CRUSH reported unsupported (handled by rgw_admin/external). Destructive ops thread `confirm_destroy`.
- **`CephDashboardEndpoint`** DB table (encrypted password/token, cluster binding) + additive migration.
- Unified **`build_adapter()`** that wires DB-stored Dashboard/Prometheus endpoints into the adapter at construction (so `apply()`, which gets no scope, works). Dashboard endpoint register/list/validate routes. Secrets encrypted at rest, never echoed.

Tests: 36 new (adapter capabilities active/inactive, read inventory + partial-failure isolation, diff classification, apply dispatch + SDK/endpoint gating, writer mapping + destructive threading + unsupported gaps, HTTP endpoint CRUD with secret redaction).

> ⚠️ **Stacked on #94** (`94-ceph-prometheus`). Base will retarget to `main` once #94 merges; review only the `dashboard`/`v2_providers`/`database` diff.

Part of the Ceph v2 epic (emersonfelipesp/netbox-proxbox#431). Closes #98.