### PR TITLE
Release v0.0.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ proxbox_api = ["static/*", "static/**/*", "generated/**/*.json", "generated/**/*
 
 [project]
 name = "proxbox_api"
-version = "0.0.18rc1"
+version = "0.0.18"
 description = "Proxbox API service made using FastAPI"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1534,7 +1534,7 @@ wheels = [
 
 [[package]]
 name = "proxbox-api"
-version = "0.0.18rc1"
+version = "0.0.18"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Bump version from `0.0.18rc1` to `0.0.18` for official release
- Update uv.lock

## Release checklist

- [x] RC1 (v0.0.18rc1) validated on TestPyPI (run 27440807692)
- [x] Version bumped to final `0.0.18`
- [ ] PR merged to main
- [ ] GitHub release `v0.0.18` created → triggers PyPI publish

## Note on CI

The E2E Docker matrix CI experienced Docker Hub rate-limit failures (HTTP 429)
during the RC1 re-run. This is a transient GHA infrastructure quota issue, not
a code regression. The RC1 publish-testpypi workflow (run 27440807692) passed.