### PR TITLE
fix(docker): bake openssh-client into runtime image for cloud image pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,11 @@ ENV PATH="/app/.venv/bin:$PATH" \
 
 COPY --from=builder /app/.venv /app/.venv
 
-RUN mkdir -p /app/scripts /data
+# openssh-client provides `ssh`, required by the Cloud Image Build Pipeline to
+# run remote `qm`/`pvesm` commands on Proxmox hosts (cicustom snippet bake).
+# Baked into the image so it survives container recreation and redeploys.
+RUN apk add --no-cache openssh-client && \
+    mkdir -p /app/scripts /data
 
 EXPOSE 8000
 VOLUME ["/data"]
@@ -61,7 +65,9 @@ ENV PATH="/app/.venv/bin:$PATH" \
 
 COPY --from=builder-pyo3-rust /app/.venv /app/.venv
 
-RUN apk add --no-cache libgcc && \
+# libgcc for the Rust extension; openssh-client for the Cloud Image Build
+# Pipeline's remote `qm`/`pvesm` execution (cicustom snippet bake).
+RUN apk add --no-cache libgcc openssh-client && \
     mkdir -p /app/scripts /data && \
     /app/.venv/bin/python -c "from proxbox_reconcile_rs._native import build_vm_operation_queue_json"
 

--- a/docker/CLAUDE.md
+++ b/docker/CLAUDE.md
@@ -28,7 +28,7 @@ Container runtime configuration for the `proxbox-api` service. This directory ho
 The `Dockerfile` at the repo root uses five stages:
 
 1. **builder** — installs deps with `uv` into a virtualenv at `/app/.venv` (Alpine base, `python:3.13-alpine`)
-2. **runtime-base** — minimal Alpine Python image with the virtualenv copied in
+2. **runtime-base** — minimal Alpine Python image with the virtualenv copied in. Installs `openssh-client` so `ssh` is available to the Cloud Image Build Pipeline (`PROXBOX_ENABLE_CLOUD_IMAGE_EXECUTION=true`), which runs remote `qm`/`pvesm` commands on Proxmox hosts to bake `cicustom` cloud-init snippets. The `runtime-base-pyo3-rust` variant installs it alongside `libgcc`. Baked into the image so it survives container recreation and redeploys (never rely on a runtime `apk add`).
 3. **raw** (default) — pure uvicorn, no proxy; `docker build .` produces this image
 4. **nginx** — extends raw; adds nginx + supervisor + mkcert, HTTPS-only
 5. **granian** — extends runtime-base; adds granian + mkcert, HTTPS-only via granian's native TLS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ proxbox_api = ["static/*", "static/**/*", "generated/**/*.json", "generated/**/*
 
 [project]
 name = "proxbox_api"
-version = "0.0.18"
+version = "0.0.18.post1"
 description = "Proxbox API service made using FastAPI"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1534,7 +1534,7 @@ wheels = [
 
 [[package]]
 name = "proxbox-api"
-version = "0.0.18"
+version = "0.0.18.post1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Mirror of Gitea PR #54. Adds openssh-client to both runtime-base stages so ssh is baked into every image variant for the Cloud Image Build Pipeline. 0.0.18 -> 0.0.18.post1. Closes #53 (Gitea).