### PR TITLE
Release v0.0.18rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ proxbox_api = ["static/*", "static/**/*", "generated/**/*.json", "generated/**/*
 
 [project]
 name = "proxbox_api"
-version = "0.0.18.post1"
+version = "0.0.18rc1"
 description = "Proxbox API service made using FastAPI"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1534,7 +1534,7 @@ wheels = [
 
 [[package]]
 name = "proxbox-api"
-version = "0.0.18.post1"
+version = "0.0.18rc1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Version bump to v0.0.18rc1 for TestPyPI release candidate validation.

- Bump version: `0.0.18.post1` → `0.0.18rc1`
- Update `uv.lock`