### PR TITLE
fix: stop VM interface IP sync from matching another server's address

### DIFF
--- a/proxbox_api/services/sync/CLAUDE.md
+++ b/proxbox_api/services/sync/CLAUDE.md
@@ -53,6 +53,15 @@ Synchronization services responsible for NetBox object creation from Proxmox dat
   `cluster/resources` VMID/type data before falling back to NetBox VM custom
   fields or `device.name`; this avoids disk sync calls against stale or FQDN
   NetBox node names.
+- **VM-interface IP ownership invariant.** IP sync must never reassign an
+  address that already belongs to a *different* object. `network.py`
+  (`_reconcile_interface_ip`) resolves ownership before writing: it reuses an
+  IP already on this interface, adopts an *unassigned* IP, or creates a new
+  record scoped to this interface — a foreign-owned address is left untouched.
+  `vm_network.py` (`ensure_ip_assigned_to_vm`) likewise only adopts unassigned
+  IPs onto a VM and returns `assigned_to_other_object` instead of stealing an
+  address owned elsewhere. This prevents the "VM interface wrongly matched to
+  another server's IP" defect; both paths stay idempotent across re-syncs.
 
 ## Extension Guidance
 

--- a/proxbox_api/services/sync/network.py
+++ b/proxbox_api/services/sync/network.py
@@ -696,6 +696,140 @@ async def cleanup_stale_ips_for_interface(
         return 0
 
 
+def _ip_address_current_normalizer(record: dict) -> dict:
+    """Shared normalizer for ip-address reconcile drift comparison."""
+    return {
+        "address": record.get("address"),
+        "assigned_object_type": record.get("assigned_object_type"),
+        "assigned_object_id": record.get("assigned_object_id"),
+        "status": record.get("status"),
+        "dns_name": record.get("dns_name"),
+        "tags": record.get("tags"),
+    }
+
+
+def _record_field(record: object, key: str, default: object = None) -> object:
+    """Read a field from a NetBox record that may be a dict or a RestRecord."""
+    if isinstance(record, dict):
+        return record.get(key, default)
+    serialize = getattr(record, "serialize", None)
+    if callable(serialize):
+        try:
+            return serialize().get(key, default)
+        except Exception:
+            pass
+    return getattr(record, key, default)
+
+
+async def _reconcile_interface_ip(
+    nb,
+    *,
+    ip_addr: str,
+    interface_id: int,
+    tag_refs: list[dict],
+    now: datetime,
+    dns_name: str | None,
+    interface_name: str,
+) -> int | None:
+    """Reconcile a single VM-interface IP without stealing another object's address.
+
+    NetBox allows the same address to exist on multiple objects. Looking an IP
+    up by address alone and PATCHing its assignment (the previous behavior)
+    reassigned -- i.e. *stole* -- an address that already belonged to a
+    different interface or device, which surfaced as a VM interface "wrongly
+    matched to another server's IP".
+
+    To prevent that, ownership is resolved before any write:
+
+    * reuse a record already assigned to *this* interface (idempotent update),
+    * adopt a record that is currently *unassigned*, or
+    * create a new record scoped to this interface.
+
+    A record assigned to a *different* object is never reused or reassigned. The
+    interface-scoped lookup on the create path also guarantees the reconcile can
+    never fall back to matching (and stealing) a foreign address.
+    """
+    payload = {
+        "address": ip_addr,
+        "assigned_object_type": "virtualization.vminterface",
+        "assigned_object_id": interface_id,
+        "status": "active",
+        "dns_name": dns_name or "",
+        "tags": tag_refs,
+        "custom_fields": {"proxmox_last_updated": now.isoformat()},
+    }
+
+    try:
+        existing = await rest_list_async(
+            nb,
+            "/api/ipam/ip-addresses/",
+            query={"address": ip_addr, "limit": 50},
+        )
+    except Exception as list_exc:
+        # If ownership cannot be resolved, fall back to the interface-scoped
+        # create path below (which still never matches a foreign address)
+        # rather than aborting the whole IP sync.
+        logger.debug(
+            "Ownership lookup for IP %s failed (%s); using interface-scoped create",
+            ip_addr,
+            list_exc,
+        )
+        existing = []
+
+    own_record: object | None = None
+    adoptable_record: object | None = None
+    for record in existing or []:
+        assigned_type = _record_field(record, "assigned_object_type")
+        assigned_id = _record_field(record, "assigned_object_id")
+        if isinstance(assigned_id, dict):
+            assigned_id = assigned_id.get("id")
+        if assigned_type == "virtualization.vminterface" and assigned_id == interface_id:
+            own_record = record
+            break
+        if adoptable_record is None and (assigned_id is None or assigned_type is None):
+            adoptable_record = record
+
+    target = own_record or adoptable_record
+    try:
+        if target is not None:
+            # Reconcile the specific record we own/adopt by id. For an owned
+            # record the assignment already matches; for an unassigned record
+            # the assignment fields are patched, adopting it onto this interface.
+            record_id = _record_field(target, "id")
+            reconciled = await rest_reconcile_async(
+                nb,
+                "/api/ipam/ip-addresses/",
+                lookup={"id": record_id},
+                payload=payload,
+                schema=NetBoxIpAddressSyncState,
+                current_normalizer=_ip_address_current_normalizer,
+                strict_lookup=True,
+            )
+        else:
+            # No reusable record exists. Create one scoped to this interface; the
+            # strict, interface-scoped lookup means the reconcile fallback can
+            # never match a foreign address and reassign it.
+            reconciled = await rest_reconcile_async(
+                nb,
+                "/api/ipam/ip-addresses/",
+                lookup={"address": ip_addr, "vminterface_id": interface_id},
+                payload=payload,
+                schema=NetBoxIpAddressSyncState,
+                current_normalizer=_ip_address_current_normalizer,
+                strict_lookup=True,
+            )
+    except Exception as ip_exc:
+        logger.warning(
+            "Failed to sync IP %s for VM interface %s: %s",
+            ip_addr,
+            interface_name,
+            ip_exc,
+        )
+        return None
+
+    return _record_field(reconciled, "id")
+
+
 async def _resolve_vm_interface_ips(  # noqa: C901
     nb,
     interface_config: dict,
@@ -779,43 +913,17 @@ async def _resolve_vm_interface_ips(  # noqa: C901
         if skip or cleaned_host is None:
             continue
         ip_addr = f"{cleaned_host}/{prefix_part}" if prefix_part else cleaned_host
-        try:
-            ip_record = await rest_reconcile_async(
-                nb,
-                "/api/ipam/ip-addresses/",
-                lookup={"address": ip_addr},
-                payload={
-                    "address": ip_addr,
-                    "assigned_object_type": "virtualization.vminterface",
-                    "assigned_object_id": interface_id,
-                    "status": "active",
-                    "dns_name": dns_name or "",
-                    "tags": tag_refs,
-                    "custom_fields": {"proxmox_last_updated": now.isoformat()},
-                },
-                schema=NetBoxIpAddressSyncState,
-                current_normalizer=lambda record: {
-                    "address": record.get("address"),
-                    "assigned_object_type": record.get("assigned_object_type"),
-                    "assigned_object_id": record.get("assigned_object_id"),
-                    "status": record.get("status"),
-                    "dns_name": record.get("dns_name"),
-                    "tags": record.get("tags"),
-                },
-            )
-            ip_id = (
-                ip_record.get("id")
-                if isinstance(ip_record, dict)
-                else getattr(ip_record, "id", None)
-            )
+        ip_id = await _reconcile_interface_ip(
+            nb,
+            ip_addr=ip_addr,
+            interface_id=interface_id,
+            tag_refs=tag_refs,
+            now=now,
+            dns_name=dns_name,
+            interface_name=interface_name,
+        )
+        if ip_id is not None:
             results.append((ip_id, ip_addr))
-        except Exception as ip_exc:
-            logger.warning(
-                "Failed to create IP %s for VM interface %s: %s",
-                ip_addr,
-                interface_name,
-                ip_exc,
-            )
 
     if results:
         current_ip_set = {ip_addr for _, ip_addr in results}

--- a/proxbox_api/services/sync/vm_network.py
+++ b/proxbox_api/services/sync/vm_network.py
@@ -28,10 +28,6 @@ from proxbox_api.services.sync.vm_helpers import (
     normalized_mac,
 )
 
-_PRIMARY_IP_REASSIGN_ERROR = (
-    "Cannot reassign IP address while it is designated as the primary IP for the parent object"
-)
-
 
 def _primary_field_from_ip_address(address: object) -> str | None:
     """Map an IP address value to the appropriate NetBox VM primary field."""
@@ -332,49 +328,6 @@ async def sync_vm_disks(
     return disk_count
 
 
-async def _clear_primary_ip_on_parent(nb: object, ip_id: int) -> bool:
-    """Remove the primary IP designation from any VM that claims ip_id as its primary.
-
-    NetBox rejects reassigning an IP while it is set as the primary IP of its parent object.
-    This helper finds the owning VM and clears the ``primary_ip4`` or ``primary_ip6`` field
-    so the IP can subsequently be reassigned.
-
-    Returns True if a parent was found and successfully patched, False otherwise.
-    """
-    for field in ("primary_ip4", "primary_ip6"):
-        vms = await rest_list_async(
-            nb,
-            "/api/virtualization/virtual-machines/",
-            query={f"{field}_id": ip_id, "limit": 5},
-        )
-        for vm in vms:
-            parent_vm_id = vm.get("id") if isinstance(vm, dict) else getattr(vm, "id", None)
-            if not parent_vm_id:
-                continue
-            try:
-                await rest_patch_async(
-                    nb,
-                    "/api/virtualization/virtual-machines/",
-                    parent_vm_id,
-                    {field: None},
-                )
-                logger.info(
-                    "_clear_primary_ip_on_parent: cleared %s (IP id=%s) from VM id=%s",
-                    field,
-                    ip_id,
-                    parent_vm_id,
-                )
-                return True
-            except Exception as clear_exc:
-                logger.warning(
-                    "_clear_primary_ip_on_parent: failed to clear %s from VM id=%s: %s",
-                    field,
-                    parent_vm_id,
-                    clear_exc,
-                )
-    return False
-
-
 async def ensure_ip_assigned_to_vm(
     nb: object,
     ip_id: int,
@@ -382,12 +335,17 @@ async def ensure_ip_assigned_to_vm(
 ) -> tuple[bool, str]:
     """Verify the IP address is assigned to an interface on the given VM.
 
-    If the IP exists but is assigned to the wrong object (or unassigned), this
-    function PATCHes the IP to assign it to the VM's first interface so that
-    NetBox will accept it as the VM's primary IP.
+    If the IP is currently *unassigned*, it is adopted onto the VM's first
+    interface so NetBox will accept it as the VM's primary IP. An IP already
+    assigned to a *different* object (another VM/device interface) is **never**
+    reassigned -- stealing the address that way is exactly what surfaced as a VM
+    interface "wrongly matched to another server's IP". In that case the
+    function returns ``(False, "assigned_to_other_object")`` and the caller
+    skips primary assignment.
 
-    Returns (True, reason) if the IP is (or was fixed to be) assigned to the VM,
-    (False, reason) otherwise. The reason string describes the outcome for diagnostics.
+    Returns (True, reason) if the IP is (or was adopted to be) assigned to the
+    VM, (False, reason) otherwise. The reason string describes the outcome for
+    diagnostics.
     """
     try:
         ip_record = await rest_first_async(nb, "/api/ipam/ip-addresses/", query={"id": ip_id})
@@ -425,7 +383,22 @@ async def ensure_ip_assigned_to_vm(
         ):
             return True, "already_assigned"
 
-        # IP is not assigned to this VM — reassign to the first available interface
+        # The IP already belongs to a different object. Never reassign it onto
+        # this VM -- doing so would steal another server's address and is the
+        # root cause of the "interface wrongly matched to another server's IP"
+        # defect. Skip primary assignment instead.
+        if assigned_object_id is not None and assigned_object_type is not None:
+            logger.info(
+                "ensure_ip_assigned_to_vm: IP id=%s already assigned to %s id=%s; "
+                "refusing to reassign to VM id=%s",
+                ip_id,
+                assigned_object_type,
+                assigned_object_id,
+                vm_id,
+            )
+            return False, "assigned_to_other_object"
+
+        # IP is unassigned -- safe to adopt it onto the VM's first interface.
         first_iface = ifaces[0]
         first_iface_id = (
             first_iface.get("id")
@@ -436,34 +409,12 @@ async def ensure_ip_assigned_to_vm(
             "assigned_object_type": "virtualization.vminterface",
             "assigned_object_id": first_iface_id,
         }
-        try:
-            patched = await rest_patch_async(
-                nb,
-                "/api/ipam/ip-addresses/",
-                ip_id,
-                assign_payload,
-            )
-        except Exception as patch_exc:
-            if _PRIMARY_IP_REASSIGN_ERROR not in str(patch_exc):
-                raise
-            logger.info(
-                "ensure_ip_assigned_to_vm: IP id=%s is designated as primary on its parent; "
-                "clearing primary designation and retrying",
-                ip_id,
-            )
-            cleared = await _clear_primary_ip_on_parent(nb, ip_id)
-            if not cleared:
-                logger.warning(
-                    "ensure_ip_assigned_to_vm: could not clear primary IP for id=%s; giving up",
-                    ip_id,
-                )
-                return False, "primary_ip_clear_failed"
-            patched = await rest_patch_async(
-                nb,
-                "/api/ipam/ip-addresses/",
-                ip_id,
-                assign_payload,
-            )
+        patched = await rest_patch_async(
+            nb,
+            "/api/ipam/ip-addresses/",
+            ip_id,
+            assign_payload,
+        )
         # Verify the PATCH took effect by inspecting the returned record
         patched_obj_id = patched.get("assigned_object_id") if isinstance(patched, dict) else None
         if isinstance(patched_obj_id, dict):
@@ -473,12 +424,13 @@ async def ensure_ip_assigned_to_vm(
         )
         if patched_obj_type == "virtualization.vminterface" and patched_obj_id == first_iface_id:
             logger.info(
-                "ensure_ip_assigned_to_vm: reassigned IP id=%s to interface id=%s on VM id=%s",
+                "ensure_ip_assigned_to_vm: adopted unassigned IP id=%s onto interface id=%s "
+                "on VM id=%s",
                 ip_id,
                 first_iface_id,
                 vm_id,
             )
-            return True, "reassigned"
+            return True, "assigned"
         logger.warning(
             "ensure_ip_assigned_to_vm: PATCH did not take effect for IP id=%s "
             "(got type=%s obj_id=%s, expected type=virtualization.vminterface obj_id=%s)",
@@ -487,7 +439,7 @@ async def ensure_ip_assigned_to_vm(
             patched_obj_id,
             first_iface_id,
         )
-        return False, f"reassign_failed(type={patched_obj_type},obj_id={patched_obj_id})"
+        return False, f"assign_failed(type={patched_obj_type},obj_id={patched_obj_id})"
     except Exception as exc:
         logger.warning(
             "ensure_ip_assigned_to_vm: failed for IP id=%s VM id=%s: %s",

--- a/tests/test_dns_name_propagation.py
+++ b/tests/test_dns_name_propagation.py
@@ -99,6 +99,10 @@ def test_resolve_vm_interface_ips_emits_phase_summary_for_skipped_ips():
 
         with (
             patch(
+                "proxbox_api.services.sync.network.rest_list_async",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch(
                 "proxbox_api.services.sync.network.rest_reconcile_async",
                 new=AsyncMock(side_effect=_fake_reconcile),
             ),
@@ -176,6 +180,10 @@ def test_resolve_vm_interface_ips_no_summary_when_nothing_skipped():
             return {"id": 1}
 
         with (
+            patch(
+                "proxbox_api.services.sync.network.rest_list_async",
+                new=AsyncMock(return_value=[]),
+            ),
             patch(
                 "proxbox_api.services.sync.network.rest_reconcile_async",
                 new=AsyncMock(side_effect=_fake_reconcile),
@@ -274,6 +282,10 @@ def test_resolve_vm_interface_ips_forwards_dns_name_to_payload():
 
         with (
             patch(
+                "proxbox_api.services.sync.network.rest_list_async",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch(
                 "proxbox_api.services.sync.network.rest_reconcile_async",
                 new=AsyncMock(side_effect=_fake_reconcile),
             ),
@@ -308,6 +320,10 @@ def test_resolve_vm_interface_ips_passes_empty_dns_name_when_unset():
             return {"id": 99}
 
         with (
+            patch(
+                "proxbox_api.services.sync.network.rest_list_async",
+                new=AsyncMock(return_value=[]),
+            ),
             patch(
                 "proxbox_api.services.sync.network.rest_reconcile_async",
                 new=AsyncMock(side_effect=_fake_reconcile),

--- a/tests/test_ip_no_cross_object_match.py
+++ b/tests/test_ip_no_cross_object_match.py
@@ -1,0 +1,127 @@
+"""Regression tests: VM interface IP sync must not match another server's IP.
+
+These cover the defect where a VM interface was "wrongly matched to another
+server's IP". The per-interface IP reconcile previously looked an address up
+globally and PATCHed its assignment, stealing an address that belonged to a
+different object. The fixed behavior resolves ownership first: reuse an IP
+already on this interface, adopt an unassigned IP, or create a new one scoped
+to this interface -- but never reassign a foreign-owned address.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+from proxbox_api.services.sync.network import _resolve_vm_interface_ips
+
+_NOW = datetime(2026, 6, 5, tzinfo=timezone.utc)
+_ADDR = "10.0.0.50/24"
+
+
+def _run_resolve(monkeypatch, existing_for_address):
+    """Drive _resolve_vm_interface_ips with a fake NetBox and capture reconcile calls."""
+    reconcile_calls: list[dict] = []
+
+    async def _fake_rest_list(nb, path, query=None):
+        query = query or {}
+        # Address ownership lookup performed by _reconcile_interface_ip.
+        if query.get("address") == _ADDR and "vminterface_id" not in query and "tag" not in query:
+            return list(existing_for_address)
+        # cleanup_stale_ips_for_interface (vminterface_id + tag) -> nothing stale.
+        return []
+
+    async def _fake_rest_reconcile(nb, path, *, lookup, payload, **kwargs):
+        reconcile_calls.append({"lookup": lookup, "payload": payload, "kwargs": kwargs})
+        # Echo a record id: reuse the looked-up id when present, else a new one.
+        rec_id = lookup.get("id", 123)
+        return {"id": rec_id, **payload}
+
+    monkeypatch.setattr("proxbox_api.services.sync.network.rest_list_async", _fake_rest_list)
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.network.rest_reconcile_async", _fake_rest_reconcile
+    )
+
+    results = asyncio.run(
+        _resolve_vm_interface_ips(
+            nb=object(),
+            interface_config={"ip": _ADDR},
+            guest_iface=None,
+            tag_refs=[],
+            interface_id=111,
+            interface_name="eth0",
+            now=_NOW,
+            create_ip=True,
+        )
+    )
+    return results, reconcile_calls
+
+
+def test_resolve_does_not_reassign_foreign_ip(monkeypatch):
+    """An address owned by another interface (id=888) must not be reassigned."""
+    foreign = {
+        "id": 999,
+        "address": _ADDR,
+        "assigned_object_type": "virtualization.vminterface",
+        "assigned_object_id": 888,
+    }
+    results, reconcile_calls = _run_resolve(monkeypatch, [foreign])
+
+    # The foreign record must never be the reconcile target.
+    assert all(call["lookup"].get("id") != 999 for call in reconcile_calls)
+    # The old global address-only reconcile (the steal pattern) must not be used.
+    assert {"address": _ADDR} not in [call["lookup"] for call in reconcile_calls]
+    # Exactly one reconcile: an interface-scoped create for this interface.
+    assert len(reconcile_calls) == 1
+    create_call = reconcile_calls[0]
+    assert create_call["lookup"] == {"address": _ADDR, "vminterface_id": 111}
+    assert create_call["kwargs"].get("strict_lookup") is True
+    assert create_call["payload"]["assigned_object_id"] == 111
+    # The interface still gets an IP id back (its own record, id=123).
+    assert results == [(123, _ADDR)]
+
+
+def test_resolve_adopts_unassigned_ip(monkeypatch):
+    """An unassigned address (e.g. pre-created in a prefix) is adopted by id."""
+    unassigned = {
+        "id": 500,
+        "address": _ADDR,
+        "assigned_object_type": None,
+        "assigned_object_id": None,
+    }
+    results, reconcile_calls = _run_resolve(monkeypatch, [unassigned])
+
+    assert len(reconcile_calls) == 1
+    call = reconcile_calls[0]
+    assert call["lookup"] == {"id": 500}
+    assert call["kwargs"].get("strict_lookup") is True
+    assert call["payload"]["assigned_object_id"] == 111
+    assert results == [(500, _ADDR)]
+
+
+def test_resolve_reuses_own_ip(monkeypatch):
+    """An address already on this interface is reconciled in place (idempotent)."""
+    own = {
+        "id": 600,
+        "address": _ADDR,
+        "assigned_object_type": "virtualization.vminterface",
+        "assigned_object_id": 111,
+    }
+    results, reconcile_calls = _run_resolve(monkeypatch, [own])
+
+    assert len(reconcile_calls) == 1
+    call = reconcile_calls[0]
+    assert call["lookup"] == {"id": 600}
+    assert call["payload"]["assigned_object_id"] == 111
+    assert results == [(600, _ADDR)]
+
+
+def test_resolve_creates_when_no_existing_record(monkeypatch):
+    """No existing address -> create a new record scoped to this interface."""
+    results, reconcile_calls = _run_resolve(monkeypatch, [])
+
+    assert len(reconcile_calls) == 1
+    call = reconcile_calls[0]
+    assert call["lookup"] == {"address": _ADDR, "vminterface_id": 111}
+    assert call["kwargs"].get("strict_lookup") is True
+    assert results == [(123, _ADDR)]

--- a/tests/test_qemu_guest_agent_sync.py
+++ b/tests/test_qemu_guest_agent_sync.py
@@ -164,6 +164,10 @@ def _install_common_sync_patches(  # noqa: C901
         "proxbox_api.services.sync.network.rest_first_async",
         _fake_rest_first,
     )
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.network.rest_list_async",
+        _fake_rest_list,
+    )
 
 
 def test_vm_sync_fetches_tag_color_map_once_per_cluster_under_concurrency(monkeypatch):

--- a/tests/test_vm_network.py
+++ b/tests/test_vm_network.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 
 from proxbox_api.exception import ProxboxException
-from proxbox_api.services.sync.vm_network import set_primary_ip
+from proxbox_api.services.sync.vm_network import ensure_ip_assigned_to_vm, set_primary_ip
 
 
 def test_set_primary_ip_retries_with_disk_aggregate_on_validation_error(monkeypatch):
@@ -193,3 +193,123 @@ def test_set_primary_ip_skips_ipv6_when_already_set(monkeypatch):
 
     assert updated is False
     assert patch_payloads == []
+
+
+def test_ensure_ip_assigned_does_not_steal_foreign_ip(monkeypatch):
+    """An IP already assigned to another object must never be reassigned.
+
+    Regression for "Virtual Server interface wrongly matched to another
+    server's IP": the IP belongs to interface id=888 (a different server) and
+    must be left untouched, returning a refusal reason instead of stealing it.
+    """
+    patch_calls: list[tuple] = []
+
+    async def _fake_rest_first(nb, path, query=None):
+        if path == "/api/ipam/ip-addresses/":
+            return {
+                "id": 77,
+                "address": "10.0.0.50/24",
+                "assigned_object_type": "virtualization.vminterface",
+                "assigned_object_id": 888,  # belongs to another server's interface
+            }
+        return None
+
+    async def _fake_rest_list(nb, path, query=None):
+        if path == "/api/virtualization/interfaces/":
+            return [{"id": 111}]  # this VM's interface
+        return []
+
+    async def _fake_rest_patch(nb, path, record_id, payload):  # pragma: no cover
+        patch_calls.append((path, record_id, payload))
+        return {}
+
+    monkeypatch.setattr("proxbox_api.services.sync.vm_network.rest_first_async", _fake_rest_first)
+    monkeypatch.setattr("proxbox_api.services.sync.vm_network.rest_list_async", _fake_rest_list)
+    monkeypatch.setattr("proxbox_api.services.sync.vm_network.rest_patch_async", _fake_rest_patch)
+
+    assigned, reason = asyncio.run(ensure_ip_assigned_to_vm(nb=object(), ip_id=77, vm_id=55))
+
+    assert assigned is False
+    assert reason == "assigned_to_other_object"
+    assert patch_calls == []  # the foreign IP was never reassigned
+
+
+def test_ensure_ip_assigned_adopts_unassigned_ip(monkeypatch):
+    """An unassigned IP is safely adopted onto the VM's first interface."""
+    patch_calls: list[tuple] = []
+
+    async def _fake_rest_first(nb, path, query=None):
+        if path == "/api/ipam/ip-addresses/":
+            return {
+                "id": 77,
+                "address": "10.0.0.50/24",
+                "assigned_object_type": None,
+                "assigned_object_id": None,
+            }
+        return None
+
+    async def _fake_rest_list(nb, path, query=None):
+        if path == "/api/virtualization/interfaces/":
+            return [{"id": 111}]
+        return []
+
+    async def _fake_rest_patch(nb, path, record_id, payload):
+        patch_calls.append((path, record_id, payload))
+        return {
+            "id": record_id,
+            "assigned_object_type": "virtualization.vminterface",
+            "assigned_object_id": 111,
+        }
+
+    monkeypatch.setattr("proxbox_api.services.sync.vm_network.rest_first_async", _fake_rest_first)
+    monkeypatch.setattr("proxbox_api.services.sync.vm_network.rest_list_async", _fake_rest_list)
+    monkeypatch.setattr("proxbox_api.services.sync.vm_network.rest_patch_async", _fake_rest_patch)
+
+    assigned, reason = asyncio.run(ensure_ip_assigned_to_vm(nb=object(), ip_id=77, vm_id=55))
+
+    assert assigned is True
+    assert reason == "assigned"
+    assert patch_calls == [
+        (
+            "/api/ipam/ip-addresses/",
+            77,
+            {
+                "assigned_object_type": "virtualization.vminterface",
+                "assigned_object_id": 111,
+            },
+        )
+    ]
+
+
+def test_ensure_ip_assigned_already_on_this_vm(monkeypatch):
+    """An IP already assigned to this VM's interface is left unchanged."""
+    patch_calls: list[tuple] = []
+
+    async def _fake_rest_first(nb, path, query=None):
+        if path == "/api/ipam/ip-addresses/":
+            return {
+                "id": 77,
+                "address": "10.0.0.50/24",
+                "assigned_object_type": "virtualization.vminterface",
+                "assigned_object_id": 111,
+            }
+        return None
+
+    async def _fake_rest_list(nb, path, query=None):
+        if path == "/api/virtualization/interfaces/":
+            return [{"id": 111}]
+        return []
+
+    async def _fake_rest_patch(nb, path, record_id, payload):  # pragma: no cover
+        patch_calls.append((path, record_id, payload))
+        return {}
+
+    monkeypatch.setattr("proxbox_api.services.sync.vm_network.rest_first_async", _fake_rest_first)
+    monkeypatch.setattr("proxbox_api.services.sync.vm_network.rest_list_async", _fake_rest_list)
+    monkeypatch.setattr("proxbox_api.services.sync.vm_network.rest_patch_async", _fake_rest_patch)
+
+    assigned, reason = asyncio.run(ensure_ip_assigned_to_vm(nb=object(), ip_id=77, vm_id=55))
+
+    assert assigned is True
+    assert reason == "already_assigned"
+    assert patch_calls == []


### PR DESCRIPTION
## Summary

Fixes the defect reported in **emersonfelipesp/netbox-proxbox#566** ("Virtual Server interfaces is wrong matched"): a virtual machine's interface in NetBox could be shown with **another server's IP address**.

## Root cause

VM interface IP synchronization reconciled each address with a **global, address-only lookup** and then PATCHed all differing fields — including the assignment fields. NetBox permits the same address to exist on multiple objects, so when an address already existed assigned to a *different* interface/device, the sync **reassigned (stole)** it onto the VM currently syncing. Two paths did this:

- `proxbox_api/services/sync/network.py::_resolve_vm_interface_ips` — reconciled `lookup={"address": ip}` with no `patchable_fields`/`strict_lookup`, so assignment was PATCHed.
- `proxbox_api/services/sync/vm_network.py::ensure_ip_assigned_to_vm` (the primary-IP step used by full sync) — explicitly reassigned an IP "not assigned to this VM" to the VM's first interface.

The bulk path already documented the correct invariant (*"Never patch assignment fields on existing IPs"*); these two paths did not follow it.

## Fix

IP synchronization is now **ownership-aware** and never reassigns a foreign-owned address:

- `_reconcile_interface_ip` (new helper) resolves ownership before any write — it **reuses** an IP already on this interface, **adopts** an *unassigned* IP, or **creates** a new record scoped to the interface. An address owned by a different object is left untouched. The create path uses a strict, interface-scoped lookup so the reconcile fallback can never match a foreign address. A transient ownership-lookup failure falls back to an interface-scoped create instead of aborting the sync.
- `ensure_ip_assigned_to_vm` now only **adopts unassigned** IPs onto a VM and returns `assigned_to_other_object` for an address owned elsewhere (no steal). The now-unnecessary primary-IP-reassign retry helper was removed.

Both paths remain idempotent across re-syncs.

## Tests

- New `tests/test_ip_no_cross_object_match.py`: foreign-IP refusal, unassigned-IP adoption, own-IP reuse, fresh create.
- New cases in `tests/test_vm_network.py` for `ensure_ip_assigned_to_vm`: refuses foreign IP, adopts unassigned, leaves already-assigned untouched.
- Updated existing IP-path tests for the new ownership lookup.

## Verification

- `uv run ruff check .` — clean on changed files.
- `uv run --extra test pytest tests/test_vm_network.py tests/test_ip_no_cross_object_match.py tests/test_dns_name_propagation.py tests/test_qemu_guest_agent_sync.py` — 38 passed.
- `uv run --extra test pytest tests/ --ignore=tests/e2e` — full unit suite green (exit 0).

## Lifecycle evidence (NPR 7150.2D Ch.4)

- **Requirements:** a VM interface IP must never be reassigned from another object; unassigned IPs may be adopted; behavior stays idempotent. Traced to the regression tests above.
- **Architecture/Design:** change is confined to the sync IP-write seam (`services/sync/network.py`, `services/sync/vm_network.py`); no schema, route, or contract changes; no NetBox-version floor change.
- **Testing/Coverage:** added regression tests fail on pre-fix behavior; full unit suite green.
- **Docs:** `proxbox_api/services/sync/CLAUDE.md` updated with the IP-ownership invariant.
