### PR TITLE
feat(cloud): bake verbatim cloud-init user_data_yaml into templates via cicustom

### DIFF
--- a/proxbox_api/routes/cloud/pipeline_scripts.py
+++ b/proxbox_api/routes/cloud/pipeline_scripts.py
@@ -264,9 +264,32 @@ def _source_tree_script(
     return "\n".join(commands) + "\n", commands
 
 
-def build_pipeline_response(
+def _custom_userdata_entry(
     request: CloudImageTemplateBuildRequest,
-) -> CloudImageTemplateBuildResponse:
+) -> CloudImageVersionEntry:
+    """Build a synthetic catalog entry for a verbatim ``user_data_yaml`` build.
+
+    Used when the caller supplies cloud-init user-data directly (for example a
+    netbox-packer ``cloud_config`` installer config) instead of selecting a
+    Proxmox product from the catalog. The entry only needs enough fields for the
+    release-image/source-tree script builders and the snippet label.
+    """
+    provider = request.provider or CloudImageBuildProvider.release_image
+    return CloudImageVersionEntry(
+        version=request.product_version or "custom",
+        label=request.name,
+        product_type=request.product_type,
+        default_provider=provider,
+        supported_providers=[provider],
+        os_family="linux",
+        image_url=request.image_url,
+    )
+
+
+def _catalog_pipeline_inputs(
+    request: CloudImageTemplateBuildRequest,
+) -> tuple[CloudImageVersionEntry, CloudImageBuildProvider, str | None, str | None]:
+    """Resolve (entry, provider, user_data, first_boot_script) from the product catalog."""
     try:
         entry = find_product_version(request.product_type, request.product_version)
     except KeyError as exc:
@@ -276,11 +299,13 @@ def build_pipeline_response(
     if provider not in entry.supported_providers:
         raise HTTPException(
             status_code=422,
-            detail=f"{provider.value} is not supported for {entry.product_type.value} {entry.version}.",
+            detail=(
+                f"{provider.value} is not supported for {entry.product_type.value} {entry.version}."
+            ),
         )
 
-    user_data = None
-    first_boot_script = None
+    user_data: str | None = None
+    first_boot_script: str | None = None
     if entry.product_type.value == "firecracker":
         from proxbox_api.routes.cloud.cloud_init_templates import generate_firecracker_userdata
 
@@ -292,6 +317,26 @@ def build_pipeline_response(
         user_data = generate_cloud_init_userdata(entry, request)
     else:
         first_boot_script = generate_appliance_first_boot_script(entry, request)
+    return entry, provider, user_data, first_boot_script
+
+
+def _resolve_pipeline_inputs(
+    request: CloudImageTemplateBuildRequest,
+) -> tuple[CloudImageVersionEntry, CloudImageBuildProvider, str | None, str | None]:
+    """Pick the build inputs from either a verbatim user_data_yaml or the catalog."""
+    if request.user_data_yaml is not None:
+        # Verbatim cloud-init user-data path: skip the product catalog entirely and
+        # bake the supplied #cloud-config as the cicustom user snippet over SSH.
+        entry = _custom_userdata_entry(request)
+        provider = request.provider or CloudImageBuildProvider.release_image
+        return entry, provider, request.user_data_yaml, None
+    return _catalog_pipeline_inputs(request)
+
+
+def build_pipeline_response(
+    request: CloudImageTemplateBuildRequest,
+) -> CloudImageTemplateBuildResponse:
+    entry, provider, user_data, first_boot_script = _resolve_pipeline_inputs(request)
 
     image_url = request.image_url or entry.image_url
     if provider == CloudImageBuildProvider.SOURCE_TREE:

--- a/proxbox_api/routes/cloud/template_images.py
+++ b/proxbox_api/routes/cloud/template_images.py
@@ -116,6 +116,7 @@ async def build_cloud_image_template(
     if (
         req.execute is not None
         or req.provider is not None
+        or req.user_data_yaml is not None
         or req.product_type in {ProxmoxProductType.pfsense, ProxmoxProductType.opnsense}
     ):
         return build_pipeline_response(req)

--- a/proxbox_api/schemas/cloud_provision.py
+++ b/proxbox_api/schemas/cloud_provision.py
@@ -171,6 +171,16 @@ class CloudImageTemplateBuildRequest(BaseModel):
     cpu: str | None = Field("host")
     verify_image_certificates: bool = True
     description: str | None = Field(None, max_length=8192)
+    user_data_yaml: str | None = Field(
+        None,
+        max_length=65536,
+        description=(
+            "Verbatim cloud-init #cloud-config user-data to bake into the template via a "
+            "Proxmox cicustom snippet. When set, the build runs through the SSH pipeline "
+            "(which can write snippets) instead of the catalog/product flow, so the cloud-config "
+            "actually executes on first boot of cloned VMs."
+        ),
+    )
     product_type: ProxmoxProductType = ProxmoxProductType.pve
     product_version: str | None = Field(
         None, description="Proxmox product version; None = latest in catalog"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ proxbox_api = ["static/*", "static/**/*", "generated/**/*.json", "generated/**/*
 
 [project]
 name = "proxbox_api"
-version = "0.0.17.post2"
+version = "0.0.18"
 description = "Proxbox API service made using FastAPI"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_cloud_image_pipeline.py
+++ b/tests/test_cloud_image_pipeline.py
@@ -84,6 +84,36 @@ def test_opnsense_source_tree_pipeline_uses_catalog_source_path():
     assert "make dvd" in response.build_script
 
 
+def test_user_data_yaml_bakes_cicustom_snippet_without_catalog_product():
+    """A verbatim user_data_yaml build skips the catalog and writes a cicustom user snippet."""
+    custom = "#cloud-config\nruncmd:\n  - echo zabbix-bootstrap\n"
+    response = build_pipeline_response(
+        CloudImageTemplateBuildRequest(
+            name="zabbix-7.4-ubuntu-2604",
+            vmid=9010,
+            image_url=(
+                "https://cloud-images.ubuntu.com/releases/24.04/release/"
+                "ubuntu-24.04-server-cloudimg-amd64.img"
+            ),
+            image_storage="local",
+            vm_storage="local",
+            storage="local",
+            snippets_storage="local",
+            user_data_yaml=custom,
+        )
+    )
+
+    assert response.status == "planned"
+    assert response.generated_userdata == custom
+    # The cloud-config is materialised as a cicustom *user* snippet (so it runs at
+    # first boot) — not merely stuffed into the VM description.
+    assert "EOF_USER_DATA" in response.build_script
+    assert "echo zabbix-bootstrap" in response.build_script
+    assert "--cicustom" in response.build_script
+    assert "user=local:snippets/" in response.build_script
+    assert "qm template 9010" in response.build_script
+
+
 def test_execute_requires_environment_opt_in():
     with pytest.raises(HTTPException) as exc:
         build_pipeline_response(

--- a/uv.lock
+++ b/uv.lock
@@ -1534,7 +1534,7 @@ wheels = [
 
 [[package]]
 name = "proxbox-api"
-version = "0.0.17.post2"
+version = "0.0.18"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
CI mirror of Gitea PR emersonfelipesp/proxbox-api#51. Adds user_data_yaml to CloudImageTemplateBuildRequest; bakes #cloud-config as a Proxmox cicustom user snippet via the SSH pipeline. Enables the netbox-packer cloud-init template-image flow. Merge happens on Gitea (deploy-on-merge); this PR exists to run ci.yml.  Closes #50