### PR TITLE
Ceph v2: external (non-Proxmox) Ceph cluster support (#97)

### DIFF
--- a/proxbox_api/ceph/dashboard_client.py
+++ b/proxbox_api/ceph/dashboard_client.py
@@ -1,0 +1,86 @@
+"""Ceph Dashboard provider client bridge for Ceph v2 (#98).
+
+Wraps the ``proxmox-sdk`` direct Ceph Dashboard client behind a defensive
+import, mirroring the ``cephwrite_importable()`` pattern: the adapter degrades
+cleanly (reports ``available=False``) when the installed ``proxmox-sdk`` pin
+does not yet ship ``proxmox_sdk.ceph.providers`` (added in 0.0.11), instead of
+silently failing. Pin proxmox-sdk to >=0.0.11 to activate the Dashboard path.
+
+The SDK client owns its own HTTP session (the Dashboard API is a standalone
+service, not the PVE API), so no Proxmox endpoint is required — this is what
+lets the Dashboard provider serve external/standalone Ceph clusters.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class DashboardEndpointConfig:
+    """Connection config for a Ceph Dashboard endpoint (secrets decrypted)."""
+
+    base_url: str
+    username: str | None = None
+    password: str | None = None
+    token: str | None = None
+    verify_ssl: bool = True
+    api_version: str = "1.0"
+    timeout: int = 30
+
+
+def dashboard_sdk_importable() -> bool:
+    """Return ``True`` when the installed ``proxmox-sdk`` ships the Dashboard client."""
+    try:
+        from proxmox_sdk.ceph.providers import DashboardCephClient  # noqa: F401,PLC0415
+    except Exception:  # noqa: BLE001 - any import failure means the provider is unavailable
+        return False
+    return True
+
+
+def build_dashboard_client(config: DashboardEndpointConfig, *, transport: Any = None) -> Any:
+    """Construct an SDK ``DashboardCephClient`` from ``config``.
+
+    Raises ``ImportError`` if the SDK Dashboard client is not importable; callers
+    gate on :func:`dashboard_sdk_importable` first.
+    """
+    from proxmox_sdk.ceph.providers import DashboardCephClient  # noqa: PLC0415
+
+    return DashboardCephClient(
+        config.base_url,
+        username=config.username,
+        password=config.password,
+        token=config.token,
+        verify_ssl=config.verify_ssl,
+        api_version=config.api_version,
+        timeout=config.timeout,
+        transport=transport,
+    )
+
+
+async def validate_dashboard_endpoint(
+    config: DashboardEndpointConfig, *, client_factory: Any = None
+) -> tuple[bool, str | None]:
+    """Probe a Ceph Dashboard endpoint. Returns ``(ok, error_message)``.
+
+    Returns ``(False, ...)`` when the SDK Dashboard client is not importable
+    (older proxmox-sdk pin) rather than raising.
+    """
+    if client_factory is None and not dashboard_sdk_importable():
+        return False, "proxmox-sdk>=0.0.11 is required for the Ceph Dashboard provider"
+    client = client_factory(config) if client_factory else build_dashboard_client(config)
+    try:
+        caps = await client.capabilities()
+    except Exception as exc:  # noqa: BLE001 - surface probe failure as an error string
+        return False, f"{type(exc).__name__}: {exc}"
+    finally:
+        close = getattr(client, "close", None)
+        if close is not None:
+            try:
+                await close()
+            except Exception:  # noqa: BLE001 - best-effort cleanup
+                pass
+    available = bool(getattr(caps, "available", False))
+    notes = getattr(caps, "notes", []) or []
+    return available, (None if available else (notes[0] if notes else "dashboard unavailable"))

--- a/proxbox_api/ceph/prometheus.py
+++ b/proxbox_api/ceph/prometheus.py
@@ -1,0 +1,212 @@
+"""Prometheus metric ingestion for Ceph v2.
+
+Queries a Prometheus source for the current Ceph cluster state and normalizes
+it into a bounded :class:`~proxbox_api.ceph.v2_schemas.CephMetricSnapshot`
+(latest snapshot only — never a time series). The snapshot powers NetBox
+health/capacity views and plan-time safety gating.
+
+The client is ``httpx``-backed and accepts an injected ``httpx.AsyncClient`` so
+tests can drive it with ``httpx.MockTransport`` and no live Prometheus.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+from proxbox_api.ceph.v2_schemas import CephHealthStatus, CephMetricSnapshot
+
+_DEFAULT_TIMEOUT = 15
+
+# PromQL for each snapshot field. Instant queries against the ceph-mgr
+# prometheus module's metric names. Missing/empty results normalize to None.
+SNAPSHOT_QUERIES: dict[str, str] = {
+    "health": "ceph_health_status",
+    "osd_up": "sum(ceph_osd_up)",
+    "osd_in": "sum(ceph_osd_in)",
+    "osd_total": "count(ceph_osd_metadata)",
+    "mon_quorum": "sum(ceph_mon_quorum_status)",
+    "mgr_active": "sum(ceph_mgr_status)",
+    "bytes_total": "ceph_cluster_total_bytes",
+    "bytes_used": "ceph_cluster_total_used_bytes",
+    "pgs_total": "ceph_pg_total",
+    "degraded_pgs": "sum(ceph_pg_degraded)",
+    "misplaced_pgs": "sum(ceph_pg_misplaced)",
+    "recovering_pgs": "sum(ceph_pg_recovering)",
+    "iops_read": "sum(rate(ceph_osd_op_r[5m]))",
+    "iops_write": "sum(rate(ceph_osd_op_w[5m]))",
+    "throughput_read_bps": "sum(rate(ceph_osd_op_r_out_bytes[5m]))",
+    "throughput_write_bps": "sum(rate(ceph_osd_op_w_in_bytes[5m]))",
+    "pools": "count(ceph_pool_metadata)",
+}
+
+_HEALTH_BY_CODE: dict[int, CephHealthStatus] = {
+    0: "HEALTH_OK",
+    1: "HEALTH_WARN",
+    2: "HEALTH_ERR",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class PrometheusSourceConfig:
+    """Connection config for a Prometheus source (secrets already decrypted)."""
+
+    url: str
+    bearer_token: str | None = None
+    verify_ssl: bool = True
+    timeout: int = _DEFAULT_TIMEOUT
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class PrometheusClient:
+    """Minimal async Prometheus HTTP API v1 client."""
+
+    def __init__(
+        self,
+        config: PrometheusSourceConfig,
+        *,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._config = config
+        self._base_url = config.url.rstrip("/")
+        self._owns_client = client is None
+        headers = {}
+        if config.bearer_token:
+            headers["Authorization"] = f"Bearer {config.bearer_token}"
+        self._client = client or httpx.AsyncClient(
+            verify=config.verify_ssl,
+            timeout=config.timeout,
+            headers=headers,
+        )
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def __aenter__(self) -> PrometheusClient:
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        await self.aclose()
+
+    async def query(self, promql: str) -> list[dict[str, Any]]:
+        """Run an instant query; return the raw result vector (may be empty)."""
+
+        response = await self._client.get(
+            f"{self._base_url}/api/v1/query", params={"query": promql}
+        )
+        response.raise_for_status()
+        body = response.json()
+        if not isinstance(body, dict) or body.get("status") != "success":
+            return []
+        data = body.get("data") or {}
+        result = data.get("result") if isinstance(data, dict) else None
+        return [r for r in result if isinstance(r, dict)] if isinstance(result, list) else []
+
+    async def query_scalar(self, promql: str) -> float | None:
+        """Run an instant query and reduce the result vector to one float."""
+
+        vector = await self.query(promql)
+        total: float | None = None
+        for sample in vector:
+            value = sample.get("value")
+            if isinstance(value, list) and len(value) == 2:
+                try:
+                    total = (total or 0.0) + float(value[1])
+                except (TypeError, ValueError):
+                    continue
+        return total
+
+
+def _as_int(value: float | None) -> int | None:
+    return int(value) if value is not None else None
+
+
+async def collect_snapshot(
+    client: PrometheusClient, *, source_url: str | None = None
+) -> CephMetricSnapshot:
+    """Query all snapshot metrics concurrently and normalize them."""
+
+    keys = list(SNAPSHOT_QUERIES)
+    warnings: list[str] = []
+
+    async def _run(promql: str) -> float | None:
+        try:
+            return await client.query_scalar(promql)
+        except httpx.HTTPError as exc:
+            warnings.append(f"query failed ({promql}): {exc}")
+            return None
+
+    values = await asyncio.gather(*(_run(SNAPSHOT_QUERIES[k]) for k in keys))
+    data = dict(zip(keys, values, strict=True))
+
+    health_code = data.get("health")
+    health: CephHealthStatus = "unknown"
+    if health_code is not None:
+        health = _HEALTH_BY_CODE.get(int(health_code), "unknown")
+
+    bytes_total = _as_int(data.get("bytes_total"))
+    bytes_used = _as_int(data.get("bytes_used"))
+    bytes_avail = (
+        bytes_total - bytes_used if bytes_total is not None and bytes_used is not None else None
+    )
+    percent_used = (
+        round(bytes_used / bytes_total * 100, 2) if bytes_total and bytes_used is not None else None
+    )
+
+    pg_states: dict[str, int] = {}
+    for state in ("degraded", "misplaced", "recovering"):
+        count = _as_int(data.get(f"{state}_pgs"))
+        if count:
+            pg_states[state] = count
+
+    return CephMetricSnapshot(
+        cluster_health=health,
+        captured_at=_utcnow(),
+        source_url=source_url,
+        bytes_total=bytes_total,
+        bytes_used=bytes_used,
+        bytes_avail=bytes_avail,
+        percent_used=percent_used,
+        osd_up=_as_int(data.get("osd_up")),
+        osd_in=_as_int(data.get("osd_in")),
+        osd_total=_as_int(data.get("osd_total")),
+        mon_quorum=_as_int(data.get("mon_quorum")),
+        mgr_active=_as_int(data.get("mgr_active")),
+        pgs_total=_as_int(data.get("pgs_total")),
+        pg_states=pg_states,
+        degraded_pgs=_as_int(data.get("degraded_pgs")),
+        misplaced_pgs=_as_int(data.get("misplaced_pgs")),
+        recovering_pgs=_as_int(data.get("recovering_pgs")),
+        iops_read=data.get("iops_read"),
+        iops_write=data.get("iops_write"),
+        throughput_read_bps=data.get("throughput_read_bps"),
+        throughput_write_bps=data.get("throughput_write_bps"),
+        pools=_as_int(data.get("pools")),
+        warnings=warnings,
+    )
+
+
+async def fetch_snapshot(config: PrometheusSourceConfig) -> CephMetricSnapshot:
+    """Construct a client from ``config`` and collect one snapshot."""
+
+    async with PrometheusClient(config) as client:
+        return await collect_snapshot(client, source_url=config.url)
+
+
+async def validate_source(config: PrometheusSourceConfig) -> tuple[bool, str | None]:
+    """Probe a Prometheus source. Returns ``(ok, error_message)``."""
+
+    try:
+        async with PrometheusClient(config) as client:
+            await client.query("ceph_health_status")
+        return True, None
+    except httpx.HTTPError as exc:
+        return False, str(exc)

--- a/proxbox_api/ceph/rgw_client.py
+++ b/proxbox_api/ceph/rgw_client.py
@@ -1,0 +1,70 @@
+"""RGW Admin Ops provider client bridge for Ceph v2 (#97 / #435).
+
+Defensive bridge to the ``proxmox-sdk`` RGW Admin Ops client (added in 0.0.11),
+mirroring ``dashboard_sdk_importable()``. Lets the external-cluster adapter
+report RGW capability accurately and degrade cleanly on an older SDK pin.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class RGWAdminConfig:
+    """Connection config for an RGW Admin Ops endpoint (secrets decrypted)."""
+
+    base_url: str
+    access_key: str
+    secret_key: str
+    admin_path: str = "admin"
+    verify_ssl: bool = True
+    timeout: int = 30
+
+
+def rgw_sdk_importable() -> bool:
+    """Return ``True`` when the installed ``proxmox-sdk`` ships the RGW client."""
+    try:
+        from proxmox_sdk.ceph.providers import RGWAdminClient  # noqa: F401,PLC0415
+    except Exception:  # noqa: BLE001 - any import failure means the provider is unavailable
+        return False
+    return True
+
+
+def build_rgw_client(config: RGWAdminConfig, *, transport: Any = None) -> Any:
+    """Construct an SDK ``RGWAdminClient`` from ``config`` (caller gates on import)."""
+    from proxmox_sdk.ceph.providers import RGWAdminClient  # noqa: PLC0415
+
+    return RGWAdminClient(
+        config.base_url,
+        access_key=config.access_key,
+        secret_key=config.secret_key,
+        admin_path=config.admin_path,
+        verify_ssl=config.verify_ssl,
+        timeout=config.timeout,
+        transport=transport,
+    )
+
+
+async def validate_rgw_endpoint(
+    config: RGWAdminConfig, *, client_factory: Any = None
+) -> tuple[bool, str | None]:
+    """Probe an RGW Admin Ops endpoint. Returns ``(ok, error_message)``."""
+    if client_factory is None and not rgw_sdk_importable():
+        return False, "proxmox-sdk>=0.0.11 is required for the RGW Admin Ops provider"
+    client = client_factory(config) if client_factory else build_rgw_client(config)
+    try:
+        caps = await client.capabilities()
+    except Exception as exc:  # noqa: BLE001
+        return False, f"{type(exc).__name__}: {exc}"
+    finally:
+        close = getattr(client, "close", None)
+        if close is not None:
+            try:
+                await close()
+            except Exception:  # noqa: BLE001
+                pass
+    available = bool(getattr(caps, "available", False))
+    notes = getattr(caps, "notes", []) or []
+    return available, (None if available else (notes[0] if notes else "rgw unavailable"))

--- a/proxbox_api/ceph/v2_engine.py
+++ b/proxbox_api/ceph/v2_engine.py
@@ -14,6 +14,7 @@ from sqlmodel import select
 from proxbox_api.ceph.v2_providers.base import CephCapabilityUnsupported, CephProviderAdapter
 from proxbox_api.ceph.v2_schemas import (
     ApplyRequest,
+    CephMetricSnapshot,
     DesiredObject,
     DesiredStateBundle,
     OperationRun,
@@ -144,6 +145,44 @@ def validation_results_for_request(request: PlanRequest) -> list[ValidationResul
                     code="target_ref_required",
                     message="Provider operations require target_ref, ref, target, or name.",
                     target=operation.kind,
+                )
+            )
+    return results
+
+
+def metric_safety_validations(
+    snapshot: CephMetricSnapshot | None,
+    operations: list[ProviderOperation],
+) -> list[ValidationResult]:
+    """Warn when destructive ops are planned while the cluster is degraded.
+
+    Consumes a Prometheus-derived metric snapshot (#94). When health is non-OK
+    or recovery/backfill is in flight, each destructive operation gets a
+    ``warning`` (surfaced, not a hard block — destructive ops already require
+    explicit confirmation) so operators can override deliberately.
+    """
+
+    if snapshot is None or not snapshot.is_degraded:
+        return []
+    reason = f"cluster health is {snapshot.cluster_health}"
+    if snapshot.recovering_pgs or snapshot.degraded_pgs or snapshot.misplaced_pgs:
+        reason += (
+            f" (recovering={snapshot.recovering_pgs or 0}, "
+            f"degraded={snapshot.degraded_pgs or 0}, "
+            f"misplaced={snapshot.misplaced_pgs or 0})"
+        )
+    results: list[ValidationResult] = []
+    for operation in operations:
+        if operation.is_destructive:
+            results.append(
+                ValidationResult(
+                    severity="warning",
+                    code="cluster_degraded",
+                    message=(
+                        f"Destructive operation while {reason}; proceed only with "
+                        "explicit confirmation."
+                    ),
+                    target=operation.target_ref or operation.kind,
                 )
             )
     return results
@@ -290,9 +329,27 @@ async def _raw_operations(
     return operations, live
 
 
+def _snapshot_from_request(
+    request: PlanRequest, metric_snapshot: CephMetricSnapshot | None
+) -> CephMetricSnapshot | None:
+    if metric_snapshot is not None:
+        return metric_snapshot
+    raw = request.scope.get("metric_snapshot")
+    if isinstance(raw, CephMetricSnapshot):
+        return raw
+    if isinstance(raw, dict):
+        try:
+            return CephMetricSnapshot.model_validate(raw)
+        except ValidationError:
+            return None
+    return None
+
+
 async def build_plan(
     request: PlanRequest,
     adapter: CephProviderAdapter,
+    *,
+    metric_snapshot: CephMetricSnapshot | None = None,
 ) -> PlanResponse:
     capabilities = await adapter.capabilities()
     validations = validation_results_for_request(request)
@@ -315,6 +372,8 @@ async def build_plan(
         (_normalize_operation(operation, capabilities) for operation in operations),
         key=_operation_priority,
     )
+    snapshot = _snapshot_from_request(request, metric_snapshot)
+    validations = validations + metric_safety_validations(snapshot, normalized)
     blocked_actions = [operation for operation in normalized if not operation.supported]
     branch_id = request.branch_schema_id
     plan = PlanResponse(

--- a/proxbox_api/ceph/v2_providers/__init__.py
+++ b/proxbox_api/ceph/v2_providers/__init__.py
@@ -6,11 +6,11 @@ from collections.abc import Callable
 
 from proxbox_api.ceph.v2_providers.base import (
     CephProviderAdapter,
-    DashboardCephProviderAdapter,
     ExternalCephProviderAdapter,
     RBDCephProviderAdapter,
     RGWAdminCephProviderAdapter,
 )
+from proxbox_api.ceph.v2_providers.dashboard import DashboardCephProviderAdapter
 from proxbox_api.ceph.v2_providers.prometheus import PrometheusCephProviderAdapter
 from proxbox_api.ceph.v2_providers.proxmox import ProxmoxCephProviderAdapter
 

--- a/proxbox_api/ceph/v2_providers/__init__.py
+++ b/proxbox_api/ceph/v2_providers/__init__.py
@@ -6,11 +6,11 @@ from collections.abc import Callable
 
 from proxbox_api.ceph.v2_providers.base import (
     CephProviderAdapter,
-    ExternalCephProviderAdapter,
     RBDCephProviderAdapter,
     RGWAdminCephProviderAdapter,
 )
 from proxbox_api.ceph.v2_providers.dashboard import DashboardCephProviderAdapter
+from proxbox_api.ceph.v2_providers.external import ExternalCephProviderAdapter
 from proxbox_api.ceph.v2_providers.prometheus import PrometheusCephProviderAdapter
 from proxbox_api.ceph.v2_providers.proxmox import ProxmoxCephProviderAdapter
 

--- a/proxbox_api/ceph/v2_providers/__init__.py
+++ b/proxbox_api/ceph/v2_providers/__init__.py
@@ -8,10 +8,10 @@ from proxbox_api.ceph.v2_providers.base import (
     CephProviderAdapter,
     DashboardCephProviderAdapter,
     ExternalCephProviderAdapter,
-    PrometheusCephProviderAdapter,
     RBDCephProviderAdapter,
     RGWAdminCephProviderAdapter,
 )
+from proxbox_api.ceph.v2_providers.prometheus import PrometheusCephProviderAdapter
 from proxbox_api.ceph.v2_providers.proxmox import ProxmoxCephProviderAdapter
 
 ProviderFactory = Callable[[list[object] | None], CephProviderAdapter]

--- a/proxbox_api/ceph/v2_providers/base.py
+++ b/proxbox_api/ceph/v2_providers/base.py
@@ -115,17 +115,12 @@ class DashboardCephProviderAdapter(UnsupportedCephProviderAdapter):
 
 class RGWAdminCephProviderAdapter(UnsupportedCephProviderAdapter):
     provider = "rgw_admin"
-    followup = "#94"
+    followup = "#435 / proxmox-sdk#12"
 
 
 class RBDCephProviderAdapter(UnsupportedCephProviderAdapter):
     provider = "rbd"
-    followup = "#12"
-
-
-class PrometheusCephProviderAdapter(UnsupportedCephProviderAdapter):
-    provider = "prometheus"
-    followup = "#97"
+    followup = "#436 / proxmox-sdk#12"
 
 
 class ExternalCephProviderAdapter(UnsupportedCephProviderAdapter):
@@ -138,7 +133,6 @@ __all__ = [
     "CephProviderAdapter",
     "DashboardCephProviderAdapter",
     "ExternalCephProviderAdapter",
-    "PrometheusCephProviderAdapter",
     "RBDCephProviderAdapter",
     "RGWAdminCephProviderAdapter",
     "UnsupportedCephProviderAdapter",

--- a/proxbox_api/ceph/v2_providers/base.py
+++ b/proxbox_api/ceph/v2_providers/base.py
@@ -108,11 +108,6 @@ class UnsupportedCephProviderAdapter(CephProviderAdapter):
         raise self._unsupported()
 
 
-class DashboardCephProviderAdapter(UnsupportedCephProviderAdapter):
-    provider = "dashboard"
-    followup = "#98"
-
-
 class RGWAdminCephProviderAdapter(UnsupportedCephProviderAdapter):
     provider = "rgw_admin"
     followup = "#435 / proxmox-sdk#12"
@@ -131,7 +126,6 @@ class ExternalCephProviderAdapter(UnsupportedCephProviderAdapter):
 __all__ = [
     "CephCapabilityUnsupported",
     "CephProviderAdapter",
-    "DashboardCephProviderAdapter",
     "ExternalCephProviderAdapter",
     "RBDCephProviderAdapter",
     "RGWAdminCephProviderAdapter",

--- a/proxbox_api/ceph/v2_providers/base.py
+++ b/proxbox_api/ceph/v2_providers/base.py
@@ -118,15 +118,9 @@ class RBDCephProviderAdapter(UnsupportedCephProviderAdapter):
     followup = "#436 / proxmox-sdk#12"
 
 
-class ExternalCephProviderAdapter(UnsupportedCephProviderAdapter):
-    provider = "external"
-    followup = "external-provider implementation"
-
-
 __all__ = [
     "CephCapabilityUnsupported",
     "CephProviderAdapter",
-    "ExternalCephProviderAdapter",
     "RBDCephProviderAdapter",
     "RGWAdminCephProviderAdapter",
     "UnsupportedCephProviderAdapter",

--- a/proxbox_api/ceph/v2_providers/dashboard.py
+++ b/proxbox_api/ceph/v2_providers/dashboard.py
@@ -1,0 +1,323 @@
+"""Direct Ceph Dashboard API provider adapter for Ceph v2 (#98).
+
+Reads inventory and applies pool/RBD writes through the Ceph Manager Dashboard
+REST API (via the ``proxmox-sdk`` Dashboard client), with **no Proxmox endpoint
+required** — so it serves Proxmox-managed and external/standalone clusters
+alike. Writes participate in the same plan/apply/operation-run flow as the
+Proxmox provider.
+
+Write capability is guarded by :func:`dashboard_sdk_importable`: an older
+proxmox-sdk pin degrades to ``apply=False`` with a clear reason instead of
+silently no-op'ing. The Dashboard endpoint config is resolved from
+``scope["dashboard_endpoint"]`` (injected by the route, which has DB access) or
+from a config passed to the constructor (tests / composition).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from proxbox_api.ceph.dashboard_client import (
+    DashboardEndpointConfig,
+    build_dashboard_client,
+    dashboard_sdk_importable,
+)
+from proxbox_api.ceph.v2_providers.base import CephCapabilityUnsupported, CephProviderAdapter
+from proxbox_api.ceph.v2_providers.dashboard_writer import (
+    execute_dashboard_operation,
+    operation_kinds,
+)
+from proxbox_api.ceph.v2_schemas import (
+    DesiredObject,
+    DesiredStateBundle,
+    ProviderCapabilities,
+    ProviderOperation,
+)
+from proxbox_api.logger import logger
+
+_DESTRUCTIVE_ACTIONS = {"delete", "destroy", "remove", "purge"}
+
+
+def _plain(value: Any) -> Any:
+    if hasattr(value, "model_dump") and callable(value.model_dump):
+        return value.model_dump(mode="json")
+    if isinstance(value, dict):
+        return {str(k): _plain(v) for k, v in value.items()}
+    if isinstance(value, list | tuple | set):
+        return [_plain(v) for v in value]
+    return value
+
+
+def _normalize_kind(kind: str) -> str:
+    cleaned = kind.strip().lower().replace("-", "_")
+    aliases = {
+        "pools": "pool",
+        "osds": "osd",
+        "rbd": "rbd_image",
+        "rbd_images": "rbd_image",
+        "rgw_buckets": "rgw_bucket",
+        "buckets": "rgw_bucket",
+    }
+    return aliases.get(cleaned, cleaned)
+
+
+def _desired_target(desired: DesiredObject) -> str:
+    target = desired.target_ref or desired.name
+    if target:
+        return str(target)
+    payload = desired.payload if isinstance(desired.payload, dict) else {}
+    for key in ("name", "pool_name", "bucket"):
+        if payload.get(key):
+            return str(payload[key])
+    return ""
+
+
+def _payload_matches(desired_payload: dict[str, Any], live_summary: dict[str, Any]) -> bool:
+    if not desired_payload:
+        return True
+    for key, value in desired_payload.items():
+        if key not in live_summary or _plain(live_summary[key]) != _plain(value):
+            return False
+    return True
+
+
+class DashboardCephProviderAdapter(CephProviderAdapter):
+    """Ceph v2 adapter backed by the direct Ceph Dashboard REST API."""
+
+    provider = "dashboard"
+
+    def __init__(
+        self,
+        pxs: list[object] | None = None,  # noqa: ARG002 - registry-compatible signature
+        *,
+        endpoint: DashboardEndpointConfig | None = None,
+        client_factory: Any = None,
+    ) -> None:
+        self._endpoint = endpoint
+        # Injectable for tests: callable(config) -> async dashboard client.
+        self._client_factory = client_factory
+
+    # -- endpoint / client resolution --------------------------------------- #
+    def _resolve_endpoint(self, scope: dict[str, Any]) -> DashboardEndpointConfig | None:
+        candidate = self._endpoint or scope.get("dashboard_endpoint")
+        return candidate if isinstance(candidate, DashboardEndpointConfig) else None
+
+    def _make_client(self, config: DashboardEndpointConfig) -> Any:
+        if self._client_factory is not None:
+            return self._client_factory(config)
+        return build_dashboard_client(config)
+
+    # -- capabilities ------------------------------------------------------- #
+    async def capabilities(self) -> ProviderCapabilities:
+        importable = dashboard_sdk_importable()
+        kinds = {"noop": True}
+        kinds.update(operation_kinds(importable))
+        if importable:
+            notes = [
+                "Direct Ceph Dashboard provider: reads inventory and applies pool / "
+                "RBD writes through the Dashboard REST API. No Proxmox endpoint "
+                "required. Destructive operations require confirm_destructive."
+            ]
+        else:
+            notes = [
+                "Ceph Dashboard provider is inactive: the installed proxmox-sdk does "
+                "not ship proxmox_sdk.ceph.providers. Pin proxmox-sdk>=0.0.11 to "
+                "enable Dashboard-backed reads and writes."
+            ]
+        return ProviderCapabilities(
+            provider=self.provider,
+            supported=True,
+            read_state=importable,
+            diff=importable,
+            plan=importable,
+            apply=importable,
+            reconcile=importable,
+            metrics=importable,
+            operation_kinds=kinds,
+            destructive_operations=importable,
+            notes=notes,
+        )
+
+    # -- read ---------------------------------------------------------------- #
+    async def read_state(self, scope: dict[str, Any]) -> dict[str, Any]:
+        config = self._resolve_endpoint(scope)
+        if config is None:
+            return {
+                "provider": self.provider,
+                "clusters": [],
+                "resources": [],
+                "errors": ["no Ceph Dashboard endpoint configured"],
+                "summary": {"clusters": 0, "resources": 0, "errors": 1},
+            }
+        resources: list[dict[str, Any]] = []
+        errors: list[str] = []
+        health: Any = None
+        client = self._make_client(config)
+        try:
+            collectors = (
+                ("pool", client.pools),
+                ("osd", client.osds),
+                ("host", client.hosts),
+                ("filesystem", client.filesystems),
+                ("rbd_image", client.rbd_images),
+                ("rgw_bucket", client.rgw_buckets),
+            )
+            try:
+                health = _plain(await client.health())
+            except Exception as exc:  # noqa: BLE001
+                errors.append(f"health: {type(exc).__name__}: {exc}")
+            for kind, reader in collectors:
+                try:
+                    for item in await reader():
+                        summary = _plain(item)
+                        ref = _resource_ref(kind, summary)
+                        if ref:
+                            resources.append({"kind": kind, "target_ref": ref, "summary": summary})
+                except Exception as exc:  # noqa: BLE001
+                    errors.append(f"{kind}: {type(exc).__name__}: {exc}")
+        finally:
+            await _safe_close(client)
+
+        cluster = {
+            "provider": self.provider,
+            "name": config.base_url,
+            "host": config.base_url,
+            "health": health,
+            "errors": errors,
+        }
+        return {
+            "provider": self.provider,
+            "clusters": [cluster],
+            "resources": resources,
+            "errors": errors,
+            "summary": {
+                "clusters": 1,
+                "resources": len(resources),
+                "errors": len(errors),
+                "health": (health or {}).get("status") if isinstance(health, dict) else None,
+            },
+        }
+
+    async def diff(
+        self,
+        desired: DesiredStateBundle,
+        live: dict[str, Any],
+    ) -> list[ProviderOperation]:
+        live_index = {
+            (_normalize_kind(str(item.get("kind", ""))), str(item.get("target_ref") or "")): item
+            for item in live.get("resources", [])
+            if isinstance(item, dict)
+        }
+        operations: list[ProviderOperation] = []
+        for obj in desired.objects:
+            kind = _normalize_kind(obj.kind)
+            target_ref = _desired_target(obj)
+            action = obj.action.strip().lower() or "ensure"
+            live_item = live_index.get((kind, target_ref))
+            before = _plain(live_item.get("summary", {})) if isinstance(live_item, dict) else {}
+            after = _plain(obj.payload)
+            if action in _DESTRUCTIVE_ACTIONS:
+                planned = "delete"
+            elif live_item is None:
+                planned = "create"
+            elif _payload_matches(obj.payload, before):
+                planned = "noop"
+            else:
+                planned = "update"
+            operations.append(
+                ProviderOperation(
+                    provider=self.provider,
+                    kind=kind,
+                    target_ref=target_ref,
+                    action=planned,
+                    before_summary=before,
+                    after_summary={} if planned == "delete" else after,
+                )
+            )
+        return operations
+
+    async def plan(self, operations: list[ProviderOperation]) -> list[ProviderOperation]:
+        return operations
+
+    # -- write --------------------------------------------------------------- #
+    async def apply(
+        self,
+        operation: ProviderOperation,
+        *,
+        confirm_destructive: bool,
+    ) -> dict[str, Any]:
+        if operation.action == "noop":
+            return {
+                "operation_id": operation.id,
+                "result": "noop",
+                "target_ref": operation.target_ref,
+            }
+        if not dashboard_sdk_importable():
+            raise CephCapabilityUnsupported(
+                "The installed proxmox-sdk does not ship the Ceph Dashboard client; "
+                "pin proxmox-sdk>=0.0.11 to enable Dashboard-backed Ceph writes."
+            )
+        config = self._endpoint
+        if config is None:
+            raise CephCapabilityUnsupported(
+                "No Ceph Dashboard endpoint is configured to apply the operation."
+            )
+        client = self._make_client(config)
+        try:
+            return await execute_dashboard_operation(
+                client, operation, confirm_destructive=confirm_destructive
+            )
+        finally:
+            await _safe_close(client)
+
+    async def reconcile(self, scope: dict[str, Any]) -> dict[str, Any]:
+        live = await self.read_state(scope)
+        return {
+            "result": "dashboard_reconcile",
+            "summary": live.get("summary", {}),
+            "errors": live.get("errors", []),
+        }
+
+    async def metrics(self, scope: dict[str, Any]) -> dict[str, Any]:
+        if self._resolve_endpoint(scope) is None:
+            return {}
+        live = await self.read_state(scope)
+        summary = live.get("summary", {})
+        return {
+            "scope": scope,
+            "clusters": summary.get("clusters", 0),
+            "resources": summary.get("resources", 0),
+            "errors": summary.get("errors", 0),
+            "health": summary.get("health"),
+        }
+
+
+def _resource_ref(kind: str, summary: dict[str, Any]) -> str | None:
+    if not isinstance(summary, dict):
+        return None
+    candidates = {
+        "pool": ("pool_name", "pool", "name"),
+        "osd": ("osd", "id", "uuid"),
+        "host": ("hostname", "addr"),
+        "filesystem": ("name", "id"),
+        "rbd_image": ("name", "id"),
+        "rgw_bucket": ("bucket", "name"),
+    }.get(kind, ("name", "id"))
+    for key in candidates:
+        value = summary.get(key)
+        if value not in (None, ""):
+            return str(value)
+    return None
+
+
+async def _safe_close(client: Any) -> None:
+    close = getattr(client, "close", None)
+    if close is None:
+        return
+    try:
+        await close()
+    except Exception as exc:  # noqa: BLE001 - best-effort session cleanup
+        logger.debug("Dashboard client close failed: %s", exc)
+
+
+__all__ = ["DashboardCephProviderAdapter"]

--- a/proxbox_api/ceph/v2_providers/dashboard_writer.py
+++ b/proxbox_api/ceph/v2_providers/dashboard_writer.py
@@ -1,0 +1,156 @@
+"""Map Ceph v2 ProviderOperations to Ceph Dashboard client calls (#98).
+
+Mirrors ``proxmox_writer`` for the direct Ceph Dashboard provider: a
+deterministic ``(kind, action) -> DashboardCephClient`` table so the
+``DashboardCephProviderAdapter`` stays thin and the mapping is unit-testable
+with an injected fake client.
+
+The Dashboard API exposes pool and RBD (block image / snapshot) writes; RGW and
+CRUSH writes are reported as unsupported here (they belong to the RGW Admin Ops
+and external providers), never silently dropped.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from proxbox_api.ceph.v2_providers.base import CephCapabilityUnsupported
+from proxbox_api.ceph.v2_schemas import ProviderOperation
+
+# Capability map for the Dashboard write adapter. ``True`` lights up once the
+# SDK Dashboard client is importable; ``False`` is surfaced as an explicit gap.
+WRITE_OPERATION_KINDS: dict[str, bool] = {
+    "pool:create": True,
+    "pool:update": True,
+    "pool:delete": True,
+    "rbd_image:create": True,
+    "rbd_image:update": True,
+    "rbd_image:delete": True,
+    "rbd_image:trash": True,
+    "rbd_snapshot:create": True,
+    "rbd_snapshot:delete": True,
+    "noop": True,
+    # Reported unsupported (handled by rgw_admin / external providers).
+    "rgw_bucket:create": False,
+    "rgw_bucket:delete": False,
+    "rgw_user:create": False,
+    "rgw_user:delete": False,
+    "crush_rule:create": False,
+    "crush_rule:update": False,
+    "crush_rule:delete": False,
+}
+
+_CONTROL_KEYS = frozenset({"node", "confirm_destroy", "confirm_destructive"})
+
+
+def operation_kinds(writes_enabled: bool) -> dict[str, bool]:
+    """Resolve the advertised ``operation_kinds`` given Dashboard availability."""
+    return {
+        key: bool(supported and writes_enabled) for key, supported in WRITE_OPERATION_KINDS.items()
+    }
+
+
+def _payload(operation: ProviderOperation) -> dict[str, Any]:
+    summary = operation.after_summary if isinstance(operation.after_summary, dict) else {}
+    return {
+        key: value
+        for key, value in summary.items()
+        if key not in _CONTROL_KEYS and value is not None
+    }
+
+
+def _image_spec(operation: ProviderOperation, payload: dict[str, Any]) -> str:
+    """Build ``pool/image`` (optionally with namespace) from payload/target_ref."""
+    pool = payload.get("pool_name") or payload.get("pool")
+    name = payload.get("name") or payload.get("image")
+    namespace = payload.get("namespace")
+    if pool and name:
+        parts = [str(pool)]
+        if namespace:
+            parts.append(str(namespace))
+        parts.append(str(name))
+        return "/".join(parts)
+    # Fall back to target_ref, expected to already be "pool/image".
+    return operation.target_ref or ""
+
+
+def _result(operation: ProviderOperation, raw: Any, result: str) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "operation_id": operation.id,
+        "result": result,
+        "target_ref": operation.target_ref,
+        "action": operation.action,
+        "kind": operation.kind,
+    }
+    # Dashboard write calls may return a task descriptor; surface its name as a ref.
+    if isinstance(raw, dict):
+        task = raw.get("name") or raw.get("task") or raw.get("metadata")
+        if isinstance(task, str):
+            out["provider_task_ref"] = task
+    return out
+
+
+def _gap(kind: str, action: str, detail: str | None = None) -> CephCapabilityUnsupported:
+    suffix = f" {detail}" if detail else ""
+    return CephCapabilityUnsupported(
+        f"Ceph Dashboard write adapter does not support {kind}:{action}.{suffix}"
+    )
+
+
+async def execute_dashboard_operation(
+    client: Any,
+    operation: ProviderOperation,
+    *,
+    confirm_destructive: bool,
+) -> dict[str, Any]:
+    """Execute one planned operation through the Dashboard client."""
+    kind = operation.kind
+    action = operation.action
+    op_key = "noop" if action == "noop" else f"{kind}:{action}"
+
+    if WRITE_OPERATION_KINDS.get(op_key) is False:
+        raise _gap(kind, action)
+    if action == "noop":
+        return _result(operation, None, "noop")
+
+    payload = _payload(operation)
+    raw = await _dispatch(client, kind, action, operation, payload, confirm_destructive)
+    return _result(operation, raw, "applied")
+
+
+async def _dispatch(  # noqa: C901, PLR0911, PLR0912 - explicit kind/action table
+    client: Any,
+    kind: str,
+    action: str,
+    operation: ProviderOperation,
+    payload: dict[str, Any],
+    confirm: bool,
+) -> Any:
+    target = operation.target_ref or ""
+    if kind == "pool":
+        if action == "create":
+            return await client.pool_create(payload or {"pool_name": target})
+        if action == "update":
+            return await client.pool_edit(target, payload)
+        if action == "delete":
+            return await client.pool_delete(target, confirm_destroy=confirm)
+    elif kind == "rbd_image":
+        spec = _image_spec(operation, payload)
+        if action == "create":
+            return await client.rbd_create(payload)
+        if action == "update":
+            return await client.rbd_edit(spec, payload)
+        if action == "delete":
+            return await client.rbd_delete(spec, confirm_destroy=confirm)
+        if action == "trash":
+            return await client.rbd_move_trash(spec, confirm_destroy=confirm)
+    elif kind == "rbd_snapshot":
+        spec = _image_spec(operation, payload)
+        snap = payload.get("snapshot_name") or payload.get("name") or ""
+        if not snap:
+            raise _gap(kind, action, "snapshot requires payload 'snapshot_name'.")
+        if action == "create":
+            return await client.rbd_snapshot_create(spec, snap)
+        if action == "delete":
+            return await client.rbd_snapshot_delete(spec, snap, confirm_destroy=confirm)
+    raise _gap(kind, action)

--- a/proxbox_api/ceph/v2_providers/external.py
+++ b/proxbox_api/ceph/v2_providers/external.py
@@ -1,0 +1,346 @@
+"""External (non-Proxmox) Ceph cluster provider adapter for Ceph v2 (#97).
+
+Composition adapter: binds a provider-neutral external Ceph cluster to its
+configured sub-providers — Ceph Dashboard (inventory + pool/RBD writes),
+Prometheus (metrics/health), and RGW Admin Ops (RGW inventory + writes) — with
+**no Proxmox endpoint, node, storage, or task semantics**. Capability detection
+is derived from which sub-providers are configured (and importable) plus the
+Ceph version hint, so unsupported operations are reported, never faked.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from proxbox_api.ceph.dashboard_client import (
+    DashboardEndpointConfig,
+    dashboard_sdk_importable,
+)
+from proxbox_api.ceph.prometheus import PrometheusSourceConfig
+from proxbox_api.ceph.rgw_client import (
+    RGWAdminConfig,
+    build_rgw_client,
+    rgw_sdk_importable,
+)
+from proxbox_api.ceph.v2_providers.base import CephCapabilityUnsupported, CephProviderAdapter
+from proxbox_api.ceph.v2_providers.dashboard import DashboardCephProviderAdapter
+from proxbox_api.ceph.v2_providers.dashboard_writer import operation_kinds as dashboard_kinds
+from proxbox_api.ceph.v2_providers.prometheus import PrometheusCephProviderAdapter
+from proxbox_api.ceph.v2_schemas import (
+    DesiredStateBundle,
+    ProviderCapabilities,
+    ProviderOperation,
+)
+from proxbox_api.logger import logger
+
+_RGW_KINDS = {"rgw_user", "rgw_bucket", "rgw_realm", "rgw_zone"}
+_DASHBOARD_KINDS = {"pool", "rbd_image", "rbd_snapshot"}
+_RGW_OPERATION_KINDS = {
+    "rgw_user:create": True,
+    "rgw_user:update": True,
+    "rgw_user:suspend": True,
+    "rgw_user:delete": True,
+    "rgw_bucket:update": True,
+    "rgw_bucket:delete": True,
+}
+
+
+class ExternalCephProviderAdapter(CephProviderAdapter):
+    """Provider-neutral adapter for external (non-Proxmox) Ceph clusters."""
+
+    provider = "external"
+
+    def __init__(
+        self,
+        pxs: list[object] | None = None,  # noqa: ARG002 - registry-compatible signature
+        *,
+        dashboard: DashboardEndpointConfig | None = None,
+        prometheus: PrometheusSourceConfig | None = None,
+        rgw: RGWAdminConfig | None = None,
+        ceph_version: str | None = None,
+        dashboard_client_factory: Any = None,
+        rgw_client_factory: Any = None,
+    ) -> None:
+        self._dashboard_cfg = dashboard
+        self._prometheus_cfg = prometheus
+        self._rgw_cfg = rgw
+        self._ceph_version = ceph_version
+        self._rgw_client_factory = rgw_client_factory
+        self._dashboard = DashboardCephProviderAdapter(
+            endpoint=dashboard, client_factory=dashboard_client_factory
+        )
+        self._prometheus = PrometheusCephProviderAdapter(source=prometheus) if prometheus else None
+
+    # -- capability detection ----------------------------------------------- #
+    def _dashboard_active(self) -> bool:
+        return self._dashboard_cfg is not None and dashboard_sdk_importable()
+
+    def _rgw_active(self) -> bool:
+        return self._rgw_cfg is not None and (
+            self._rgw_client_factory is not None or rgw_sdk_importable()
+        )
+
+    async def capabilities(self) -> ProviderCapabilities:
+        dash = self._dashboard_active()
+        rgw = self._rgw_active()
+        metrics = self._prometheus_cfg is not None or dash
+        kinds: dict[str, bool] = {"noop": True}
+        kinds.update(dashboard_kinds(dash))
+        for key, supported in _RGW_OPERATION_KINDS.items():
+            kinds[key] = bool(supported and rgw)
+        configured = []
+        if self._dashboard_cfg:
+            configured.append("dashboard" + ("" if dash else " (needs proxmox-sdk>=0.0.11)"))
+        if self._prometheus_cfg:
+            configured.append("prometheus")
+        if self._rgw_cfg:
+            configured.append("rgw_admin" + ("" if rgw else " (needs proxmox-sdk>=0.0.11)"))
+        notes = [
+            "External (non-Proxmox) Ceph cluster. Configured providers: "
+            + (", ".join(configured) if configured else "none")
+            + (f". Ceph version hint: {self._ceph_version}." if self._ceph_version else ".")
+        ]
+        if not configured:
+            notes.append("Configure a Dashboard, Prometheus, or RGW provider to enable operations.")
+        return ProviderCapabilities(
+            provider=self.provider,
+            supported=True,
+            read_state=dash or rgw,
+            diff=dash or rgw,
+            plan=dash or rgw,
+            apply=dash or rgw,
+            reconcile=dash or rgw,
+            metrics=metrics,
+            operation_kinds=kinds,
+            destructive_operations=dash or rgw,
+            notes=notes,
+        )
+
+    # -- read ---------------------------------------------------------------- #
+    async def read_state(self, scope: dict[str, Any]) -> dict[str, Any]:
+        resources: list[dict[str, Any]] = []
+        errors: list[str] = []
+        health: Any = None
+
+        if self._dashboard_cfg is not None:
+            dash_state = await self._dashboard.read_state(scope)
+            resources.extend(dash_state.get("resources", []))
+            errors.extend(dash_state.get("errors", []))
+            health = (dash_state.get("summary") or {}).get("health")
+
+        if self._rgw_cfg is not None:
+            await self._read_rgw(resources, errors)
+
+        if self._dashboard_cfg is None and self._rgw_cfg is None:
+            errors.append("no external Ceph providers configured")
+
+        return {
+            "provider": self.provider,
+            "clusters": [
+                {
+                    "provider": self.provider,
+                    "name": self._cluster_name(),
+                    "ceph_version": self._ceph_version,
+                    "errors": errors,
+                }
+            ],
+            "resources": resources,
+            "errors": errors,
+            "summary": {
+                "clusters": 1,
+                "resources": len(resources),
+                "errors": len(errors),
+                "health": health,
+            },
+        }
+
+    async def _read_rgw(self, resources: list[dict[str, Any]], errors: list[str]) -> None:
+        if not self._rgw_active():
+            errors.append("rgw_admin: proxmox-sdk>=0.0.11 required")
+            return
+        client = self._make_rgw_client()
+        try:
+            try:
+                for user in await client.list_users():
+                    summary = _plain(user)
+                    ref = summary.get("user_id") or summary.get("uid")
+                    if ref:
+                        resources.append(
+                            {"kind": "rgw_user", "target_ref": str(ref), "summary": summary}
+                        )
+            except Exception as exc:  # noqa: BLE001
+                errors.append(f"rgw_user: {type(exc).__name__}: {exc}")
+            try:
+                for bucket in await client.list_buckets():
+                    resources.append(
+                        {
+                            "kind": "rgw_bucket",
+                            "target_ref": str(bucket),
+                            "summary": {"bucket": bucket},
+                        }
+                    )
+            except Exception as exc:  # noqa: BLE001
+                errors.append(f"rgw_bucket: {type(exc).__name__}: {exc}")
+        finally:
+            await _safe_close(client)
+
+    async def diff(
+        self,
+        desired: DesiredStateBundle,
+        live: dict[str, Any],
+    ) -> list[ProviderOperation]:
+        # Reuse the Dashboard diff (provider-neutral kind/target comparison),
+        # then stamp the operations with this provider name.
+        operations = await self._dashboard.diff(desired, live)
+        for operation in operations:
+            operation.provider = self.provider
+        return operations
+
+    async def plan(self, operations: list[ProviderOperation]) -> list[ProviderOperation]:
+        return operations
+
+    # -- write --------------------------------------------------------------- #
+    async def apply(
+        self,
+        operation: ProviderOperation,
+        *,
+        confirm_destructive: bool,
+    ) -> dict[str, Any]:
+        if operation.action == "noop":
+            return {
+                "operation_id": operation.id,
+                "result": "noop",
+                "target_ref": operation.target_ref,
+            }
+        kind = operation.kind
+        if kind in _DASHBOARD_KINDS:
+            if not self._dashboard_active():
+                raise CephCapabilityUnsupported(
+                    "External cluster has no active Ceph Dashboard provider for "
+                    f"{kind} writes (configure a Dashboard endpoint and pin "
+                    "proxmox-sdk>=0.0.11)."
+                )
+            return await self._dashboard.apply(operation, confirm_destructive=confirm_destructive)
+        if kind in _RGW_KINDS:
+            return await self._apply_rgw(operation, confirm_destructive=confirm_destructive)
+        raise CephCapabilityUnsupported(
+            f"External cluster does not support {kind}:{operation.action}."
+        )
+
+    async def _apply_rgw(
+        self, operation: ProviderOperation, *, confirm_destructive: bool
+    ) -> dict[str, Any]:
+        if not self._rgw_active():
+            raise CephCapabilityUnsupported(
+                "External cluster has no active RGW Admin Ops provider (configure RGW "
+                "credentials and pin proxmox-sdk>=0.0.11)."
+            )
+        payload = operation.after_summary if isinstance(operation.after_summary, dict) else {}
+        target = operation.target_ref or ""
+        client = self._make_rgw_client()
+        try:
+            raw = await _dispatch_rgw(
+                client, operation.kind, operation.action, target, payload, confirm_destructive
+            )
+        finally:
+            await _safe_close(client)
+        return {
+            "operation_id": operation.id,
+            "result": "applied",
+            "target_ref": operation.target_ref,
+            "action": operation.action,
+            "kind": operation.kind,
+            "provider_summary": _plain(raw) if raw is not None else None,
+        }
+
+    async def reconcile(self, scope: dict[str, Any]) -> dict[str, Any]:
+        live = await self.read_state(scope)
+        return {
+            "result": "external_reconcile",
+            "summary": live.get("summary", {}),
+            "errors": live.get("errors", []),
+        }
+
+    async def metrics(self, scope: dict[str, Any]) -> dict[str, Any]:
+        if self._prometheus is not None:
+            return await self._prometheus.metrics(scope)
+        if self._dashboard_cfg is not None:
+            return await self._dashboard.metrics(scope)
+        return {}
+
+    # -- helpers ------------------------------------------------------------- #
+    def _make_rgw_client(self) -> Any:
+        assert self._rgw_cfg is not None
+        if self._rgw_client_factory is not None:
+            return self._rgw_client_factory(self._rgw_cfg)
+        return build_rgw_client(self._rgw_cfg)
+
+    def _cluster_name(self) -> str:
+        if self._dashboard_cfg:
+            return self._dashboard_cfg.base_url
+        if self._rgw_cfg:
+            return self._rgw_cfg.base_url
+        if self._prometheus_cfg:
+            return self._prometheus_cfg.url
+        return "external"
+
+
+async def _dispatch_rgw(  # noqa: C901, PLR0911, PLR0912 - explicit kind/action table
+    client: Any,
+    kind: str,
+    action: str,
+    target: str,
+    payload: dict[str, Any],
+    confirm: bool,
+) -> Any:
+    if kind == "rgw_user":
+        if action in ("create", "ensure"):
+            display = payload.get("display_name") or payload.get("display-name") or target
+            return await client.create_user(target, display_name=display)
+        if action == "update":
+            return await client.modify_user(target, **_rgw_user_fields(payload))
+        if action == "suspend":
+            return await client.set_user_suspended(target, suspended=True)
+        if action == "delete":
+            if not confirm:
+                raise ValueError("rgw_user delete is destructive; confirm_destructive required.")
+            return await client.remove_user(target, confirm_destroy=True)
+    elif kind == "rgw_bucket":
+        if action == "update":
+            owner = payload.get("owner") or payload.get("uid")
+            if owner:
+                return await client.link_bucket(bucket=target, uid=str(owner))
+            return None
+        if action == "delete":
+            if not confirm:
+                raise ValueError("rgw_bucket delete is destructive; confirm_destructive required.")
+            return await client.remove_bucket(target, confirm_destroy=True)
+    raise CephCapabilityUnsupported(f"RGW Admin Ops adapter does not support {kind}:{action}.")
+
+
+def _rgw_user_fields(payload: dict[str, Any]) -> dict[str, Any]:
+    allowed = {"display_name", "email", "max_buckets"}
+    return {k: v for k, v in payload.items() if k in allowed and v is not None}
+
+
+def _plain(value: Any) -> Any:
+    if hasattr(value, "model_dump") and callable(value.model_dump):
+        return value.model_dump(mode="json")
+    if isinstance(value, dict):
+        return {str(k): _plain(v) for k, v in value.items()}
+    if isinstance(value, list | tuple | set):
+        return [_plain(v) for v in value]
+    return value
+
+
+async def _safe_close(client: Any) -> None:
+    close = getattr(client, "close", None)
+    if close is None:
+        return
+    try:
+        await close()
+    except Exception as exc:  # noqa: BLE001 - best-effort cleanup
+        logger.debug("RGW client close failed: %s", exc)
+
+
+__all__ = ["ExternalCephProviderAdapter"]

--- a/proxbox_api/ceph/v2_providers/prometheus.py
+++ b/proxbox_api/ceph/v2_providers/prometheus.py
@@ -1,0 +1,112 @@
+"""Prometheus Ceph v2 provider adapter.
+
+Read/metrics-only provider: it ingests current Ceph metrics from a configured
+Prometheus source and exposes them as a bounded snapshot. It does not perform
+writes (diff/plan/apply/reconcile raise ``CephCapabilityUnsupported``).
+
+The Prometheus source config is resolved by the route (which has DB access) and
+injected via ``scope["prometheus_source"]``; it can also be passed directly to
+the constructor for tests or external-cluster composition.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from proxbox_api.ceph.prometheus import PrometheusSourceConfig, fetch_snapshot
+from proxbox_api.ceph.v2_providers.base import (
+    CephCapabilityUnsupported,
+    CephProviderAdapter,
+)
+from proxbox_api.ceph.v2_schemas import (
+    DesiredStateBundle,
+    ProviderCapabilities,
+    ProviderOperation,
+)
+
+
+class PrometheusCephProviderAdapter(CephProviderAdapter):
+    """Metrics/health provider backed by a Prometheus source (read-only)."""
+
+    provider = "prometheus"
+
+    def __init__(
+        self,
+        pxs: list[object] | None = None,  # noqa: ARG002 - registry-compatible signature
+        *,
+        source: PrometheusSourceConfig | None = None,
+    ) -> None:
+        self._source = source
+
+    def _resolve_source(self, scope: dict[str, Any]) -> PrometheusSourceConfig | None:
+        candidate = self._source or scope.get("prometheus_source")
+        return candidate if isinstance(candidate, PrometheusSourceConfig) else None
+
+    async def capabilities(self) -> ProviderCapabilities:
+        return ProviderCapabilities(
+            provider=self.provider,
+            supported=True,
+            read_state=True,
+            metrics=True,
+            diff=False,
+            plan=False,
+            apply=False,
+            reconcile=False,
+            destructive_operations=False,
+            notes=["prometheus is a read-only metrics/health provider"],
+        )
+
+    async def metrics(self, scope: dict[str, Any]) -> dict[str, Any]:
+        source = self._resolve_source(scope)
+        if source is None:
+            return {}
+        snapshot = await fetch_snapshot(source)
+        return snapshot.model_dump(mode="json")
+
+    async def read_state(self, scope: dict[str, Any]) -> dict[str, Any]:
+        source = self._resolve_source(scope)
+        if source is None:
+            return {}
+        snapshot = await fetch_snapshot(source)
+        return {
+            "health": snapshot.cluster_health,
+            "summary": {
+                "cluster_health": snapshot.cluster_health,
+                "percent_used": snapshot.percent_used,
+                "osd_up": snapshot.osd_up,
+                "osd_total": snapshot.osd_total,
+            },
+            "snapshot": snapshot.model_dump(mode="json"),
+        }
+
+    def _unsupported(self, capability: str) -> CephCapabilityUnsupported:
+        return CephCapabilityUnsupported(
+            f"prometheus provider is read-only; '{capability}' is not supported."
+        )
+
+    async def diff(
+        self,
+        desired: DesiredStateBundle,  # noqa: ARG002
+        live: dict[str, Any],  # noqa: ARG002
+    ) -> list[ProviderOperation]:
+        raise self._unsupported("diff")
+
+    async def plan(
+        self,
+        operations: list[ProviderOperation],  # noqa: ARG002
+    ) -> list[ProviderOperation]:
+        raise self._unsupported("plan")
+
+    async def apply(
+        self,
+        operation: ProviderOperation,  # noqa: ARG002
+        *,
+        confirm_destructive: bool,  # noqa: ARG002
+    ) -> dict[str, Any]:
+        raise self._unsupported("apply")
+
+    async def reconcile(self, scope: dict[str, Any]) -> dict[str, Any]:  # noqa: ARG002
+        raise self._unsupported("reconcile")
+
+
+__all__ = ["PrometheusCephProviderAdapter"]

--- a/proxbox_api/ceph/v2_routes.py
+++ b/proxbox_api/ceph/v2_routes.py
@@ -23,7 +23,13 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Header, HTTPException, Query
 from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+from sqlmodel import select
 
+from proxbox_api.ceph.prometheus import (
+    PrometheusSourceConfig,
+    validate_source,
+)
 from proxbox_api.ceph.v2_engine import (
     CephApplyError,
     CephPlanNotFound,
@@ -39,6 +45,7 @@ from proxbox_api.ceph.v2_providers import adapter_for_provider, provider_names
 from proxbox_api.ceph.v2_schemas import (
     ApplyRequest,
     CapabilitiesResponse,
+    CephMetricSnapshot,
     MetricsResponse,
     OperationRun,
     PlanRequest,
@@ -47,13 +54,40 @@ from proxbox_api.ceph.v2_schemas import (
     SSEEvent,
     ValidationResponse,
 )
-from proxbox_api.database import AsyncDatabaseSessionDep, CephOperationRunRecord
+from proxbox_api.database import (
+    AsyncDatabaseSessionDep,
+    CephOperationRunRecord,
+    PrometheusSource,
+)
 from proxbox_api.logger import logger
 from proxbox_api.session.proxmox import ProxmoxSessionsDep
 
 router = APIRouter()
 
 ActorHeader = Annotated[str | None, Header(alias="X-Proxbox-Actor")]
+
+
+def _source_to_config(source: PrometheusSource) -> PrometheusSourceConfig:
+    return PrometheusSourceConfig(
+        url=source.url,
+        bearer_token=source.get_decrypted_bearer_token(),
+        verify_ssl=source.verify_ssl,
+        timeout=source.timeout_seconds,
+    )
+
+
+async def _resolve_prometheus_source(
+    session: AsyncDatabaseSessionDep, cluster_ref: str | None
+) -> PrometheusSource | None:
+    """Pick the enabled Prometheus source bound to ``cluster_ref``, else any."""
+
+    stmt = select(PrometheusSource).where(PrometheusSource.enabled == True)  # noqa: E712
+    rows = list((await session.exec(stmt)).all())
+    if cluster_ref:
+        for row in rows:
+            if row.cluster_ref == cluster_ref:
+                return row
+    return rows[0] if rows else None
 
 
 def _with_actor(model: Any, actor: str | None) -> None:
@@ -257,20 +291,139 @@ async def ceph_v2_reconcile(
 @router.get("/metrics", response_model=MetricsResponse)
 async def ceph_v2_metrics(
     pxs: ProxmoxSessionsDep,
+    session: AsyncDatabaseSessionDep,
     provider: Annotated[str, Query()] = "proxmox",
     object_ref: Annotated[str | None, Query()] = None,
 ) -> MetricsResponse:
-    """Return the latest provider metrics for the requested scope."""
+    """Return the latest provider metrics for the requested scope.
+
+    For ``provider=prometheus`` the configured Prometheus source is resolved
+    from the DB and injected into the adapter scope, and the result is parsed
+    into a typed :class:`CephMetricSnapshot`.
+    """
 
     adapter = adapter_for_provider(provider, list(pxs))
     scope: dict[str, Any] = {}
     if object_ref:
         scope["object_ref"] = object_ref
     warnings: list[str] = []
+    if provider == "prometheus":
+        source = await _resolve_prometheus_source(session, object_ref)
+        if source is None:
+            warnings.append("no Prometheus source configured")
+        else:
+            scope["prometheus_source"] = _source_to_config(source)
     try:
         metrics = await adapter.metrics(scope)
     except Exception as exc:  # noqa: BLE001 - surface adapter gaps as a warning, not a 500
         logger.warning("Ceph v2 metrics unavailable for provider %s: %s", provider, exc)
         metrics = {}
         warnings.append(str(exc))
-    return MetricsResponse(provider=provider, scope=scope, metrics=metrics, warnings=warnings)
+    snapshot: CephMetricSnapshot | None = None
+    if metrics:
+        try:
+            snapshot = CephMetricSnapshot.model_validate(metrics)
+        except Exception:  # noqa: BLE001 - non-snapshot providers return free-form metrics
+            snapshot = None
+    # Drop the (unserializable) source config from the echoed scope.
+    scope.pop("prometheus_source", None)
+    return MetricsResponse(
+        provider=provider, scope=scope, metrics=metrics, snapshot=snapshot, warnings=warnings
+    )
+
+
+class PrometheusSourceCreate(BaseModel):
+    """Request body to register a Prometheus source for Ceph metrics."""
+
+    name: str = Field(..., min_length=1)
+    url: str = Field(..., min_length=1)
+    bearer_token: str | None = None
+    credential_ref: str | None = None
+    cluster_ref: str | None = None
+    verify_ssl: bool = True
+    enabled: bool = True
+    timeout_seconds: int = 15
+    scrape_interval_seconds: int = 60
+
+
+class PrometheusSourceOut(BaseModel):
+    """Redacted Prometheus source record (never exposes the bearer token)."""
+
+    id: int
+    name: str
+    url: str
+    credential_ref: str | None = None
+    cluster_ref: str | None = None
+    verify_ssl: bool
+    enabled: bool
+    timeout_seconds: int
+    scrape_interval_seconds: int
+    has_token: bool
+
+
+def _source_out(source: PrometheusSource) -> PrometheusSourceOut:
+    return PrometheusSourceOut(
+        id=source.id or 0,
+        name=source.name,
+        url=source.url,
+        credential_ref=source.credential_ref,
+        cluster_ref=source.cluster_ref,
+        verify_ssl=source.verify_ssl,
+        enabled=source.enabled,
+        timeout_seconds=source.timeout_seconds,
+        scrape_interval_seconds=source.scrape_interval_seconds,
+        has_token=bool(source.bearer_token),
+    )
+
+
+@router.get("/metrics/sources", response_model=list[PrometheusSourceOut])
+async def ceph_v2_list_prometheus_sources(
+    session: AsyncDatabaseSessionDep,
+) -> list[PrometheusSourceOut]:
+    """List configured Prometheus sources (bearer tokens redacted)."""
+
+    rows = list((await session.exec(select(PrometheusSource))).all())
+    return [_source_out(row) for row in rows]
+
+
+@router.post("/metrics/sources", response_model=PrometheusSourceOut, status_code=201)
+async def ceph_v2_create_prometheus_source(
+    payload: PrometheusSourceCreate,
+    session: AsyncDatabaseSessionDep,
+) -> PrometheusSourceOut:
+    """Register a Prometheus source. The bearer token is encrypted at rest."""
+
+    existing = (
+        await session.exec(select(PrometheusSource).where(PrometheusSource.name == payload.name))
+    ).first()
+    if existing is not None:
+        raise HTTPException(status_code=409, detail="A source with that name already exists.")
+    source = PrometheusSource(
+        name=payload.name,
+        url=payload.url,
+        credential_ref=payload.credential_ref,
+        cluster_ref=payload.cluster_ref,
+        verify_ssl=payload.verify_ssl,
+        enabled=payload.enabled,
+        timeout_seconds=payload.timeout_seconds,
+        scrape_interval_seconds=payload.scrape_interval_seconds,
+    )
+    source.set_encrypted_bearer_token(payload.bearer_token)
+    session.add(source)
+    await session.commit()
+    await session.refresh(source)
+    return _source_out(source)
+
+
+@router.post("/metrics/sources/{source_id}/validate")
+async def ceph_v2_validate_prometheus_source(
+    source_id: int,
+    session: AsyncDatabaseSessionDep,
+) -> dict[str, Any]:
+    """Probe a registered Prometheus source for reachability."""
+
+    source = await session.get(PrometheusSource, source_id)
+    if source is None:
+        raise HTTPException(status_code=404, detail="Prometheus source not found.")
+    ok, error = await validate_source(_source_to_config(source))
+    return {"id": source_id, "ok": ok, "error": error}

--- a/proxbox_api/ceph/v2_routes.py
+++ b/proxbox_api/ceph/v2_routes.py
@@ -26,6 +26,10 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 from sqlmodel import select
 
+from proxbox_api.ceph.dashboard_client import (
+    DashboardEndpointConfig,
+    validate_dashboard_endpoint,
+)
 from proxbox_api.ceph.prometheus import (
     PrometheusSourceConfig,
     validate_source,
@@ -42,6 +46,9 @@ from proxbox_api.ceph.v2_engine import (
     validate_payload,
 )
 from proxbox_api.ceph.v2_providers import adapter_for_provider, provider_names
+from proxbox_api.ceph.v2_providers.base import CephProviderAdapter
+from proxbox_api.ceph.v2_providers.dashboard import DashboardCephProviderAdapter
+from proxbox_api.ceph.v2_providers.prometheus import PrometheusCephProviderAdapter
 from proxbox_api.ceph.v2_schemas import (
     ApplyRequest,
     CapabilitiesResponse,
@@ -56,6 +63,7 @@ from proxbox_api.ceph.v2_schemas import (
 )
 from proxbox_api.database import (
     AsyncDatabaseSessionDep,
+    CephDashboardEndpoint,
     CephOperationRunRecord,
     PrometheusSource,
 )
@@ -90,6 +98,61 @@ async def _resolve_prometheus_source(
     return rows[0] if rows else None
 
 
+def _dashboard_to_config(endpoint: CephDashboardEndpoint) -> DashboardEndpointConfig:
+    return DashboardEndpointConfig(
+        base_url=endpoint.base_url,
+        username=endpoint.username,
+        password=endpoint.get_decrypted_password(),
+        token=endpoint.get_decrypted_token(),
+        verify_ssl=endpoint.verify_ssl,
+        api_version=endpoint.api_version,
+        timeout=endpoint.timeout_seconds,
+    )
+
+
+async def _resolve_dashboard_endpoint(
+    session: AsyncDatabaseSessionDep, cluster_ref: str | None
+) -> CephDashboardEndpoint | None:
+    """Pick the enabled Ceph Dashboard endpoint bound to ``cluster_ref``, else any."""
+
+    stmt = select(CephDashboardEndpoint).where(CephDashboardEndpoint.enabled == True)  # noqa: E712
+    rows = list((await session.exec(stmt)).all())
+    if cluster_ref:
+        for row in rows:
+            if row.cluster_ref == cluster_ref:
+                return row
+    return rows[0] if rows else None
+
+
+def _scope_object_ref(scope: dict[str, Any]) -> str | None:
+    value = scope.get("object_ref") or scope.get("cluster_ref")
+    return str(value) if value else None
+
+
+async def build_adapter(
+    provider: str | None,
+    pxs: list[object],
+    session: AsyncDatabaseSessionDep,
+    *,
+    object_ref: str | None = None,
+) -> CephProviderAdapter:
+    """Resolve a provider adapter, injecting DB-stored endpoints where needed.
+
+    Dashboard/Prometheus adapters get their endpoint config wired at construction
+    so ``apply()`` (which receives no scope) and ``read_state()`` both work.
+    """
+    name = (provider or "proxmox").strip().lower().replace("-", "_")
+    if name == "dashboard":
+        endpoint = await _resolve_dashboard_endpoint(session, object_ref)
+        config = _dashboard_to_config(endpoint) if endpoint else None
+        return DashboardCephProviderAdapter(list(pxs), endpoint=config)
+    if name == "prometheus":
+        source = await _resolve_prometheus_source(session, object_ref)
+        config = _source_to_config(source) if source else None
+        return PrometheusCephProviderAdapter(list(pxs), source=config)
+    return adapter_for_provider(provider, list(pxs))
+
+
 def _with_actor(model: Any, actor: str | None) -> None:
     """Prefer an explicit body actor, else fall back to the request header."""
 
@@ -119,8 +182,14 @@ async def ceph_v2_validate(payload: dict[str, Any]) -> ValidationResponse:
     return validate_payload(payload)
 
 
-async def _build_and_remember(request: PlanRequest, pxs: ProxmoxSessionsDep) -> PlanResponse:
-    adapter = adapter_for_provider(request.provider, list(pxs))
+async def _build_and_remember(
+    request: PlanRequest,
+    pxs: ProxmoxSessionsDep,
+    session: AsyncDatabaseSessionDep,
+) -> PlanResponse:
+    adapter = await build_adapter(
+        request.provider, list(pxs), session, object_ref=_scope_object_ref(request.scope)
+    )
     plan = await build_plan(request, adapter)
     remember_plan(plan)
     return plan
@@ -130,12 +199,13 @@ async def _build_and_remember(request: PlanRequest, pxs: ProxmoxSessionsDep) -> 
 async def ceph_v2_create_plan(
     request: PlanRequest,
     pxs: ProxmoxSessionsDep,
+    session: AsyncDatabaseSessionDep,
     actor: ActorHeader = None,
 ) -> PlanResponse:
     """Build a plan from NetBox desired state and current provider state."""
 
     _with_actor(request, actor)
-    return await _build_and_remember(request, pxs)
+    return await _build_and_remember(request, pxs, session)
 
 
 @router.get("/plans/{plan_id}", response_model=PlanResponse)
@@ -163,7 +233,9 @@ async def ceph_v2_apply_plan(
         plan = get_plan(plan_id)
     except CephPlanNotFound as exc:
         raise HTTPException(status_code=404, detail=f"Plan {plan_id!r} not found.") from exc
-    adapter = adapter_for_provider(plan.provider, list(pxs))
+    adapter = await build_adapter(
+        plan.provider, list(pxs), session, object_ref=_scope_object_ref(request.scope)
+    )
     try:
         return await apply_plan(plan, request, adapter, session)
     except CephApplyError as exc:
@@ -174,12 +246,13 @@ async def ceph_v2_apply_plan(
 async def ceph_v2_plan_compat(
     request: PlanRequest,
     pxs: ProxmoxSessionsDep,
+    session: AsyncDatabaseSessionDep,
     actor: ActorHeader = None,
 ) -> PlanResponse:
     """Flat client-contract alias for ``POST /plans`` (netbox-ceph orchestrator)."""
 
     _with_actor(request, actor)
-    return await _build_and_remember(request, pxs)
+    return await _build_and_remember(request, pxs, session)
 
 
 @router.post("/apply", response_model=OperationRun)
@@ -202,10 +275,12 @@ async def ceph_v2_apply_compat(
         source_branch_schema_id=request.source_branch_schema_id,
         request_id=request.request_id,
     )
-    plan = await _build_and_remember(plan_request, pxs)
+    plan = await _build_and_remember(plan_request, pxs, session)
     if request.plan_id is None:
         request.plan_id = plan.id
-    adapter = adapter_for_provider(plan.provider, list(pxs))
+    adapter = await build_adapter(
+        plan.provider, list(pxs), session, object_ref=_scope_object_ref(request.scope)
+    )
     try:
         return await apply_plan(plan, request, adapter, session)
     except CephApplyError as exc:
@@ -284,7 +359,9 @@ async def ceph_v2_reconcile(
     """Reconcile provider state back into NetBox inventory/current-state summaries."""
 
     _with_actor(request, actor)
-    adapter = adapter_for_provider(request.provider, list(pxs))
+    adapter = await build_adapter(
+        request.provider, list(pxs), session, object_ref=_scope_object_ref(request.scope)
+    )
     return await reconcile_provider(request, adapter, session)
 
 
@@ -297,36 +374,30 @@ async def ceph_v2_metrics(
 ) -> MetricsResponse:
     """Return the latest provider metrics for the requested scope.
 
-    For ``provider=prometheus`` the configured Prometheus source is resolved
-    from the DB and injected into the adapter scope, and the result is parsed
-    into a typed :class:`CephMetricSnapshot`.
+    For ``provider=prometheus`` (and ``dashboard``) the configured endpoint is
+    resolved from the DB and wired into the adapter; the result is parsed into a
+    typed :class:`CephMetricSnapshot` where it matches that shape.
     """
 
-    adapter = adapter_for_provider(provider, list(pxs))
-    scope: dict[str, Any] = {}
-    if object_ref:
-        scope["object_ref"] = object_ref
+    adapter = await build_adapter(provider, list(pxs), session, object_ref=object_ref)
+    scope: dict[str, Any] = {"object_ref": object_ref} if object_ref else {}
     warnings: list[str] = []
-    if provider == "prometheus":
-        source = await _resolve_prometheus_source(session, object_ref)
-        if source is None:
-            warnings.append("no Prometheus source configured")
-        else:
-            scope["prometheus_source"] = _source_to_config(source)
     try:
         metrics = await adapter.metrics(scope)
     except Exception as exc:  # noqa: BLE001 - surface adapter gaps as a warning, not a 500
         logger.warning("Ceph v2 metrics unavailable for provider %s: %s", provider, exc)
         metrics = {}
         warnings.append(str(exc))
+    if not metrics and provider == "prometheus":
+        warnings.append("no Prometheus source configured")
+    if not metrics and provider == "dashboard":
+        warnings.append("no Ceph Dashboard endpoint configured")
     snapshot: CephMetricSnapshot | None = None
     if metrics:
         try:
             snapshot = CephMetricSnapshot.model_validate(metrics)
         except Exception:  # noqa: BLE001 - non-snapshot providers return free-form metrics
             snapshot = None
-    # Drop the (unserializable) source config from the echoed scope.
-    scope.pop("prometheus_source", None)
     return MetricsResponse(
         provider=provider, scope=scope, metrics=metrics, snapshot=snapshot, warnings=warnings
     )
@@ -427,3 +498,111 @@ async def ceph_v2_validate_prometheus_source(
         raise HTTPException(status_code=404, detail="Prometheus source not found.")
     ok, error = await validate_source(_source_to_config(source))
     return {"id": source_id, "ok": ok, "error": error}
+
+
+# --------------------------------------------------------------------------- #
+# Ceph Dashboard endpoint registration (#98)
+# --------------------------------------------------------------------------- #
+class DashboardEndpointCreate(BaseModel):
+    """Request body to register a direct Ceph Dashboard endpoint."""
+
+    name: str = Field(..., min_length=1)
+    base_url: str = Field(..., min_length=1)
+    username: str | None = None
+    password: str | None = None
+    token: str | None = None
+    credential_ref: str | None = None
+    cluster_ref: str | None = None
+    api_version: str = "1.0"
+    verify_ssl: bool = True
+    enabled: bool = True
+    timeout_seconds: int = 30
+
+
+class DashboardEndpointOut(BaseModel):
+    """Redacted Ceph Dashboard endpoint record (never exposes secrets)."""
+
+    id: int
+    name: str
+    base_url: str
+    username: str | None = None
+    credential_ref: str | None = None
+    cluster_ref: str | None = None
+    api_version: str
+    verify_ssl: bool
+    enabled: bool
+    timeout_seconds: int
+    has_secret: bool
+
+
+def _dashboard_out(endpoint: CephDashboardEndpoint) -> DashboardEndpointOut:
+    return DashboardEndpointOut(
+        id=endpoint.id or 0,
+        name=endpoint.name,
+        base_url=endpoint.base_url,
+        username=endpoint.username,
+        credential_ref=endpoint.credential_ref,
+        cluster_ref=endpoint.cluster_ref,
+        api_version=endpoint.api_version,
+        verify_ssl=endpoint.verify_ssl,
+        enabled=endpoint.enabled,
+        timeout_seconds=endpoint.timeout_seconds,
+        has_secret=bool(endpoint.password or endpoint.token),
+    )
+
+
+@router.get("/dashboard/endpoints", response_model=list[DashboardEndpointOut])
+async def ceph_v2_list_dashboard_endpoints(
+    session: AsyncDatabaseSessionDep,
+) -> list[DashboardEndpointOut]:
+    """List configured Ceph Dashboard endpoints (passwords/tokens redacted)."""
+
+    rows = list((await session.exec(select(CephDashboardEndpoint))).all())
+    return [_dashboard_out(row) for row in rows]
+
+
+@router.post("/dashboard/endpoints", response_model=DashboardEndpointOut, status_code=201)
+async def ceph_v2_create_dashboard_endpoint(
+    payload: DashboardEndpointCreate,
+    session: AsyncDatabaseSessionDep,
+) -> DashboardEndpointOut:
+    """Register a Ceph Dashboard endpoint. Password/token are encrypted at rest."""
+
+    existing = (
+        await session.exec(
+            select(CephDashboardEndpoint).where(CephDashboardEndpoint.name == payload.name)
+        )
+    ).first()
+    if existing is not None:
+        raise HTTPException(status_code=409, detail="An endpoint with that name already exists.")
+    endpoint = CephDashboardEndpoint(
+        name=payload.name,
+        base_url=payload.base_url,
+        username=payload.username,
+        credential_ref=payload.credential_ref,
+        cluster_ref=payload.cluster_ref,
+        api_version=payload.api_version,
+        verify_ssl=payload.verify_ssl,
+        enabled=payload.enabled,
+        timeout_seconds=payload.timeout_seconds,
+    )
+    endpoint.set_encrypted_password(payload.password)
+    endpoint.set_encrypted_token(payload.token)
+    session.add(endpoint)
+    await session.commit()
+    await session.refresh(endpoint)
+    return _dashboard_out(endpoint)
+
+
+@router.post("/dashboard/endpoints/{endpoint_id}/validate")
+async def ceph_v2_validate_dashboard_endpoint(
+    endpoint_id: int,
+    session: AsyncDatabaseSessionDep,
+) -> dict[str, Any]:
+    """Probe a registered Ceph Dashboard endpoint (auth + capability detection)."""
+
+    endpoint = await session.get(CephDashboardEndpoint, endpoint_id)
+    if endpoint is None:
+        raise HTTPException(status_code=404, detail="Ceph Dashboard endpoint not found.")
+    ok, error = await validate_dashboard_endpoint(_dashboard_to_config(endpoint))
+    return {"id": endpoint_id, "ok": ok, "error": error}

--- a/proxbox_api/ceph/v2_routes.py
+++ b/proxbox_api/ceph/v2_routes.py
@@ -34,6 +34,7 @@ from proxbox_api.ceph.prometheus import (
     PrometheusSourceConfig,
     validate_source,
 )
+from proxbox_api.ceph.rgw_client import RGWAdminConfig
 from proxbox_api.ceph.v2_engine import (
     CephApplyError,
     CephPlanNotFound,
@@ -48,6 +49,7 @@ from proxbox_api.ceph.v2_engine import (
 from proxbox_api.ceph.v2_providers import adapter_for_provider, provider_names
 from proxbox_api.ceph.v2_providers.base import CephProviderAdapter
 from proxbox_api.ceph.v2_providers.dashboard import DashboardCephProviderAdapter
+from proxbox_api.ceph.v2_providers.external import ExternalCephProviderAdapter
 from proxbox_api.ceph.v2_providers.prometheus import PrometheusCephProviderAdapter
 from proxbox_api.ceph.v2_schemas import (
     ApplyRequest,
@@ -64,6 +66,7 @@ from proxbox_api.ceph.v2_schemas import (
 from proxbox_api.database import (
     AsyncDatabaseSessionDep,
     CephDashboardEndpoint,
+    CephExternalCluster,
     CephOperationRunRecord,
     PrometheusSource,
 )
@@ -129,6 +132,57 @@ def _scope_object_ref(scope: dict[str, Any]) -> str | None:
     return str(value) if value else None
 
 
+async def _resolve_external_cluster(
+    session: AsyncDatabaseSessionDep, cluster_ref: str | None
+) -> CephExternalCluster | None:
+    stmt = select(CephExternalCluster).where(CephExternalCluster.enabled == True)  # noqa: E712
+    rows = list((await session.exec(stmt)).all())
+    if cluster_ref:
+        for row in rows:
+            if row.cluster_ref == cluster_ref or row.name == cluster_ref:
+                return row
+    return rows[0] if rows else None
+
+
+def _rgw_config_from_cluster(cluster: CephExternalCluster) -> RGWAdminConfig | None:
+    access = cluster.get_decrypted_rgw_access_key()
+    secret = cluster.get_decrypted_rgw_secret_key()
+    if cluster.rgw_admin_url and access and secret:
+        return RGWAdminConfig(
+            base_url=cluster.rgw_admin_url,
+            access_key=access,
+            secret_key=secret,
+            verify_ssl=cluster.verify_ssl,
+        )
+    return None
+
+
+async def _external_adapter(
+    cluster: CephExternalCluster | None,
+    pxs: list[object],
+    session: AsyncDatabaseSessionDep,
+) -> ExternalCephProviderAdapter:
+    if cluster is None:
+        return ExternalCephProviderAdapter(list(pxs))
+    dashboard_cfg = None
+    if cluster.dashboard_endpoint_id is not None:
+        endpoint = await session.get(CephDashboardEndpoint, cluster.dashboard_endpoint_id)
+        if endpoint is not None:
+            dashboard_cfg = _dashboard_to_config(endpoint)
+    prometheus_cfg = None
+    if cluster.prometheus_source_id is not None:
+        source = await session.get(PrometheusSource, cluster.prometheus_source_id)
+        if source is not None:
+            prometheus_cfg = _source_to_config(source)
+    return ExternalCephProviderAdapter(
+        list(pxs),
+        dashboard=dashboard_cfg,
+        prometheus=prometheus_cfg,
+        rgw=_rgw_config_from_cluster(cluster),
+        ceph_version=cluster.ceph_version_hint,
+    )
+
+
 async def build_adapter(
     provider: str | None,
     pxs: list[object],
@@ -138,8 +192,9 @@ async def build_adapter(
 ) -> CephProviderAdapter:
     """Resolve a provider adapter, injecting DB-stored endpoints where needed.
 
-    Dashboard/Prometheus adapters get their endpoint config wired at construction
-    so ``apply()`` (which receives no scope) and ``read_state()`` both work.
+    Dashboard/Prometheus/External adapters get their endpoint config wired at
+    construction so ``apply()`` (which receives no scope) and ``read_state()``
+    both work.
     """
     name = (provider or "proxmox").strip().lower().replace("-", "_")
     if name == "dashboard":
@@ -150,6 +205,9 @@ async def build_adapter(
         source = await _resolve_prometheus_source(session, object_ref)
         config = _source_to_config(source) if source else None
         return PrometheusCephProviderAdapter(list(pxs), source=config)
+    if name == "external":
+        cluster = await _resolve_external_cluster(session, object_ref)
+        return await _external_adapter(cluster, list(pxs), session)
     return adapter_for_provider(provider, list(pxs))
 
 
@@ -392,6 +450,8 @@ async def ceph_v2_metrics(
         warnings.append("no Prometheus source configured")
     if not metrics and provider == "dashboard":
         warnings.append("no Ceph Dashboard endpoint configured")
+    if not metrics and provider == "external":
+        warnings.append("no metrics provider configured for the external cluster")
     snapshot: CephMetricSnapshot | None = None
     if metrics:
         try:
@@ -606,3 +666,118 @@ async def ceph_v2_validate_dashboard_endpoint(
         raise HTTPException(status_code=404, detail="Ceph Dashboard endpoint not found.")
     ok, error = await validate_dashboard_endpoint(_dashboard_to_config(endpoint))
     return {"id": endpoint_id, "ok": ok, "error": error}
+
+
+# --------------------------------------------------------------------------- #
+# External (non-Proxmox) Ceph cluster registration (#97)
+# --------------------------------------------------------------------------- #
+class ExternalClusterCreate(BaseModel):
+    """Request body to register an external (non-Proxmox) Ceph cluster."""
+
+    name: str = Field(..., min_length=1)
+    cluster_ref: str | None = None
+    ceph_version_hint: str | None = None
+    dashboard_endpoint_id: int | None = None
+    prometheus_source_id: int | None = None
+    rgw_admin_url: str | None = None
+    rgw_access_key: str | None = None
+    rgw_secret_key: str | None = None
+    ssh_host: str | None = None
+    ssh_user: str | None = None
+    ssh_credential_ref: str | None = None
+    verify_ssl: bool = True
+    enabled: bool = True
+
+
+class ExternalClusterOut(BaseModel):
+    """Redacted external cluster record (never exposes RGW secret keys)."""
+
+    id: int
+    name: str
+    cluster_ref: str | None = None
+    ceph_version_hint: str | None = None
+    dashboard_endpoint_id: int | None = None
+    prometheus_source_id: int | None = None
+    rgw_admin_url: str | None = None
+    has_rgw_credentials: bool
+    ssh_host: str | None = None
+    ssh_user: str | None = None
+    verify_ssl: bool
+    enabled: bool
+
+
+def _external_out(cluster: CephExternalCluster) -> ExternalClusterOut:
+    return ExternalClusterOut(
+        id=cluster.id or 0,
+        name=cluster.name,
+        cluster_ref=cluster.cluster_ref,
+        ceph_version_hint=cluster.ceph_version_hint,
+        dashboard_endpoint_id=cluster.dashboard_endpoint_id,
+        prometheus_source_id=cluster.prometheus_source_id,
+        rgw_admin_url=cluster.rgw_admin_url,
+        has_rgw_credentials=bool(cluster.rgw_access_key and cluster.rgw_secret_key),
+        ssh_host=cluster.ssh_host,
+        ssh_user=cluster.ssh_user,
+        verify_ssl=cluster.verify_ssl,
+        enabled=cluster.enabled,
+    )
+
+
+@router.get("/external/clusters", response_model=list[ExternalClusterOut])
+async def ceph_v2_list_external_clusters(
+    session: AsyncDatabaseSessionDep,
+) -> list[ExternalClusterOut]:
+    """List configured external Ceph clusters (RGW secret keys redacted)."""
+
+    rows = list((await session.exec(select(CephExternalCluster))).all())
+    return [_external_out(row) for row in rows]
+
+
+@router.post("/external/clusters", response_model=ExternalClusterOut, status_code=201)
+async def ceph_v2_create_external_cluster(
+    payload: ExternalClusterCreate,
+    session: AsyncDatabaseSessionDep,
+) -> ExternalClusterOut:
+    """Register an external Ceph cluster. RGW secret keys are encrypted at rest."""
+
+    existing = (
+        await session.exec(
+            select(CephExternalCluster).where(CephExternalCluster.name == payload.name)
+        )
+    ).first()
+    if existing is not None:
+        raise HTTPException(status_code=409, detail="A cluster with that name already exists.")
+    cluster = CephExternalCluster(
+        name=payload.name,
+        cluster_ref=payload.cluster_ref,
+        ceph_version_hint=payload.ceph_version_hint,
+        dashboard_endpoint_id=payload.dashboard_endpoint_id,
+        prometheus_source_id=payload.prometheus_source_id,
+        rgw_admin_url=payload.rgw_admin_url,
+        ssh_host=payload.ssh_host,
+        ssh_user=payload.ssh_user,
+        ssh_credential_ref=payload.ssh_credential_ref,
+        verify_ssl=payload.verify_ssl,
+        enabled=payload.enabled,
+    )
+    cluster.set_encrypted_rgw_access_key(payload.rgw_access_key)
+    cluster.set_encrypted_rgw_secret_key(payload.rgw_secret_key)
+    session.add(cluster)
+    await session.commit()
+    await session.refresh(cluster)
+    return _external_out(cluster)
+
+
+@router.post("/external/clusters/{cluster_id}/capabilities", response_model=CapabilitiesResponse)
+async def ceph_v2_external_cluster_capabilities(
+    cluster_id: int,
+    pxs: ProxmoxSessionsDep,
+    session: AsyncDatabaseSessionDep,
+) -> CapabilitiesResponse:
+    """Detect capabilities for an external cluster from its configured providers."""
+
+    cluster = await session.get(CephExternalCluster, cluster_id)
+    if cluster is None:
+        raise HTTPException(status_code=404, detail="External Ceph cluster not found.")
+    adapter = await _external_adapter(cluster, list(pxs), session)
+    return CapabilitiesResponse(providers=[await adapter.capabilities()])

--- a/proxbox_api/ceph/v2_schemas.py
+++ b/proxbox_api/ceph/v2_schemas.py
@@ -340,10 +340,62 @@ class CapabilitiesResponse(BaseModel):
     providers: list[ProviderCapabilities]
 
 
+CephHealthStatus = Literal["HEALTH_OK", "HEALTH_WARN", "HEALTH_ERR", "unknown"]
+
+
+class CephMetricSnapshot(BaseModel):
+    """Bounded, latest-only Ceph metric snapshot normalized from Prometheus.
+
+    Deliberately stores a single current snapshot (not a time series): the
+    fields needed for health, capacity, and drift/safety decisions. ``unknown``
+    health and ``None`` metric values mean "no data" rather than zero.
+    """
+
+    cluster_health: CephHealthStatus = "unknown"
+    captured_at: datetime
+    source_url: str | None = None
+    # capacity
+    bytes_total: int | None = None
+    bytes_used: int | None = None
+    bytes_avail: int | None = None
+    percent_used: float | None = None
+    # daemons
+    osd_up: int | None = None
+    osd_in: int | None = None
+    osd_total: int | None = None
+    mon_quorum: int | None = None
+    mgr_active: int | None = None
+    # placement groups
+    pgs_total: int | None = None
+    pg_states: dict[str, int] = Field(default_factory=dict)
+    degraded_pgs: int | None = None
+    misplaced_pgs: int | None = None
+    recovering_pgs: int | None = None
+    # performance
+    iops_read: float | None = None
+    iops_write: float | None = None
+    throughput_read_bps: float | None = None
+    throughput_write_bps: float | None = None
+    # pools / rgw / cephfs counters
+    pools: int | None = None
+    warnings: list[str] = Field(default_factory=list)
+
+    @property
+    def is_degraded(self) -> bool:
+        """True when health is non-OK or recovery/backfill is in flight."""
+        if self.cluster_health in ("HEALTH_WARN", "HEALTH_ERR"):
+            return True
+        for value in (self.degraded_pgs, self.misplaced_pgs, self.recovering_pgs):
+            if value:
+                return True
+        return False
+
+
 class MetricsResponse(BaseModel):
     provider: str
     scope: dict[str, Any] = Field(default_factory=dict)
     metrics: dict[str, Any] = Field(default_factory=dict)
+    snapshot: CephMetricSnapshot | None = None
     warnings: list[str] = Field(default_factory=list)
 
 
@@ -362,6 +414,8 @@ class SSEEvent(BaseModel):
 __all__ = [
     "ApplyRequest",
     "CapabilitiesResponse",
+    "CephHealthStatus",
+    "CephMetricSnapshot",
     "DesiredObject",
     "DesiredStateBundle",
     "MetricsResponse",

--- a/proxbox_api/database.py
+++ b/proxbox_api/database.py
@@ -336,6 +336,47 @@ class CephDashboardEndpoint(SQLModel, table=True):
         self.token = encrypt_value(value) if value else None
 
 
+class CephExternalCluster(SQLModel, table=True):
+    """External (non-Proxmox) Ceph cluster binding for Ceph v2 (#97).
+
+    Provider-neutral: references an optional Ceph Dashboard endpoint and
+    Prometheus source (by id) and carries inline RGW Admin Ops credentials.
+    No Proxmox endpoint / node / storage / task fields. ``ceph_version_hint``
+    feeds capability detection.
+    """
+
+    __tablename__: ClassVar[str] = "ceph_external_cluster"
+    __table_args__ = {"extend_existing": True}
+
+    id: int | None = Field(default=None, primary_key=True)
+    name: str = Field(index=True, unique=True)
+    cluster_ref: str | None = Field(default=None, index=True)
+    ceph_version_hint: str | None = Field(default=None)
+    dashboard_endpoint_id: int | None = Field(default=None)
+    prometheus_source_id: int | None = Field(default=None)
+    rgw_admin_url: str | None = Field(default=None)
+    rgw_access_key: str | None = Field(default=None)
+    rgw_secret_key: str | None = Field(default=None)
+    ssh_host: str | None = Field(default=None)
+    ssh_user: str | None = Field(default=None)
+    ssh_credential_ref: str | None = Field(default=None)
+    verify_ssl: bool = Field(default=True)
+    enabled: bool = Field(default=True)
+    last_seen_at: float | None = Field(default=None)
+
+    def get_decrypted_rgw_access_key(self) -> str | None:
+        return decrypt_value(self.rgw_access_key) if self.rgw_access_key else None
+
+    def set_encrypted_rgw_access_key(self, value: str | None) -> None:
+        self.rgw_access_key = encrypt_value(value) if value else None
+
+    def get_decrypted_rgw_secret_key(self) -> str | None:
+        return decrypt_value(self.rgw_secret_key) if self.rgw_secret_key else None
+
+    def set_encrypted_rgw_secret_key(self, value: str | None) -> None:
+        self.rgw_secret_key = encrypt_value(value) if value else None
+
+
 class AuthLockout(SQLModel, table=True):
     __table_args__ = {"extend_existing": True}
 
@@ -758,6 +799,42 @@ def _migrate_ceph_dashboard_endpoint_columns() -> None:
             conn.execute(text(stmt))
 
 
+def _migrate_ceph_external_cluster_columns() -> None:
+    table = CephExternalCluster.__tablename__
+    try:
+        insp = inspect(engine)
+        if not insp.has_table(table):
+            return
+        existing = {c["name"] for c in insp.get_columns(table)}
+    except Exception:
+        return
+    column_specs: dict[str, str] = {
+        "cluster_ref": "VARCHAR",
+        "ceph_version_hint": "VARCHAR",
+        "dashboard_endpoint_id": "INTEGER",
+        "prometheus_source_id": "INTEGER",
+        "rgw_admin_url": "VARCHAR",
+        "rgw_access_key": "VARCHAR",
+        "rgw_secret_key": "VARCHAR",
+        "ssh_host": "VARCHAR",
+        "ssh_user": "VARCHAR",
+        "ssh_credential_ref": "VARCHAR",
+        "verify_ssl": "BOOLEAN NOT NULL DEFAULT 1",
+        "enabled": "BOOLEAN NOT NULL DEFAULT 1",
+        "last_seen_at": "REAL",
+    }
+    stmts = [
+        f"ALTER TABLE {table} ADD COLUMN {col} {spec}"
+        for col, spec in column_specs.items()
+        if col not in existing
+    ]
+    if not stmts:
+        return
+    with engine.begin() as conn:
+        for stmt in stmts:
+            conn.execute(text(stmt))
+
+
 def create_db_and_tables() -> None:
     SQLModel.metadata.create_all(engine)
     _migrate_proxmox_endpoint_columns()
@@ -768,6 +845,7 @@ def create_db_and_tables() -> None:
     _migrate_ceph_operation_run_columns()
     _migrate_prometheus_source_columns()
     _migrate_ceph_dashboard_endpoint_columns()
+    _migrate_ceph_external_cluster_columns()
 
 
 def get_session() -> Generator[Session, None, None]:

--- a/proxbox_api/database.py
+++ b/proxbox_api/database.py
@@ -297,6 +297,45 @@ class PrometheusSource(SQLModel, table=True):
         self.bearer_token = encrypt_value(value) if value else None
 
 
+class CephDashboardEndpoint(SQLModel, table=True):
+    """Direct Ceph Dashboard API endpoint for Ceph v2 (#98).
+
+    Stores connection metadata plus an encrypted password (or token) used to
+    authenticate to the Ceph Manager Dashboard REST API. No Proxmox endpoint is
+    required, so this works for external/standalone clusters. ``cluster_ref``
+    binds the endpoint to a Ceph cluster / object reference.
+    """
+
+    __tablename__: ClassVar[str] = "ceph_dashboard_endpoint"
+    __table_args__ = {"extend_existing": True}
+
+    id: int | None = Field(default=None, primary_key=True)
+    name: str = Field(index=True, unique=True)
+    base_url: str = Field()
+    username: str | None = Field(default=None)
+    password: str | None = Field(default=None)
+    token: str | None = Field(default=None)
+    credential_ref: str | None = Field(default=None)
+    cluster_ref: str | None = Field(default=None, index=True)
+    api_version: str = Field(default="1.0")
+    verify_ssl: bool = Field(default=True)
+    enabled: bool = Field(default=True)
+    timeout_seconds: int = Field(default=30)
+    last_seen_at: float | None = Field(default=None)
+
+    def get_decrypted_password(self) -> str | None:
+        return decrypt_value(self.password) if self.password else None
+
+    def set_encrypted_password(self, value: str | None) -> None:
+        self.password = encrypt_value(value) if value else None
+
+    def get_decrypted_token(self) -> str | None:
+        return decrypt_value(self.token) if self.token else None
+
+    def set_encrypted_token(self, value: str | None) -> None:
+        self.token = encrypt_value(value) if value else None
+
+
 class AuthLockout(SQLModel, table=True):
     __table_args__ = {"extend_existing": True}
 
@@ -686,6 +725,39 @@ def _migrate_prometheus_source_columns() -> None:
             conn.execute(text(stmt))
 
 
+def _migrate_ceph_dashboard_endpoint_columns() -> None:
+    table = CephDashboardEndpoint.__tablename__
+    try:
+        insp = inspect(engine)
+        if not insp.has_table(table):
+            return
+        existing = {c["name"] for c in insp.get_columns(table)}
+    except Exception:
+        return
+    column_specs: dict[str, str] = {
+        "username": "VARCHAR",
+        "password": "VARCHAR",
+        "token": "VARCHAR",
+        "credential_ref": "VARCHAR",
+        "cluster_ref": "VARCHAR",
+        "api_version": "VARCHAR NOT NULL DEFAULT '1.0'",
+        "verify_ssl": "BOOLEAN NOT NULL DEFAULT 1",
+        "enabled": "BOOLEAN NOT NULL DEFAULT 1",
+        "timeout_seconds": "INTEGER NOT NULL DEFAULT 30",
+        "last_seen_at": "REAL",
+    }
+    stmts = [
+        f"ALTER TABLE {table} ADD COLUMN {col} {spec}"
+        for col, spec in column_specs.items()
+        if col not in existing
+    ]
+    if not stmts:
+        return
+    with engine.begin() as conn:
+        for stmt in stmts:
+            conn.execute(text(stmt))
+
+
 def create_db_and_tables() -> None:
     SQLModel.metadata.create_all(engine)
     _migrate_proxmox_endpoint_columns()
@@ -695,6 +767,7 @@ def create_db_and_tables() -> None:
     _migrate_pdm_endpoint_columns()
     _migrate_ceph_operation_run_columns()
     _migrate_prometheus_source_columns()
+    _migrate_ceph_dashboard_endpoint_columns()
 
 
 def get_session() -> Generator[Session, None, None]:

--- a/proxbox_api/database.py
+++ b/proxbox_api/database.py
@@ -266,6 +266,37 @@ class CephOperationRunRecord(SQLModel, table=True):
     )
 
 
+class PrometheusSource(SQLModel, table=True):
+    """Prometheus metric source for a Ceph cluster (Ceph v2 #94).
+
+    Stores only connection metadata and an optional encrypted bearer token; no
+    time-series data is persisted here. ``cluster_ref`` binds the source to a
+    Ceph cluster / object reference so the metrics route can resolve the right
+    source for a scope.
+    """
+
+    __tablename__: ClassVar[str] = "prometheus_source"
+    __table_args__ = {"extend_existing": True}
+
+    id: int | None = Field(default=None, primary_key=True)
+    name: str = Field(index=True, unique=True)
+    url: str = Field()
+    bearer_token: str | None = Field(default=None)
+    credential_ref: str | None = Field(default=None)
+    cluster_ref: str | None = Field(default=None, index=True)
+    verify_ssl: bool = Field(default=True)
+    enabled: bool = Field(default=True)
+    timeout_seconds: int = Field(default=15)
+    scrape_interval_seconds: int = Field(default=60)
+    last_seen_at: float | None = Field(default=None)
+
+    def get_decrypted_bearer_token(self) -> str | None:
+        return decrypt_value(self.bearer_token) if self.bearer_token else None
+
+    def set_encrypted_bearer_token(self, value: str | None) -> None:
+        self.bearer_token = encrypt_value(value) if value else None
+
+
 class AuthLockout(SQLModel, table=True):
     __table_args__ = {"extend_existing": True}
 
@@ -624,6 +655,37 @@ def _migrate_ceph_operation_run_columns() -> None:
         )
 
 
+def _migrate_prometheus_source_columns() -> None:
+    table = PrometheusSource.__tablename__
+    try:
+        insp = inspect(engine)
+        if not insp.has_table(table):
+            return
+        existing = {c["name"] for c in insp.get_columns(table)}
+    except Exception:
+        return
+    column_specs: dict[str, str] = {
+        "bearer_token": "VARCHAR",
+        "credential_ref": "VARCHAR",
+        "cluster_ref": "VARCHAR",
+        "verify_ssl": "BOOLEAN NOT NULL DEFAULT 1",
+        "enabled": "BOOLEAN NOT NULL DEFAULT 1",
+        "timeout_seconds": "INTEGER NOT NULL DEFAULT 15",
+        "scrape_interval_seconds": "INTEGER NOT NULL DEFAULT 60",
+        "last_seen_at": "REAL",
+    }
+    stmts = [
+        f"ALTER TABLE {table} ADD COLUMN {col} {spec}"
+        for col, spec in column_specs.items()
+        if col not in existing
+    ]
+    if not stmts:
+        return
+    with engine.begin() as conn:
+        for stmt in stmts:
+            conn.execute(text(stmt))
+
+
 def create_db_and_tables() -> None:
     SQLModel.metadata.create_all(engine)
     _migrate_proxmox_endpoint_columns()
@@ -632,6 +694,7 @@ def create_db_and_tables() -> None:
     _migrate_pbs_endpoint_columns()
     _migrate_pdm_endpoint_columns()
     _migrate_ceph_operation_run_columns()
+    _migrate_prometheus_source_columns()
 
 
 def get_session() -> Generator[Session, None, None]:

--- a/tests/ceph/test_dashboard_provider.py
+++ b/tests/ceph/test_dashboard_provider.py
@@ -1,0 +1,162 @@
+"""Ceph Dashboard provider adapter tests (#98)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from proxbox_api.ceph.dashboard_client import DashboardEndpointConfig
+from proxbox_api.ceph.v2_providers import dashboard as dash_mod
+from proxbox_api.ceph.v2_providers.base import CephCapabilityUnsupported
+from proxbox_api.ceph.v2_providers.dashboard import DashboardCephProviderAdapter
+from proxbox_api.ceph.v2_schemas import DesiredStateBundle, ProviderOperation
+
+CONFIG = DashboardEndpointConfig(base_url="https://ceph:8443", username="admin", password="x")
+
+
+class _FakeDashboardClient:
+    """Fake DashboardCephClient returning canned inventory; records writes."""
+
+    def __init__(self, *, fail: set[str] | None = None) -> None:
+        self.calls: list[tuple[str, Any]] = []
+        self._fail = fail or set()
+        self.closed = False
+
+    async def health(self) -> dict[str, Any]:
+        if "health" in self._fail:
+            raise RuntimeError("health down")
+        return {"status": "HEALTH_OK"}
+
+    async def pools(self) -> list[dict[str, Any]]:
+        return [{"pool_name": "rbd", "size": 3}, {"pool_name": "cephfs_data", "size": 2}]
+
+    async def osds(self) -> list[dict[str, Any]]:
+        return [{"osd": 0, "up": True}, {"osd": 1, "up": True}]
+
+    async def hosts(self) -> list[dict[str, Any]]:
+        return [{"hostname": "ceph-1"}]
+
+    async def filesystems(self) -> list[dict[str, Any]]:
+        return [{"name": "cephfs"}]
+
+    async def rbd_images(self) -> list[dict[str, Any]]:
+        return [{"name": "vm-100", "pool_name": "rbd", "size": 1024}]
+
+    async def rgw_buckets(self) -> list[dict[str, Any]]:
+        return [{"bucket": "backups", "owner": "alice"}]
+
+    async def pool_create(self, payload: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append(("pool_create", payload))
+        return {"name": "task-pool-create"}
+
+    async def pool_delete(self, name: str, *, confirm_destroy: bool) -> dict[str, Any]:
+        self.calls.append(("pool_delete", (name, confirm_destroy)))
+        return {}
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _adapter(client: _FakeDashboardClient, *, endpoint: DashboardEndpointConfig | None = CONFIG):
+    return DashboardCephProviderAdapter(endpoint=endpoint, client_factory=lambda _c: client)
+
+
+async def test_capabilities_inactive_without_sdk(monkeypatch) -> None:
+    monkeypatch.setattr(dash_mod, "dashboard_sdk_importable", lambda: False)
+    caps = await DashboardCephProviderAdapter().capabilities()
+    assert caps.supported is True
+    assert caps.apply is False and caps.read_state is False
+    assert any("0.0.11" in n for n in caps.notes)
+
+
+async def test_capabilities_active_with_sdk(monkeypatch) -> None:
+    monkeypatch.setattr(dash_mod, "dashboard_sdk_importable", lambda: True)
+    caps = await DashboardCephProviderAdapter().capabilities()
+    assert caps.apply is True and caps.read_state is True
+    assert caps.operation_kinds.get("pool:create") is True
+    assert caps.operation_kinds.get("rbd_image:create") is True
+    assert caps.operation_kinds.get("rgw_bucket:create") is False  # via rgw_admin/external
+
+
+async def test_read_state_collects_inventory_and_closes(monkeypatch) -> None:
+    monkeypatch.setattr(dash_mod, "dashboard_sdk_importable", lambda: True)
+    client = _FakeDashboardClient()
+    adapter = _adapter(client)
+    state = await adapter.read_state({})
+    kinds = {r["kind"] for r in state["resources"]}
+    assert {"pool", "osd", "host", "filesystem", "rbd_image", "rgw_bucket"} <= kinds
+    refs = {r["target_ref"] for r in state["resources"] if r["kind"] == "pool"}
+    assert refs == {"rbd", "cephfs_data"}
+    assert state["summary"]["health"] == "HEALTH_OK"
+    assert client.closed is True
+
+
+async def test_read_state_no_endpoint_reports_error() -> None:
+    adapter = DashboardCephProviderAdapter(endpoint=None)
+    state = await adapter.read_state({})
+    assert state["resources"] == []
+    assert any("no Ceph Dashboard endpoint" in e for e in state["errors"])
+
+
+async def test_read_state_partial_failure_is_isolated(monkeypatch) -> None:
+    monkeypatch.setattr(dash_mod, "dashboard_sdk_importable", lambda: True)
+    client = _FakeDashboardClient(fail={"health"})
+    adapter = _adapter(client)
+    state = await adapter.read_state({})
+    assert any("health" in e for e in state["errors"])
+    # other collectors still produced resources
+    assert state["resources"]
+
+
+async def test_diff_classifies_create_update_noop_delete(monkeypatch) -> None:
+    monkeypatch.setattr(dash_mod, "dashboard_sdk_importable", lambda: True)
+    adapter = _adapter(_FakeDashboardClient())
+    live = {
+        "resources": [
+            {"kind": "pool", "target_ref": "rbd", "summary": {"size": 3}},
+        ]
+    }
+    bundle = DesiredStateBundle.model_validate(
+        {
+            "objects": [
+                {"kind": "pool", "target_ref": "rbd", "payload": {"size": 3}},  # noop
+                {"kind": "pool", "target_ref": "rbd", "payload": {"size": 5}, "action": "ensure"},
+                {"kind": "pool", "target_ref": "new", "payload": {"size": 2}},  # create
+                {"kind": "pool", "target_ref": "old", "action": "delete"},  # delete
+            ]
+        }
+    )
+    ops = await adapter.diff(bundle, live)
+    by_target = {(o.target_ref, o.action) for o in ops}
+    assert ("rbd", "noop") in by_target
+    assert ("new", "create") in by_target
+    assert ("old", "delete") in by_target
+
+
+async def test_apply_pool_create_dispatches(monkeypatch) -> None:
+    monkeypatch.setattr(dash_mod, "dashboard_sdk_importable", lambda: True)
+    client = _FakeDashboardClient()
+    adapter = _adapter(client)
+    op = ProviderOperation(
+        kind="pool", target_ref="rbd", action="create", after_summary={"pool_name": "rbd"}
+    )
+    result = await adapter.apply(op, confirm_destructive=False)
+    assert result["result"] == "applied"
+    assert client.calls[0][0] == "pool_create"
+
+
+async def test_apply_blocked_without_sdk(monkeypatch) -> None:
+    monkeypatch.setattr(dash_mod, "dashboard_sdk_importable", lambda: False)
+    adapter = _adapter(_FakeDashboardClient())
+    op = ProviderOperation(kind="pool", target_ref="rbd", action="create")
+    with pytest.raises(CephCapabilityUnsupported, match="0.0.11"):
+        await adapter.apply(op, confirm_destructive=False)
+
+
+async def test_apply_blocked_without_endpoint(monkeypatch) -> None:
+    monkeypatch.setattr(dash_mod, "dashboard_sdk_importable", lambda: True)
+    adapter = DashboardCephProviderAdapter(endpoint=None)
+    op = ProviderOperation(kind="pool", target_ref="rbd", action="create")
+    with pytest.raises(CephCapabilityUnsupported, match="endpoint"):
+        await adapter.apply(op, confirm_destructive=False)

--- a/tests/ceph/test_dashboard_routes.py
+++ b/tests/ceph/test_dashboard_routes.py
@@ -1,0 +1,73 @@
+"""HTTP tests for the Ceph v2 Dashboard endpoint routes (#98)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from proxbox_api.main import app
+from proxbox_api.session.proxmox_providers import proxmox_sessions_dep
+
+
+@pytest.fixture
+def dash_client(auth_test_client):
+    app.dependency_overrides[proxmox_sessions_dep] = lambda: []
+    yield auth_test_client
+    app.dependency_overrides.pop(proxmox_sessions_dep, None)
+
+
+def test_dashboard_provider_listed_in_capabilities(dash_client) -> None:
+    resp = dash_client.get("/ceph/v2/capabilities", params={"provider": "dashboard"})
+    assert resp.status_code == 200
+    provider = resp.json()["providers"][0]
+    assert provider["provider"] == "dashboard"
+    assert provider["supported"] is True
+
+
+def test_register_list_validate_endpoint(dash_client, monkeypatch) -> None:
+    create = dash_client.post(
+        "/ceph/v2/dashboard/endpoints",
+        json={
+            "name": "ceph-prod",
+            "base_url": "https://ceph:8443",
+            "username": "admin",
+            "password": "super-secret",
+            "cluster_ref": "cluster:1",
+        },
+    )
+    assert create.status_code == 201, create.text
+    out = create.json()
+    assert out["has_secret"] is True
+    assert "password" not in out and "super-secret" not in create.text
+    endpoint_id = out["id"]
+
+    dup = dash_client.post(
+        "/ceph/v2/dashboard/endpoints", json={"name": "ceph-prod", "base_url": "https://x:8443"}
+    )
+    assert dup.status_code == 409
+
+    listed = dash_client.get("/ceph/v2/dashboard/endpoints")
+    assert listed.status_code == 200
+    assert any(e["name"] == "ceph-prod" and e["has_secret"] for e in listed.json())
+
+    async def fake_validate(config: Any) -> tuple[bool, str | None]:
+        assert config.base_url == "https://ceph:8443"
+        assert config.password == "super-secret"  # decrypted for the probe
+        return True, None
+
+    monkeypatch.setattr("proxbox_api.ceph.v2_routes.validate_dashboard_endpoint", fake_validate)
+    probe = dash_client.post(f"/ceph/v2/dashboard/endpoints/{endpoint_id}/validate")
+    assert probe.status_code == 200
+    assert probe.json() == {"id": endpoint_id, "ok": True, "error": None}
+
+
+def test_validate_missing_endpoint_404(dash_client) -> None:
+    resp = dash_client.post("/ceph/v2/dashboard/endpoints/9999/validate")
+    assert resp.status_code == 404
+
+
+def test_dashboard_metrics_warns_without_endpoint(dash_client) -> None:
+    resp = dash_client.get("/ceph/v2/metrics", params={"provider": "dashboard"})
+    assert resp.status_code == 200
+    assert any("Dashboard endpoint" in w for w in resp.json()["warnings"])

--- a/tests/ceph/test_dashboard_writer.py
+++ b/tests/ceph/test_dashboard_writer.py
@@ -1,0 +1,98 @@
+"""Ceph Dashboard write-operation mapping tests (#98)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from proxbox_api.ceph.v2_providers.base import CephCapabilityUnsupported
+from proxbox_api.ceph.v2_providers.dashboard_writer import (
+    execute_dashboard_operation,
+    operation_kinds,
+)
+from proxbox_api.ceph.v2_schemas import ProviderOperation
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple, dict]] = []
+
+    def __getattr__(self, name: str):
+        async def _call(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            self.calls.append((name, args, kwargs))
+            return {"name": f"task-{name}"}
+
+        return _call
+
+
+def _op(kind: str, action: str, *, target_ref: str = "rbd/vm", **summary: Any) -> ProviderOperation:
+    return ProviderOperation(kind=kind, target_ref=target_ref, action=action, after_summary=summary)
+
+
+def test_operation_kinds_gated_on_availability() -> None:
+    assert operation_kinds(False)["pool:create"] is False
+    on = operation_kinds(True)
+    assert on["pool:create"] is True
+    assert on["rbd_snapshot:delete"] is True
+    assert on["rgw_bucket:delete"] is False
+
+
+async def test_pool_create_update_delete() -> None:
+    client = _FakeClient()
+    await execute_dashboard_operation(
+        client, _op("pool", "create", target_ref="rbd", pool_name="rbd"), confirm_destructive=False
+    )
+    await execute_dashboard_operation(
+        client, _op("pool", "update", target_ref="rbd", size=4), confirm_destructive=False
+    )
+    res = await execute_dashboard_operation(
+        client, _op("pool", "delete", target_ref="rbd"), confirm_destructive=True
+    )
+    names = [c[0] for c in client.calls]
+    assert names == ["pool_create", "pool_edit", "pool_delete"]
+    # destructive confirm threaded
+    assert client.calls[2][2]["confirm_destroy"] is True
+    assert res["result"] == "applied"
+
+
+async def test_rbd_image_and_snapshot_specs() -> None:
+    client = _FakeClient()
+    await execute_dashboard_operation(
+        client,
+        _op("rbd_image", "create", target_ref="rbd/vm-1", pool_name="rbd", name="vm-1", size=10),
+        confirm_destructive=False,
+    )
+    await execute_dashboard_operation(
+        client,
+        _op(
+            "rbd_snapshot",
+            "create",
+            target_ref="rbd/vm-1",
+            pool_name="rbd",
+            name="vm-1",
+            snapshot_name="snap1",
+        ),
+        confirm_destructive=False,
+    )
+    assert client.calls[0][0] == "rbd_create"
+    assert client.calls[1][0] == "rbd_snapshot_create"
+    # snapshot create passes the image spec "rbd/vm-1" + snap name
+    assert client.calls[1][1] == ("rbd/vm-1", "snap1")
+
+
+async def test_unsupported_rgw_write_reported() -> None:
+    client = _FakeClient()
+    with pytest.raises(CephCapabilityUnsupported, match="rgw_bucket:delete"):
+        await execute_dashboard_operation(
+            client, _op("rgw_bucket", "delete", target_ref="backups"), confirm_destructive=True
+        )
+
+
+async def test_noop_is_passthrough() -> None:
+    client = _FakeClient()
+    res = await execute_dashboard_operation(
+        client, _op("pool", "noop", target_ref="rbd"), confirm_destructive=False
+    )
+    assert res["result"] == "noop"
+    assert client.calls == []

--- a/tests/ceph/test_external_provider.py
+++ b/tests/ceph/test_external_provider.py
@@ -1,0 +1,184 @@
+"""External (non-Proxmox) Ceph cluster provider adapter tests (#97)."""
+
+from __future__ import annotations
+
+import pytest
+
+from proxbox_api.ceph.dashboard_client import DashboardEndpointConfig
+from proxbox_api.ceph.prometheus import PrometheusSourceConfig
+from proxbox_api.ceph.rgw_client import RGWAdminConfig
+from proxbox_api.ceph.v2_providers import dashboard as dash_mod
+from proxbox_api.ceph.v2_providers import external as ext_mod
+from proxbox_api.ceph.v2_providers.base import CephCapabilityUnsupported
+from proxbox_api.ceph.v2_providers.external import ExternalCephProviderAdapter
+from proxbox_api.ceph.v2_schemas import ProviderOperation
+
+DASH = DashboardEndpointConfig(base_url="https://ceph:8443", username="a", password="b")
+PROM = PrometheusSourceConfig(url="http://prom:9090")
+RGW = RGWAdminConfig(base_url="http://rgw:8080", access_key="AK", secret_key="SK")
+
+
+class _FakeDashboard:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def pools(self):
+        return [{"pool_name": "rbd"}]
+
+    async def osds(self):
+        return []
+
+    async def hosts(self):
+        return []
+
+    async def filesystems(self):
+        return []
+
+    async def rbd_images(self):
+        return []
+
+    async def rgw_buckets(self):
+        return []
+
+    async def health(self):
+        return {"status": "HEALTH_OK"}
+
+    async def pool_create(self, payload):
+        self.calls.append("pool_create")
+        return {"name": "task"}
+
+    async def close(self):
+        pass
+
+
+class _FakeRGW:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple, dict]] = []
+
+    async def list_users(self):
+        return [{"user_id": "alice"}]
+
+    async def list_buckets(self):
+        return ["backups"]
+
+    async def create_user(self, uid, *, display_name):
+        self.calls.append(("create_user", (uid,), {"display_name": display_name}))
+        return {"user_id": uid}
+
+    async def remove_user(self, uid, *, confirm_destroy):
+        self.calls.append(("remove_user", (uid,), {"confirm_destroy": confirm_destroy}))
+        return {}
+
+    async def close(self):
+        pass
+
+
+def _enable_sdks(monkeypatch) -> None:
+    monkeypatch.setattr(ext_mod, "dashboard_sdk_importable", lambda: True)
+    monkeypatch.setattr(dash_mod, "dashboard_sdk_importable", lambda: True)
+
+
+async def test_capabilities_report_configured_providers(monkeypatch) -> None:
+    _enable_sdks(monkeypatch)
+    adapter = ExternalCephProviderAdapter(
+        dashboard=DASH,
+        prometheus=PROM,
+        rgw=RGW,
+        ceph_version="18.2.4",
+        dashboard_client_factory=lambda _c: _FakeDashboard(),
+        rgw_client_factory=lambda _c: _FakeRGW(),
+    )
+    caps = await adapter.capabilities()
+    assert caps.supported is True
+    assert caps.apply is True and caps.metrics is True
+    assert caps.operation_kinds.get("pool:create") is True
+    assert caps.operation_kinds.get("rgw_user:create") is True
+    assert "18.2.4" in caps.notes[0]
+
+
+async def test_capabilities_none_configured() -> None:
+    caps = await ExternalCephProviderAdapter().capabilities()
+    assert caps.supported is True
+    assert caps.apply is False and caps.read_state is False
+    assert "none" in caps.notes[0]
+
+
+async def test_read_state_merges_dashboard_and_rgw(monkeypatch) -> None:
+    _enable_sdks(monkeypatch)
+    adapter = ExternalCephProviderAdapter(
+        dashboard=DASH,
+        rgw=RGW,
+        dashboard_client_factory=lambda _c: _FakeDashboard(),
+        rgw_client_factory=lambda _c: _FakeRGW(),
+    )
+    state = await adapter.read_state({})
+    kinds = {r["kind"] for r in state["resources"]}
+    assert "pool" in kinds
+    assert "rgw_user" in kinds and "rgw_bucket" in kinds
+    assert state["summary"]["health"] == "HEALTH_OK"
+
+
+async def test_apply_routes_pool_to_dashboard(monkeypatch) -> None:
+    _enable_sdks(monkeypatch)
+    fake = _FakeDashboard()
+    adapter = ExternalCephProviderAdapter(dashboard=DASH, dashboard_client_factory=lambda _c: fake)
+    op = ProviderOperation(
+        kind="pool", target_ref="rbd", action="create", after_summary={"pool_name": "rbd"}
+    )
+    res = await adapter.apply(op, confirm_destructive=False)
+    assert res["result"] == "applied"
+    assert "pool_create" in fake.calls
+
+
+async def test_apply_routes_rgw_user_to_rgw(monkeypatch) -> None:
+    _enable_sdks(monkeypatch)
+    fake = _FakeRGW()
+    adapter = ExternalCephProviderAdapter(rgw=RGW, rgw_client_factory=lambda _c: fake)
+    op = ProviderOperation(
+        kind="rgw_user",
+        target_ref="alice",
+        action="create",
+        after_summary={"display_name": "Alice"},
+    )
+    res = await adapter.apply(op, confirm_destructive=False)
+    assert res["result"] == "applied"
+    assert fake.calls[0][0] == "create_user"
+
+
+async def test_apply_rgw_delete_requires_confirmation(monkeypatch) -> None:
+    _enable_sdks(monkeypatch)
+    adapter = ExternalCephProviderAdapter(rgw=RGW, rgw_client_factory=lambda _c: _FakeRGW())
+    op = ProviderOperation(kind="rgw_user", target_ref="alice", action="delete")
+    with pytest.raises(ValueError, match="destructive"):
+        await adapter.apply(op, confirm_destructive=False)
+
+
+async def test_apply_pool_without_dashboard_is_unsupported() -> None:
+    adapter = ExternalCephProviderAdapter(rgw=RGW, rgw_client_factory=lambda _c: _FakeRGW())
+    op = ProviderOperation(kind="pool", target_ref="rbd", action="create")
+    with pytest.raises(CephCapabilityUnsupported, match="Dashboard"):
+        await adapter.apply(op, confirm_destructive=False)
+
+
+async def test_apply_unknown_kind_unsupported(monkeypatch) -> None:
+    _enable_sdks(monkeypatch)
+    adapter = ExternalCephProviderAdapter(
+        dashboard=DASH, dashboard_client_factory=lambda _c: _FakeDashboard()
+    )
+    op = ProviderOperation(kind="crush_rule", target_ref="r1", action="create")
+    with pytest.raises(CephCapabilityUnsupported):
+        await adapter.apply(op, confirm_destructive=False)
+
+
+async def test_metrics_prefers_prometheus(monkeypatch) -> None:
+    snap_dict = {"cluster_health": "HEALTH_WARN", "captured_at": "2026-01-01T00:00:00Z"}
+
+    async def fake_fetch(_config):
+        from proxbox_api.ceph.v2_schemas import CephMetricSnapshot
+
+        return CephMetricSnapshot.model_validate(snap_dict)
+
+    monkeypatch.setattr("proxbox_api.ceph.v2_providers.prometheus.fetch_snapshot", fake_fetch)
+    adapter = ExternalCephProviderAdapter(prometheus=PROM)
+    metrics = await adapter.metrics({})
+    assert metrics["cluster_health"] == "HEALTH_WARN"

--- a/tests/ceph/test_external_routes.py
+++ b/tests/ceph/test_external_routes.py
@@ -1,0 +1,75 @@
+"""HTTP tests for the Ceph v2 external-cluster routes (#97)."""
+
+from __future__ import annotations
+
+import pytest
+
+from proxbox_api.main import app
+from proxbox_api.session.proxmox_providers import proxmox_sessions_dep
+
+
+@pytest.fixture
+def ext_client(auth_test_client):
+    app.dependency_overrides[proxmox_sessions_dep] = lambda: []
+    yield auth_test_client
+    app.dependency_overrides.pop(proxmox_sessions_dep, None)
+
+
+def test_external_provider_listed_in_capabilities(ext_client) -> None:
+    resp = ext_client.get("/ceph/v2/capabilities", params={"provider": "external"})
+    assert resp.status_code == 200
+    provider = resp.json()["providers"][0]
+    assert provider["provider"] == "external"
+    assert provider["supported"] is True
+
+
+def test_register_list_external_cluster_redacts_secrets(ext_client) -> None:
+    create = ext_client.post(
+        "/ceph/v2/external/clusters",
+        json={
+            "name": "lab-ceph",
+            "cluster_ref": "ext:1",
+            "ceph_version_hint": "18.2.4",
+            "rgw_admin_url": "http://rgw:8080",
+            "rgw_access_key": "AKIA",
+            "rgw_secret_key": "topsecret",
+        },
+    )
+    assert create.status_code == 201, create.text
+    out = create.json()
+    assert out["has_rgw_credentials"] is True
+    assert "rgw_secret_key" not in out and "topsecret" not in create.text
+    cluster_id = out["id"]
+
+    dup = ext_client.post("/ceph/v2/external/clusters", json={"name": "lab-ceph"})
+    assert dup.status_code == 409
+
+    listed = ext_client.get("/ceph/v2/external/clusters")
+    assert listed.status_code == 200
+    assert any(c["name"] == "lab-ceph" and c["has_rgw_credentials"] for c in listed.json())
+    assert cluster_id > 0
+
+
+def test_external_cluster_capability_detection(ext_client) -> None:
+    create = ext_client.post(
+        "/ceph/v2/external/clusters",
+        json={"name": "lab-2", "cluster_ref": "ext:2", "ceph_version_hint": "18.2.4"},
+    )
+    cluster_id = create.json()["id"]
+    caps = ext_client.post(f"/ceph/v2/external/clusters/{cluster_id}/capabilities")
+    assert caps.status_code == 200
+    provider = caps.json()["providers"][0]
+    assert provider["provider"] == "external"
+    # no sub-providers configured -> writes/reads off
+    assert provider["apply"] is False
+
+
+def test_capabilities_missing_cluster_404(ext_client) -> None:
+    resp = ext_client.post("/ceph/v2/external/clusters/9999/capabilities")
+    assert resp.status_code == 404
+
+
+def test_external_metrics_warns_without_provider(ext_client) -> None:
+    resp = ext_client.get("/ceph/v2/metrics", params={"provider": "external"})
+    assert resp.status_code == 200
+    assert any("external cluster" in w for w in resp.json()["warnings"])

--- a/tests/ceph/test_prometheus_client.py
+++ b/tests/ceph/test_prometheus_client.py
@@ -1,0 +1,150 @@
+"""Tests for the Prometheus client + snapshot normalization (Ceph v2 #94)."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from proxbox_api.ceph.prometheus import (
+    PrometheusClient,
+    PrometheusSourceConfig,
+    collect_snapshot,
+)
+
+
+def _vector(value: float) -> dict:
+    return {
+        "status": "success",
+        "data": {
+            "resultType": "vector",
+            "result": [{"metric": {}, "value": [1700000000, str(value)]}],
+        },
+    }
+
+
+def _empty() -> dict:
+    return {"status": "success", "data": {"resultType": "vector", "result": []}}
+
+
+# Canned values per PromQL query (keyed by a discriminating substring).
+_RESPONSES = {
+    "ceph_health_status": _vector(1),  # HEALTH_WARN
+    "ceph_osd_up": _vector(5),
+    "ceph_osd_in": _vector(5),
+    "ceph_osd_metadata": _vector(6),
+    "ceph_mon_quorum_status": _vector(3),
+    "ceph_mgr_status": _vector(1),
+    "ceph_cluster_total_bytes": _vector(1000),
+    "ceph_cluster_total_used_bytes": _vector(250),
+    "ceph_pg_total": _vector(128),
+    "ceph_pg_degraded": _vector(4),
+    "ceph_pg_misplaced": _empty(),
+    "ceph_pg_recovering": _vector(2),
+    "ceph_osd_op_r": _vector(10),
+    "ceph_osd_op_w": _vector(20),
+    "ceph_osd_op_r_out_bytes": _vector(1024),
+    "ceph_osd_op_w_in_bytes": _vector(2048),
+    "ceph_pool_metadata": _vector(3),
+}
+
+
+def _handler(request: httpx.Request) -> httpx.Response:
+    query = request.url.params.get("query", "")
+    # match the most specific key contained in the query
+    for key in sorted(_RESPONSES, key=len, reverse=True):
+        if key in query:
+            return httpx.Response(200, json=_RESPONSES[key])
+    return httpx.Response(200, json=_empty())
+
+
+def _client() -> PrometheusClient:
+    transport = httpx.MockTransport(_handler)
+    inner = httpx.AsyncClient(transport=transport)
+    return PrometheusClient(PrometheusSourceConfig(url="http://prom:9090"), client=inner)
+
+
+async def test_query_and_query_scalar() -> None:
+    client = _client()
+    assert await client.query_scalar("ceph_pg_total") == 128.0
+    assert await client.query_scalar("ceph_pg_misplaced") is None  # empty vector -> None
+    await client.aclose()
+
+
+async def test_collect_snapshot_normalizes_all_fields() -> None:
+    client = _client()
+    snap = await collect_snapshot(client, source_url="http://prom:9090")
+    await client.aclose()
+    assert snap.cluster_health == "HEALTH_WARN"
+    assert snap.osd_up == 5 and snap.osd_in == 5 and snap.osd_total == 6
+    assert snap.bytes_total == 1000 and snap.bytes_used == 250
+    assert snap.bytes_avail == 750
+    assert snap.percent_used == 25.0
+    assert snap.pgs_total == 128
+    assert snap.degraded_pgs == 4 and snap.recovering_pgs == 2
+    assert snap.misplaced_pgs is None
+    assert snap.pg_states == {"degraded": 4, "recovering": 2}
+    assert snap.pools == 3
+    assert snap.source_url == "http://prom:9090"
+    assert snap.is_degraded is True  # WARN + recovery in flight
+
+
+async def test_collect_snapshot_handles_no_data() -> None:
+    def empty_handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_empty())
+
+    inner = httpx.AsyncClient(transport=httpx.MockTransport(empty_handler))
+    client = PrometheusClient(PrometheusSourceConfig(url="http://prom:9090"), client=inner)
+    snap = await collect_snapshot(client)
+    await client.aclose()
+    assert snap.cluster_health == "unknown"
+    assert snap.osd_up is None and snap.bytes_total is None
+    assert snap.pg_states == {}
+    assert snap.is_degraded is False
+
+
+async def test_collect_snapshot_records_query_errors_as_warnings() -> None:
+    def err_handler(request: httpx.Request) -> httpx.Response:
+        if "ceph_health_status" in request.url.params.get("query", ""):
+            return httpx.Response(500, text="boom")
+        return httpx.Response(200, json=_empty())
+
+    inner = httpx.AsyncClient(transport=httpx.MockTransport(err_handler))
+    client = PrometheusClient(PrometheusSourceConfig(url="http://prom:9090"), client=inner)
+    snap = await collect_snapshot(client)
+    await client.aclose()
+    assert snap.cluster_health == "unknown"
+    assert any("query failed" in w for w in snap.warnings)
+
+
+async def test_bearer_token_sent_as_authorization_header() -> None:
+    seen: dict[str, str] = {}
+
+    def auth_handler(request: httpx.Request) -> httpx.Response:
+        seen["auth"] = request.headers.get("authorization", "")
+        return httpx.Response(200, json=_empty())
+
+    inner = httpx.AsyncClient(transport=httpx.MockTransport(auth_handler))
+    config = PrometheusSourceConfig(url="http://prom:9090", bearer_token="s3cr3t")
+    # bearer header is applied via the owned client; here we pass our own client,
+    # so assert the config carries the token and the owned-client path builds it.
+    client = PrometheusClient(config)
+    assert client._client.headers.get("authorization") == "Bearer s3cr3t"
+    await client.aclose()
+    # the injected-client path doesn't re-inject; ensure no crash either way
+    client2 = PrometheusClient(config, client=inner)
+    await client2.query("ceph_health_status")
+    await client2.aclose()
+
+
+@pytest.mark.parametrize("code,expected", [(0, "HEALTH_OK"), (1, "HEALTH_WARN"), (2, "HEALTH_ERR")])
+async def test_health_code_mapping(code: int, expected: str) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "ceph_health_status" in request.url.params.get("query", ""):
+            return httpx.Response(200, json=_vector(code))
+        return httpx.Response(200, json=_empty())
+
+    inner = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    client = PrometheusClient(PrometheusSourceConfig(url="http://prom:9090"), client=inner)
+    snap = await collect_snapshot(client)
+    await client.aclose()
+    assert snap.cluster_health == expected

--- a/tests/ceph/test_prometheus_provider.py
+++ b/tests/ceph/test_prometheus_provider.py
@@ -1,0 +1,133 @@
+"""Prometheus provider adapter + plan-time metric safety gating (Ceph v2 #94)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from proxbox_api.ceph import v2_engine
+from proxbox_api.ceph.prometheus import PrometheusSourceConfig
+from proxbox_api.ceph.v2_engine import build_plan, metric_safety_validations
+from proxbox_api.ceph.v2_providers.base import CephCapabilityUnsupported
+from proxbox_api.ceph.v2_providers.prometheus import PrometheusCephProviderAdapter
+from proxbox_api.ceph.v2_schemas import (
+    CephMetricSnapshot,
+    PlanRequest,
+    ProviderCapabilities,
+    ProviderOperation,
+)
+
+
+def _snapshot(**kwargs: Any) -> CephMetricSnapshot:
+    base = {"cluster_health": "HEALTH_OK", "captured_at": datetime(2026, 1, 1, tzinfo=timezone.utc)}
+    base.update(kwargs)
+    return CephMetricSnapshot(**base)
+
+
+async def test_adapter_capabilities_are_read_metrics_only() -> None:
+    caps = await PrometheusCephProviderAdapter().capabilities()
+    assert caps.supported is True
+    assert caps.metrics is True and caps.read_state is True
+    assert caps.apply is False and caps.diff is False and caps.plan is False
+
+
+async def test_adapter_metrics_without_source_returns_empty() -> None:
+    adapter = PrometheusCephProviderAdapter()
+    assert await adapter.metrics({}) == {}
+
+
+async def test_adapter_metrics_with_source_returns_snapshot(monkeypatch) -> None:
+    snap = _snapshot(cluster_health="HEALTH_WARN", osd_up=5)
+
+    async def fake_fetch(config: PrometheusSourceConfig) -> CephMetricSnapshot:
+        assert config.url == "http://prom:9090"
+        return snap
+
+    monkeypatch.setattr("proxbox_api.ceph.v2_providers.prometheus.fetch_snapshot", fake_fetch)
+    adapter = PrometheusCephProviderAdapter(source=PrometheusSourceConfig(url="http://prom:9090"))
+    metrics = await adapter.metrics({})
+    assert metrics["cluster_health"] == "HEALTH_WARN"
+    assert metrics["osd_up"] == 5
+
+
+async def test_adapter_write_paths_raise_unsupported() -> None:
+    adapter = PrometheusCephProviderAdapter()
+    with pytest.raises(CephCapabilityUnsupported):
+        await adapter.apply(
+            ProviderOperation(kind="pool", target_ref="rbd"), confirm_destructive=True
+        )
+    with pytest.raises(CephCapabilityUnsupported):
+        await adapter.reconcile({})
+
+
+def test_metric_safety_validations_only_warns_when_degraded() -> None:
+    ops = [
+        ProviderOperation(kind="pool", target_ref="rbd", action="delete", is_destructive=True),
+        ProviderOperation(kind="pool", target_ref="rbd2", action="ensure"),
+    ]
+    # Healthy cluster -> no warnings.
+    assert metric_safety_validations(_snapshot(), ops) == []
+    # Degraded cluster -> one warning for the destructive op only.
+    degraded = _snapshot(cluster_health="HEALTH_WARN", recovering_pgs=3)
+    results = metric_safety_validations(degraded, ops)
+    assert len(results) == 1
+    assert results[0].severity == "warning"
+    assert results[0].code == "cluster_degraded"
+    assert results[0].target == "rbd"
+
+
+class _FakeAdapter:
+    async def capabilities(self) -> ProviderCapabilities:
+        return ProviderCapabilities(provider="proxmox", supported=True, plan=False, apply=True)
+
+    async def read_state(self, scope: dict[str, Any]) -> dict[str, Any]:  # noqa: ARG002
+        return {"summary": {}}
+
+    async def diff(self, desired: Any, live: Any) -> list[Any]:  # noqa: ARG002
+        return []
+
+    async def plan(self, operations: list[Any]) -> list[Any]:
+        return operations
+
+    async def apply(self, operation: Any, *, confirm_destructive: bool) -> dict[str, Any]:
+        return {}
+
+    async def reconcile(self, scope: dict[str, Any]) -> dict[str, Any]:  # noqa: ARG002
+        return {}
+
+    async def metrics(self, scope: dict[str, Any]) -> dict[str, Any]:  # noqa: ARG002
+        return {}
+
+
+async def test_build_plan_consumes_metric_snapshot_for_warnings(monkeypatch) -> None:
+    monkeypatch.setattr(v2_engine, "_PLAN_STORE", {})
+    monkeypatch.setattr(v2_engine, "_PLAN_STORE_ORDER", [])
+    request = PlanRequest.model_validate(
+        {
+            "provider": "proxmox",
+            "operations": [{"kind": "pool", "target_ref": "rbd", "action": "delete"}],
+        }
+    )
+    snapshot = _snapshot(cluster_health="HEALTH_ERR", degraded_pgs=10)
+    plan = await build_plan(request, _FakeAdapter(), metric_snapshot=snapshot)
+    warns = [v for v in plan.validations if v.code == "cluster_degraded"]
+    assert warns, "degraded snapshot must surface a safety warning"
+    # warnings (not errors) keep the plan valid
+    assert plan.valid is True
+
+
+async def test_build_plan_reads_snapshot_from_request_scope(monkeypatch) -> None:
+    monkeypatch.setattr(v2_engine, "_PLAN_STORE", {})
+    monkeypatch.setattr(v2_engine, "_PLAN_STORE_ORDER", [])
+    snapshot = _snapshot(cluster_health="HEALTH_WARN", misplaced_pgs=5)
+    request = PlanRequest.model_validate(
+        {
+            "provider": "proxmox",
+            "operations": [{"kind": "pool", "target_ref": "rbd", "action": "delete"}],
+            "scope": {"metric_snapshot": snapshot.model_dump(mode="json")},
+        }
+    )
+    plan = await build_plan(request, _FakeAdapter())
+    assert any(v.code == "cluster_degraded" for v in plan.validations)

--- a/tests/ceph/test_prometheus_routes.py
+++ b/tests/ceph/test_prometheus_routes.py
@@ -1,0 +1,102 @@
+"""HTTP tests for the Ceph v2 Prometheus metrics + source routes (#94)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from proxbox_api.ceph.v2_schemas import CephMetricSnapshot
+from proxbox_api.main import app
+from proxbox_api.session.proxmox_providers import proxmox_sessions_dep
+
+
+@pytest.fixture
+def prom_client(auth_test_client):
+    app.dependency_overrides[proxmox_sessions_dep] = lambda: []
+    yield auth_test_client
+    app.dependency_overrides.pop(proxmox_sessions_dep, None)
+
+
+def test_metrics_prometheus_without_source_warns(prom_client) -> None:
+    resp = prom_client.get("/ceph/v2/metrics", params={"provider": "prometheus"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["snapshot"] is None
+    assert any("no Prometheus source" in w for w in body["warnings"])
+
+
+def test_register_list_and_validate_source(prom_client, monkeypatch) -> None:
+    # Register a source; the bearer token must never be echoed back.
+    create = prom_client.post(
+        "/ceph/v2/metrics/sources",
+        json={
+            "name": "ceph-prod",
+            "url": "http://prom:9090",
+            "bearer_token": "super-secret",
+            "cluster_ref": "cluster:1",
+        },
+    )
+    assert create.status_code == 201, create.text
+    out = create.json()
+    assert out["has_token"] is True
+    assert "bearer_token" not in out and "super-secret" not in create.text
+    source_id = out["id"]
+
+    # Duplicate name -> 409.
+    dup = prom_client.post(
+        "/ceph/v2/metrics/sources", json={"name": "ceph-prod", "url": "http://x:9090"}
+    )
+    assert dup.status_code == 409
+
+    listed = prom_client.get("/ceph/v2/metrics/sources")
+    assert listed.status_code == 200
+    assert any(s["name"] == "ceph-prod" and s["has_token"] for s in listed.json())
+
+    # Validate probes the source; monkeypatch the network probe.
+    async def fake_validate(config: Any) -> tuple[bool, str | None]:
+        assert config.url == "http://prom:9090"
+        assert config.bearer_token == "super-secret"  # decrypted for the probe
+        return True, None
+
+    monkeypatch.setattr("proxbox_api.ceph.v2_routes.validate_source", fake_validate)
+    probe = prom_client.post(f"/ceph/v2/metrics/sources/{source_id}/validate")
+    assert probe.status_code == 200
+    assert probe.json() == {"id": source_id, "ok": True, "error": None}
+
+
+def test_metrics_returns_typed_snapshot_when_source_configured(prom_client, monkeypatch) -> None:
+    prom_client.post(
+        "/ceph/v2/metrics/sources",
+        json={"name": "ceph-1", "url": "http://prom:9090", "cluster_ref": "cluster:1"},
+    )
+    snap = CephMetricSnapshot(
+        cluster_health="HEALTH_WARN",
+        captured_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        osd_up=5,
+        recovering_pgs=2,
+    )
+
+    async def fake_fetch(config: Any) -> CephMetricSnapshot:
+        return snap
+
+    monkeypatch.setattr("proxbox_api.ceph.v2_providers.prometheus.fetch_snapshot", fake_fetch)
+    resp = prom_client.get(
+        "/ceph/v2/metrics", params={"provider": "prometheus", "object_ref": "cluster:1"}
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["snapshot"]["cluster_health"] == "HEALTH_WARN"
+    assert body["snapshot"]["osd_up"] == 5
+    # the source config must not leak into the echoed scope
+    assert "prometheus_source" not in body["scope"]
+
+
+def test_prometheus_listed_in_capabilities(prom_client) -> None:
+    resp = prom_client.get("/ceph/v2/capabilities", params={"provider": "prometheus"})
+    assert resp.status_code == 200
+    providers = resp.json()["providers"]
+    assert providers[0]["provider"] == "prometheus"
+    assert providers[0]["supported"] is True
+    assert providers[0]["metrics"] is True


### PR DESCRIPTION
## Summary

Implements **#97** — a provider-neutral external (non-Proxmox) Ceph cluster binding that composes the Dashboard, Prometheus, and RGW Admin Ops providers with **no Proxmox endpoint/node/storage/task semantics**.

- **`ExternalCephProviderAdapter`** (real, replaces the stub; also the unknown-provider fallback): capability detection derived from configured sub-providers (+ SDK availability) and the Ceph version hint. `read_state` merges Dashboard + RGW inventory; `apply` routes pool/RBD → Dashboard and `rgw_*` → RGW Admin Ops (destructive gated); `metrics` prefers Prometheus, falls back to Dashboard.
- **`rgw_client.py`**: defensive bridge to the proxmox-sdk RGW Admin Ops client.
- **`CephExternalCluster`** DB table (references a Dashboard endpoint + Prometheus source by id, inline encrypted RGW admin credentials, optional SSH metadata, `ceph_version_hint`) + additive migration. No Proxmox fields.
- `build_adapter()` resolves the external cluster + sub-provider configs at construction; external cluster register/list + capability-detection routes. RGW secret keys encrypted at rest, never echoed.

Unsupported operations (no active sub-provider / older SDK pin) are reported with an actionable reason, never faked.

Tests: 14 new (capability detection across provider combos, merged inventory, apply routing + destructive gating + unsupported kinds, metrics preference, HTTP cluster CRUD with secret redaction). Full ceph suite: 102 tests green.

> ⚠️ **Stacked on #98** (`98-ceph-dashboard`). Base will retarget once #98 merges.

Part of the Ceph v2 epic (emersonfelipesp/netbox-proxbox#431). Closes #97.