### PR TITLE
Parallelize virtual disk sync in proxbox-api

### DIFF
--- a/docs/api/http-reference.md
+++ b/docs/api/http-reference.md
@@ -417,6 +417,9 @@ Every VM stream endpoint listed above (`/virtualization/virtual-machines/...crea
 
 See [Overwrite Flags](../sync/overwrite-flags.md) for the full matrix and defaults.
 
+The three virtual-disk endpoints also accept an optional `fetch_max_concurrency`
+query parameter to override the Proxmox VM-config fetch width for that request.
+
 ## Full Update
 
 - `GET /full-update` - Runs device sync, storage sync, VM sync, task history sync, disk sync, backup sync, snapshot sync, node interface sync, VM interface sync, VM IP sync, replication sync, and backup routine sync.

--- a/docs/development/async-semaphores.md
+++ b/docs/development/async-semaphores.md
@@ -18,7 +18,7 @@ async def task(i):
 Unlike `threading.Semaphore`, `asyncio.Semaphore` never uses OS threads or
 locks; it is entirely cooperative and safe to use from coroutines.
 
-## The Three Semaphores in the VM Sync Pipeline
+## The Three Semaphores in the VM and Virtual-Disk Sync Pipeline
 
 ```mermaid
 graph TD
@@ -63,7 +63,9 @@ fetch_results = await asyncio.gather(
 **Why it is needed:** Proxmox clusters can have thousands of VMs. Firing all
 config requests simultaneously would overwhelm the Proxmox API's rate limiter
 and exhaust the aiohttp connection pool. The semaphore serializes bursts to at
-most `PROXBOX_VM_SYNC_MAX_CONCURRENCY` concurrent in-flight requests.
+most `PROXBOX_VM_SYNC_MAX_CONCURRENCY` concurrent in-flight requests. The same
+limit now applies to the `virtual-disks` stage, which resolves VM configs in a
+separate fetch phase before any NetBox writes begin.
 
 ### 2. Write Semaphore
 
@@ -87,7 +89,8 @@ async def _run_single(operation):
 **Why it is needed:** NetBox's PostgreSQL backend has a limited connection pool.
 Sending 500 concurrent write requests would hit pool exhaustion, causing
 cascading timeouts. The default of 8 writes keeps PostgreSQL pressure
-manageable while still achieving significant parallelism.
+manageable while still achieving significant parallelism. The `virtual-disks`
+stage also uses this semaphore to bound per-VM reconcile/delete/patch work.
 
 ### 3. Interface Fetch Semaphore
 

--- a/docs/development/async-tunables.md
+++ b/docs/development/async-tunables.md
@@ -39,8 +39,8 @@ the plugin settings page in NetBox and the new value will take effect within
 
 | Env Var | Plugin Settings Key | Default | Min | Description |
 |---|---|---|---|---|
-| `PROXBOX_VM_SYNC_MAX_CONCURRENCY` | `vm_sync_max_concurrency` | 4 | 1 | Max concurrent Proxmox VM config fetches in phase 1 |
-| `PROXBOX_NETBOX_WRITE_CONCURRENCY` | `netbox_write_concurrency` | 8 | 1 | Max concurrent NetBox API writes in the dispatch queue |
+| `PROXBOX_VM_SYNC_MAX_CONCURRENCY` | `vm_sync_max_concurrency` | 4 | 1 | Max concurrent Proxmox VM config fetches in the VM and virtual-disk sync phases |
+| `PROXBOX_NETBOX_WRITE_CONCURRENCY` | `netbox_write_concurrency` | 8 | 1 | Max concurrent NetBox API write-heavy per-VM sync tasks (VMs and virtual disks) |
 | `PROXBOX_PROXMOX_FETCH_CONCURRENCY` | `proxmox_fetch_concurrency` | 8 | 1 | Max concurrent Proxmox API reads for interfaces |
 | `PROXBOX_INTERFACE_BATCH_SIZE` | `interface_batch_size` | 5 | 1 | VMs per interface-sync batch (prevents NetBox overload) |
 | `PROXBOX_INTERFACE_BATCH_DELAY_MS` | `interface_batch_delay_ms` | 100 | 0 | Milliseconds between interface-sync batches |

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -185,10 +185,10 @@ A handful of variables stay process-level only because they are read before the 
 | `PROXBOX_NETBOX_MAX_RETRIES` | `5` | Retry attempts for transient NetBox connection failures. |
 | `PROXBOX_NETBOX_RETRY_DELAY` | `2.0` | Initial retry delay in seconds for NetBox retries. |
 | `PROXBOX_NETBOX_MAX_CONCURRENT` | `1` | Maximum concurrent NetBox API requests. Keep low (1-2) to avoid exhausting NetBox's PostgreSQL connection pool. |
-| `PROXBOX_VM_SYNC_MAX_CONCURRENCY` | `4` | Maximum number of concurrent VM sync write tasks. |
+| `PROXBOX_VM_SYNC_MAX_CONCURRENCY` | `4` | Maximum number of concurrent Proxmox VM config fetches during VM and virtual-disk sync. |
 | `PROXBOX_GUEST_AGENT_TIMEOUT` | `15` | Per-call timeout (seconds, range 1-600) for the QEMU guest-agent `network-get-interfaces` request. Interface-dense guests (many VRRP/alias interfaces) can be slow to enumerate; raise this if guest-agent interface fetches time out. Maps to the `ProxboxPluginSettings.guest_agent_timeout` plugin field. |
 | `PROXBOX_RECONCILIATION_ENGINE` | `python` | Optional env override for `ProxboxPluginSettings.reconciliation_engine`. Valid values are `python`, `compare`, and `rust`. |
-| `PROXBOX_NETBOX_WRITE_CONCURRENCY` | `8` (VM sync) / `4` (task-history, snapshots) | Maximum number of concurrent NetBox write operations. Default varies by sync service. |
+| `PROXBOX_NETBOX_WRITE_CONCURRENCY` | `8` (VM sync, virtual disks) / `4` (task-history, snapshots) | Maximum number of concurrent NetBox write operations. Default varies by sync service. |
 | `PROXBOX_PROXMOX_FETCH_CONCURRENCY` | `8` (most paths) / `4` (task-history) | Maximum number of concurrent Proxmox read operations. Default varies by sync service. |
 | `PROXBOX_FETCH_MAX_CONCURRENCY` | `8` | Legacy fetch concurrency override used by some sync entrypoints. |
 | `PROXBOX_RATE_LIMIT` | `300` | Maximum API requests per minute per IP address. |
@@ -227,8 +227,8 @@ in-flight NetBox requests at a time.
 | Env var | Plugin key | Default | What it controls |
 |---------|-----------|---------|-----------------|
 | `PROXBOX_NETBOX_MAX_CONCURRENT` | `netbox_max_concurrent` | 1 | Maximum simultaneous NetBox HTTP requests per worker (GET + POST + PATCH combined). This is the primary knob for PostgreSQL connection usage. |
-| `PROXBOX_NETBOX_WRITE_CONCURRENCY` | `netbox_write_concurrency` | 8 | Maximum simultaneous VM create/update operations per sync pass, bounded by a per-pass `asyncio.Semaphore`. |
-| `PROXBOX_VM_SYNC_MAX_CONCURRENCY` | `vm_sync_max_concurrency` | 4 | Maximum concurrent Proxmox VM config fetches (Proxmox-side, not NetBox-side). |
+| `PROXBOX_NETBOX_WRITE_CONCURRENCY` | `netbox_write_concurrency` | 8 | Maximum simultaneous write-heavy per-VM sync operations per pass, bounded by a per-pass `asyncio.Semaphore`. |
+| `PROXBOX_VM_SYNC_MAX_CONCURRENCY` | `vm_sync_max_concurrency` | 4 | Maximum concurrent Proxmox VM config fetches for the VM and virtual-disk stages (Proxmox-side, not NetBox-side). |
 | `PROXBOX_NETBOX_MAX_RETRIES` | `netbox_max_retries` | 5 | Maximum retry attempts on transient NetBox errors. |
 | `PROXBOX_NETBOX_RETRY_DELAY` | `netbox_retry_delay` | 2.0 s | Base delay between retries (exponential backoff). |
 | `PROXBOX_NETBOX_GET_CACHE_TTL` | `netbox_get_cache_ttl` | 60 s | GET response cache TTL. Raising this reduces NetBox requests on read-heavy paths. Set `0` to disable. |

--- a/docs/pt-BR/api/http-reference.md
+++ b/docs/pt-BR/api/http-reference.md
@@ -285,6 +285,10 @@ Cobertura de testes:
 - `GET /full-update` - Executa sync de devices, storages, VMs, task history, discos, backups, snapshots, interfaces de node, interfaces de VM, IPs de VM, replications e backup routines.
 - `GET /full-update/stream` - Variacao SSE.
 
+Os tres endpoints de `virtual-disks` tambem aceitam o parametro opcional
+`fetch_max_concurrency` para sobrescrever a largura do fetch de config de VM
+Proxmox naquela requisicao.
+
 ## WebSocket
 
 - `GET /` - WebSocket basico de contagem para testes de conectividade.

--- a/docs/pt-BR/development/async-semaphores.md
+++ b/docs/pt-BR/development/async-semaphores.md
@@ -19,7 +19,7 @@ Ao contrário do `threading.Semaphore`, o `asyncio.Semaphore` nunca usa threads
 ou locks do OS; é totalmente cooperativo e seguro de usar a partir de
 corrotinas.
 
-## Os Três Semáforos no Pipeline de Sincronização de VMs
+## Os Três Semáforos no Pipeline de Sincronização de VMs e Discos
 
 ```mermaid
 graph TD
@@ -65,7 +65,9 @@ fetch_results = await asyncio.gather(
 todas as requisições de configuração simultaneamente sobrecarregaria o rate
 limiter da API Proxmox e esgotaria o pool de conexões do aiohttp. O semáforo
 serializa os bursts para no máximo `PROXBOX_VM_SYNC_MAX_CONCURRENCY` requisições
-concorrentes em voo.
+concorrentes em voo. O mesmo limite agora vale para a etapa `virtual-disks`,
+que resolve as configs das VMs em uma fase de fetch separada antes de iniciar
+as escritas no NetBox.
 
 ### 2. Semáforo de Escrita
 
@@ -90,7 +92,8 @@ async def _run_single(operation):
 conexões limitado. Enviar 500 requisições de escrita concorrentes causaria
 esgotamento do pool, resultando em timeouts em cascata. O padrão de 8 escritas
 mantém a pressão sobre o PostgreSQL gerenciável enquanto ainda alcança
-paralelismo significativo.
+paralelismo significativo. A etapa `virtual-disks` também usa este semáforo
+para limitar o trabalho por VM de reconcile/delete/patch.
 
 ### 3. Semáforo de Fetch de Interfaces
 

--- a/docs/pt-BR/development/async-tunables.md
+++ b/docs/pt-BR/development/async-tunables.md
@@ -39,8 +39,8 @@ efeito em até 5 minutos (ou imediatamente ao reiniciar).
 
 | Variável de Env | Chave de Configurações do Plugin | Padrão | Mín | Descrição |
 |---|---|---|---|---|
-| `PROXBOX_VM_SYNC_MAX_CONCURRENCY` | `vm_sync_max_concurrency` | 4 | 1 | Máx de fetches concorrentes de configuração de VM Proxmox na fase 1 |
-| `PROXBOX_NETBOX_WRITE_CONCURRENCY` | `netbox_write_concurrency` | 8 | 1 | Máx de escritas concorrentes na API NetBox na fila de despacho |
+| `PROXBOX_VM_SYNC_MAX_CONCURRENCY` | `vm_sync_max_concurrency` | 4 | 1 | Máx de fetches concorrentes de configuração de VM Proxmox nas fases de sync de VMs e discos |
+| `PROXBOX_NETBOX_WRITE_CONCURRENCY` | `netbox_write_concurrency` | 8 | 1 | Máx de tarefas concorrentes de sync por VM com escrita intensa no NetBox (VMs e discos) |
 | `PROXBOX_PROXMOX_FETCH_CONCURRENCY` | `proxmox_fetch_concurrency` | 8 | 1 | Máx de leituras concorrentes da API Proxmox para interfaces |
 | `PROXBOX_INTERFACE_BATCH_SIZE` | `interface_batch_size` | 5 | 1 | VMs por lote de sincronização de interfaces (evita sobrecarga do NetBox) |
 | `PROXBOX_INTERFACE_BATCH_DELAY_MS` | `interface_batch_delay_ms` | 100 | 0 | Milissegundos entre lotes de sincronização de interfaces |

--- a/docs/pt-BR/getting-started/configuration.md
+++ b/docs/pt-BR/getting-started/configuration.md
@@ -167,10 +167,10 @@ Algumas variaveis permanecem somente em nivel de processo porque sao lidas antes
 | `PROXBOX_NETBOX_MAX_RETRIES` | `5` | Numero de tentativas para falhas transientes do NetBox. |
 | `PROXBOX_NETBOX_RETRY_DELAY` | `2.0` | Delay inicial, em segundos, para retries do NetBox. |
 | `PROXBOX_NETBOX_MAX_CONCURRENT` | `1` | Maximo de requisicoes simultaneas ao NetBox. Mantenha baixo (1-2) para evitar agotar o pool de conexoes PostgreSQL do NetBox. |
-| `PROXBOX_VM_SYNC_MAX_CONCURRENCY` | `4` | Maximo de tarefas concorrentes de escrita no sync de VMs. |
+| `PROXBOX_VM_SYNC_MAX_CONCURRENCY` | `4` | Maximo de fetches concorrentes de configuracao de VM Proxmox durante o sync de VMs e discos. |
 | `PROXBOX_GUEST_AGENT_TIMEOUT` | `15` | Timeout por chamada (segundos, intervalo 1-600) para a requisicao `network-get-interfaces` do guest-agent QEMU. Guests com muitas interfaces (VRRP/alias) podem demorar a enumerar; aumente este valor se as buscas de interface via guest-agent expirarem. Mapeia para o campo `ProxboxPluginSettings.guest_agent_timeout`. |
 | `PROXBOX_RECONCILIATION_ENGINE` | `python` | Override opcional para `ProxboxPluginSettings.reconciliation_engine`. Valores validos: `python`, `compare` e `rust`. |
-| `PROXBOX_NETBOX_WRITE_CONCURRENCY` | `8` (sync de VM) / `4` (task-history, snapshots) | Maximo de operacoes concorrentes de escrita no NetBox. O padrao varia por servico de sync. |
+| `PROXBOX_NETBOX_WRITE_CONCURRENCY` | `8` (sync de VM, discos) / `4` (task-history, snapshots) | Maximo de operacoes concorrentes de escrita no NetBox. O padrao varia por servico de sync. |
 | `PROXBOX_PROXMOX_FETCH_CONCURRENCY` | `8` (maioria dos fluxos) / `4` (task-history) | Maximo de operacoes concorrentes de leitura no Proxmox. O padrao varia por servico de sync. |
 | `PROXBOX_FETCH_MAX_CONCURRENCY` | `8` | Override legado de concorrencia usado por alguns entrypoints de sync. |
 | `PROXBOX_RATE_LIMIT` | `60` | Maximo de requisicoes por minuto por endereco IP. |

--- a/proxbox_api/app/full_update.py
+++ b/proxbox_api/app/full_update.py
@@ -268,6 +268,7 @@ async def _full_update_sync_impl(  # noqa: C901
                 tag=tag,
                 use_websocket=False,
                 use_css=False,
+                fetch_max_concurrency=fetch_max_concurrency,
             )
         except ProxboxException:
             raise
@@ -735,6 +736,7 @@ async def full_update_sync_stream(  # noqa: C901
                             websocket=disks_bridge,
                             use_websocket=True,
                             use_css=False,
+                            fetch_max_concurrency=fetch_max_concurrency,
                         )
                     finally:
                         await disks_bridge.close()

--- a/proxbox_api/routes/virtualization/virtual_machines/disks_vm.py
+++ b/proxbox_api/routes/virtualization/virtual_machines/disks_vm.py
@@ -41,6 +41,11 @@ async def create_virtual_disks(
         title="NetBox VM IDs",
         description="Comma-separated list of NetBox VM IDs to sync. When provided, only these VMs will be synced.",
     ),
+    fetch_max_concurrency: int | None = Query(
+        default=None,
+        title="Fetch max concurrency",
+        description="Optional override for the number of concurrent Proxmox VM config fetches.",
+    ),
 ):
     """
     Syncs virtual disks for existing Virtual Machines in NetBox.
@@ -63,6 +68,7 @@ async def create_virtual_disks(
         use_websocket=use_websocket,
         use_css=use_css,
         netbox_vm_ids=netbox_vm_id_list,
+        fetch_max_concurrency=fetch_max_concurrency,
     )
     return result
 
@@ -78,6 +84,11 @@ async def create_virtual_disks_stream(
         default=None,
         title="NetBox VM IDs",
         description="Comma-separated list of NetBox VM IDs to sync. When provided, only these VMs will be synced.",
+    ),
+    fetch_max_concurrency: int | None = Query(
+        default=None,
+        title="Fetch max concurrency",
+        description="Optional override for the number of concurrent Proxmox VM config fetches.",
     ),
 ):
     netbox_vm_id_list = None
@@ -100,6 +111,7 @@ async def create_virtual_disks_stream(
                     use_websocket=True,
                     use_css=False,
                     netbox_vm_ids=netbox_vm_id_list,
+                    fetch_max_concurrency=fetch_max_concurrency,
                 )
             finally:
                 await bridge.close()
@@ -133,6 +145,11 @@ async def create_virtual_disks_for_vm_stream(
     cluster_status: ClusterStatusDep,
     cluster_resources: ClusterResourcesDep,
     tag: ProxboxTagDep,
+    fetch_max_concurrency: int | None = Query(
+        default=None,
+        title="Fetch max concurrency",
+        description="Optional override for the number of concurrent Proxmox VM config fetches.",
+    ),
 ):
     """Sync virtual disks for a single NetBox VM identified by its primary key."""
     vm_record = await asyncio.to_thread(
@@ -159,6 +176,7 @@ async def create_virtual_disks_for_vm_stream(
                     use_websocket=True,
                     use_css=False,
                     netbox_vm_id=netbox_vm_id,
+                    fetch_max_concurrency=fetch_max_concurrency,
                 )
             finally:
                 await bridge.close()

--- a/proxbox_api/services/sync/virtual_disks.py
+++ b/proxbox_api/services/sync/virtual_disks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 
 from proxbox_api.logger import logger
@@ -13,6 +14,7 @@ from proxbox_api.netbox_rest import (
     rest_patch_async,
 )
 from proxbox_api.proxmox_to_netbox.models import NetBoxVirtualDiskSyncState, ProxmoxVmConfigInput
+from proxbox_api.runtime_settings import get_int
 from proxbox_api.services.proxmox.config import resolve_vm_config
 from proxbox_api.services.sync.storage_links import (
     build_storage_index,
@@ -37,6 +39,26 @@ class VmConfigTarget:
     source: str
     netbox_device_name: str | None
     custom_field_node: str | None
+
+
+@dataclass(frozen=True)
+class VmDiskFetchResult:
+    vm: dict[str, object]
+    vmid: str
+    vm_name: str
+    cluster_name: str | None
+    target: VmConfigTarget | None
+    vm_config: dict[str, object] | None
+    failure_message: str | None = None
+
+
+@dataclass(frozen=True)
+class VmDiskSyncOutcome:
+    state: str
+    disks_created: int = 0
+    disks_updated: int = 0
+    disks_deleted: int = 0
+    parent_vm_disk_updated: bool = False
 
 
 def _text_or_none(value: object) -> str | None:
@@ -269,6 +291,334 @@ async def _sync_parent_vm_disk_total(
     return True
 
 
+def _resolve_fetch_concurrency(fetch_max_concurrency: int | None) -> int:
+    if fetch_max_concurrency is not None:
+        return max(1, int(fetch_max_concurrency))
+    return get_int(
+        settings_key="vm_sync_max_concurrency",
+        env="PROXBOX_VM_SYNC_MAX_CONCURRENCY",
+        default=4,
+        minimum=1,
+    )
+
+
+def _resolve_write_concurrency() -> int:
+    return get_int(
+        settings_key="netbox_write_concurrency",
+        env="PROXBOX_NETBOX_WRITE_CONCURRENCY",
+        default=8,
+        minimum=1,
+    )
+
+
+def _resolve_cluster_name(
+    vm: dict[str, object],
+    cluster_status: list[object] | None,
+) -> str | None:
+    cluster = vm.get("cluster")
+    if isinstance(cluster, dict):
+        cluster_name = _text_or_none(cluster.get("name"))
+        if cluster_name:
+            return cluster_name
+
+    for cs in cluster_status or []:
+        cs_name = _text_or_none(getattr(cs, "name", None))
+        if cs_name:
+            return cs_name
+    return None
+
+
+async def _send_virtual_disk_payload(
+    *,
+    websocket: object | None,
+    websocket_lock: asyncio.Lock | None,
+    use_websocket: bool,
+    payload: dict[str, object],
+) -> None:
+    if not use_websocket or websocket is None:
+        return
+    if websocket_lock is None:
+        await websocket.send_json(payload)
+        return
+    async with websocket_lock:
+        await websocket.send_json(payload)
+
+
+def _virtual_disk_rowid(vm_name: str) -> str:
+    return f"{vm_name}-disks"
+
+
+async def _fetch_virtual_disk_vm_config(
+    *,
+    vm: dict[str, object],
+    pxs: ProxmoxSessionsDep,
+    cluster_status: list[object] | None,
+    cluster_resources: list[dict[str, object]] | None,
+) -> VmDiskFetchResult:
+    vmid = extract_proxmox_vmid(vm)
+    vm_name = str(vm.get("name", "unknown") or "unknown")
+    if not vmid:
+        return VmDiskFetchResult(
+            vm=vm,
+            vmid="",
+            vm_name=vm_name,
+            cluster_name=_resolve_cluster_name(vm, cluster_status),
+            target=None,
+            vm_config=None,
+            failure_message="Missing proxmox VM id",
+        )
+
+    cluster_name = _resolve_cluster_name(vm, cluster_status)
+    extracted_vm_type = extract_proxmox_vm_type(vm)
+    vm_type = extracted_vm_type or "qemu"
+    target = _resolve_vm_config_target(
+        vm=vm,
+        vmid=vmid,
+        vm_type=vm_type,
+        vm_type_was_explicit=extracted_vm_type is not None,
+        cluster_name=cluster_name,
+        cluster_resources=cluster_resources,
+    )
+    node_name = target.node
+    vm_type = target.vm_type
+    cluster_name = target.cluster_name
+
+    if not node_name:
+        logger.warning(
+            "No node found for VM %s (vmid=%s type=%s cluster=%s, device=%s custom_field_node=%s), skipping disk sync",
+            vm_name,
+            vmid,
+            vm_type,
+            cluster_name,
+            target.netbox_device_name,
+            target.custom_field_node,
+        )
+        return VmDiskFetchResult(
+            vm=vm,
+            vmid=vmid,
+            vm_name=vm_name,
+            cluster_name=cluster_name,
+            target=target,
+            vm_config=None,
+            failure_message="No node associated",
+        )
+
+    logger.debug(
+        "Resolved virtual disk VM config target for %s (vmid=%s type=%s cluster=%s node=%s source=%s)",
+        vm_name,
+        vmid,
+        vm_type,
+        cluster_name,
+        node_name,
+        target.source,
+    )
+
+    try:
+        vm_config = await resolve_vm_config(
+            pxs=pxs,
+            node=node_name,
+            vm_type=vm_type,
+            vmid=vmid,
+        )
+    except Exception as error:
+        logger.error(
+            "Error getting VM config for %s (vmid=%s type=%s cluster=%s node=%s source=%s): %s",
+            vm_name,
+            vmid,
+            vm_type,
+            cluster_name,
+            node_name,
+            target.source,
+            error,
+        )
+        return VmDiskFetchResult(
+            vm=vm,
+            vmid=vmid,
+            vm_name=vm_name,
+            cluster_name=cluster_name,
+            target=target,
+            vm_config=None,
+            failure_message="Config not available",
+        )
+
+    if not vm_config:
+        logger.warning("Could not get VM config for VM %s (vmid: %s)", vm_name, vmid)
+        return VmDiskFetchResult(
+            vm=vm,
+            vmid=vmid,
+            vm_name=vm_name,
+            cluster_name=cluster_name,
+            target=target,
+            vm_config=None,
+            failure_message="Config not available",
+        )
+
+    return VmDiskFetchResult(
+        vm=vm,
+        vmid=vmid,
+        vm_name=vm_name,
+        cluster_name=cluster_name,
+        target=target,
+        vm_config=vm_config,
+    )
+
+
+async def _sync_virtual_disks_for_vm(
+    *,
+    nb: object,
+    fetched_vm: VmDiskFetchResult,
+    storage_index: dict[tuple[str, str], dict],
+    tag_refs: list[dict[str, object]],
+    websocket: object | None,
+    websocket_lock: asyncio.Lock | None,
+    use_websocket: bool,
+    completed_html: str,
+    failed_html: str,
+) -> VmDiskSyncOutcome:
+    vm = fetched_vm.vm
+    vm_name = fetched_vm.vm_name
+    vm_id = vm.get("id")
+
+    try:
+        vm_config_obj = await asyncio.to_thread(
+            ProxmoxVmConfigInput.model_validate,
+            fetched_vm.vm_config,
+        )
+        disk_entries = vm_config_obj.disks
+
+        disks_created = 0
+        disks_updated = 0
+        disks_deleted = 0
+        parent_vm_disk_updated = False
+
+        disk_payloads: list[dict[str, object]] = []
+        for disk_entry in disk_entries:
+            storage_name = disk_entry.storage_name or storage_name_from_volume_id(
+                disk_entry.storage
+            )
+            storage_record = find_storage_record(
+                storage_index,
+                cluster_name=fetched_vm.cluster_name,
+                storage_name=storage_name,
+            )
+            storage_id = storage_record.get("id") if storage_record else None
+            custom_fields: dict[str, object] = {}
+            if storage_id is not None:
+                custom_fields["proxbox_storage_id"] = storage_id
+            disk_payload: dict[str, object] = {
+                "virtual_machine": vm_id,
+                "name": disk_entry.name,
+                "size": disk_entry.size_mb,
+                "storage": storage_id,
+                "description": disk_entry.description,
+                "tags": tag_refs,
+            }
+            if custom_fields:
+                disk_payload["custom_fields"] = custom_fields
+            disk_payloads.append(disk_payload)
+
+        desired_disk_sizes = {
+            str(payload.get("name")): int(payload.get("size") or 0) for payload in disk_payloads
+        }
+        desired_disk_total = sum(int(payload.get("size") or 0) for payload in disk_payloads)
+
+        if disk_payloads:
+            bulk_result = await rest_bulk_reconcile_async(
+                nb,
+                "/api/virtualization/virtual-disks/",
+                payloads=disk_payloads,
+                lookup_fields=["virtual_machine", "name"],
+                schema=NetBoxVirtualDiskSyncState,
+                current_normalizer=lambda record: {
+                    "virtual_machine": record.get("virtual_machine"),
+                    "name": record.get("name"),
+                    "size": record.get("size") if record.get("size") is not None else 0,
+                    "storage": record.get("storage"),
+                    "description": record.get("description"),
+                    "tags": record.get("tags"),
+                    "custom_fields": record.get("custom_fields"),
+                },
+                base_query={"virtual_machine_id": vm_id},
+                lookup_query_field_map={"virtual_machine": "virtual_machine_id"},
+                strict_lookup=True,
+                nullable_fields={"storage"},
+            )
+            disks_created = bulk_result.created
+            disks_updated = bulk_result.updated
+
+        vm_id_int = relation_id(vm_id)
+        if vm_id_int is not None:
+            disks_deleted = await _delete_stale_virtual_disks(
+                nb,
+                vm_id=vm_id_int,
+                desired_disks=desired_disk_sizes,
+            )
+            parent_vm_disk_updated = await _sync_parent_vm_disk_total(
+                nb,
+                vm=vm,
+                desired_disk_total=desired_disk_total,
+            )
+
+        disk_summary = (
+            f"{len(disk_entries)} disks ({disks_created} created, "
+            f"{disks_updated} updated, {disks_deleted} deleted)"
+        )
+        await _send_virtual_disk_payload(
+            websocket=websocket,
+            websocket_lock=websocket_lock,
+            use_websocket=use_websocket,
+            payload={
+                "object": "virtual_disk",
+                "type": "sync",
+                "data": {
+                    "completed": True,
+                    "increment_count": "yes" if disks_created > 0 else "no",
+                    "rowid": _virtual_disk_rowid(vm_name),
+                    "name": vm_name,
+                    "sync_status": completed_html,
+                    "disks": disk_summary,
+                },
+            },
+        )
+
+        if disks_created > 0:
+            return VmDiskSyncOutcome(
+                state="created",
+                disks_created=disks_created,
+                disks_updated=disks_updated,
+                disks_deleted=disks_deleted,
+                parent_vm_disk_updated=parent_vm_disk_updated,
+            )
+        if disks_updated > 0 or disks_deleted > 0 or parent_vm_disk_updated:
+            return VmDiskSyncOutcome(
+                state="updated",
+                disks_created=disks_created,
+                disks_updated=disks_updated,
+                disks_deleted=disks_deleted,
+                parent_vm_disk_updated=parent_vm_disk_updated,
+            )
+        return VmDiskSyncOutcome(state="skipped")
+    except Exception as error:
+        logger.error("Error syncing disks for VM %s: %s", vm_name, error)
+        await _send_virtual_disk_payload(
+            websocket=websocket,
+            websocket_lock=websocket_lock,
+            use_websocket=use_websocket,
+            payload={
+                "object": "virtual_disk",
+                "type": "sync",
+                "data": {
+                    "completed": True,
+                    "rowid": _virtual_disk_rowid(vm_name),
+                    "name": vm_name,
+                    "sync_status": failed_html,
+                    "disks": str(error),
+                },
+            },
+        )
+        return VmDiskSyncOutcome(state="skipped")
+
+
 async def create_virtual_disks(  # noqa: C901
     netbox_session: object,
     pxs: ProxmoxSessionsDep,
@@ -280,6 +630,7 @@ async def create_virtual_disks(  # noqa: C901
     use_css: bool = False,
     netbox_vm_id: int | None = None,
     netbox_vm_ids: list[int] | None = None,
+    fetch_max_concurrency: int | None = None,
 ) -> dict[str, object]:
     """
     Sync virtual disks for existing Virtual Machines in NetBox.
@@ -370,259 +721,89 @@ async def create_virtual_disks(  # noqa: C901
     created = 0
     updated = 0
     skipped = 0
+    websocket_lock = asyncio.Lock() if use_websocket and websocket else None
 
     logger.info(f"Found {total_vms} VMs with cf_proxmox_vm_id to process")
 
     for vm in vms:
-        vmid = extract_proxmox_vmid(vm)
-        vm_name = vm.get("name", "unknown")
-        vm_id = vm.get("id")
+        vm_name = str(vm.get("name", "unknown") or "unknown")
+        await _send_virtual_disk_payload(
+            websocket=websocket,
+            websocket_lock=websocket_lock,
+            use_websocket=use_websocket,
+            payload={
+                "object": "virtual_disk",
+                "type": "sync",
+                "data": {
+                    "completed": False,
+                    "rowid": _virtual_disk_rowid(vm_name),
+                    "name": vm_name,
+                    "sync_status": syncing_html,
+                    "disks": undefined_html,
+                },
+            },
+        )
 
-        if not vmid:
-            skipped += 1
-            continue
+    fetch_semaphore = asyncio.Semaphore(_resolve_fetch_concurrency(fetch_max_concurrency))
 
-        initial_disk_json = {
-            "completed": False,
-            "rowid": f"{vm_name}-disks",
-            "name": vm_name,
-            "sync_status": syncing_html,
-            "disks": undefined_html,
-        }
-
-        if use_websocket and websocket:
-            await websocket.send_json(
-                {"object": "virtual_disk", "type": "sync", "data": initial_disk_json}
-            )
-
-        try:
-            cluster_name = None
-            if vm.get("cluster"):
-                cluster_name = (
-                    vm.get("cluster").get("name") if isinstance(vm.get("cluster"), dict) else None
-                )
-
-            if not cluster_name:
-                for cs in cluster_status or []:
-                    cs_name = getattr(cs, "name", None)
-                    if cs_name:
-                        cluster_name = cs_name
-                        break
-
-            extracted_vm_type = extract_proxmox_vm_type(vm)
-            vm_type = extracted_vm_type or "qemu"
-            target = _resolve_vm_config_target(
+    async def _fetch_with_limit(vm: dict[str, object]) -> VmDiskFetchResult:
+        async with fetch_semaphore:
+            return await _fetch_virtual_disk_vm_config(
                 vm=vm,
-                vmid=vmid,
-                vm_type=vm_type,
-                vm_type_was_explicit=extracted_vm_type is not None,
-                cluster_name=cluster_name,
+                pxs=pxs,
+                cluster_status=cluster_status,
                 cluster_resources=cluster_resources,
             )
-            node_name = target.node
-            vm_type = target.vm_type
-            cluster_name = target.cluster_name
 
-            if not node_name:
-                logger.warning(
-                    "No node found for VM %s (vmid=%s type=%s cluster=%s, "
-                    "device=%s custom_field_node=%s), skipping disk sync",
-                    vm_name,
-                    vmid,
-                    vm_type,
-                    cluster_name,
-                    target.netbox_device_name,
-                    target.custom_field_node,
-                )
-                skipped += 1
-                if use_websocket and websocket:
-                    await websocket.send_json(
-                        {
-                            "object": "virtual_disk",
-                            "type": "sync",
-                            "data": {
-                                "completed": True,
-                                "rowid": f"{vm_name}-disks",
-                                "name": vm_name,
-                                "sync_status": failed_html,
-                                "disks": "No node associated",
-                            },
-                        }
-                    )
-                continue
+    fetch_results = await asyncio.gather(*[_fetch_with_limit(vm) for vm in vms])
 
-            logger.debug(
-                "Resolved virtual disk VM config target for %s "
-                "(vmid=%s type=%s cluster=%s node=%s source=%s)",
-                vm_name,
-                vmid,
-                vm_type,
-                cluster_name,
-                node_name,
-                target.source,
-            )
-
-            vm_config = None
-            try:
-                vm_config = await resolve_vm_config(
-                    pxs=pxs,
-                    node=node_name,
-                    vm_type=vm_type,
-                    vmid=vmid,
-                )
-            except Exception as e:
-                logger.error(
-                    "Error getting VM config for %s (vmid=%s type=%s cluster=%s "
-                    "node=%s source=%s): %s",
-                    vm_name,
-                    vmid,
-                    vm_type,
-                    cluster_name,
-                    node_name,
-                    target.source,
-                    e,
-                )
-
-            if not vm_config:
-                logger.warning(f"Could not get VM config for VM {vm_name} (vmid: {vmid})")
-                skipped += 1
-                if use_websocket and websocket:
-                    await websocket.send_json(
-                        {
-                            "object": "virtual_disk",
-                            "type": "sync",
-                            "data": {
-                                "completed": True,
-                                "rowid": f"{vm_name}-disks",
-                                "name": vm_name,
-                                "sync_status": failed_html,
-                                "disks": "Config not available",
-                            },
-                        }
-                    )
-                continue
-
-            vm_config_obj = ProxmoxVmConfigInput.model_validate(vm_config)
-            disk_entries = vm_config_obj.disks
-
-            disks_created = 0
-            disks_updated = 0
-            disks_deleted = 0
-            parent_vm_disk_updated = False
-
-            disk_payloads: list[dict[str, object]] = []
-            for disk_entry in disk_entries:
-                storage_name = disk_entry.storage_name or storage_name_from_volume_id(
-                    disk_entry.storage
-                )
-                storage_record = find_storage_record(
-                    storage_index,
-                    cluster_name=cluster_name,
-                    storage_name=storage_name,
-                )
-                storage_id = storage_record.get("id") if storage_record else None
-                custom_fields: dict[str, object] = {}
-                if storage_id is not None:
-                    custom_fields["proxbox_storage_id"] = storage_id
-                disk_payload: dict[str, object] = {
-                    "virtual_machine": vm_id,
-                    "name": disk_entry.name,
-                    "size": disk_entry.size_mb,
-                    "storage": storage_id,
-                    "description": disk_entry.description,
-                    "tags": tag_refs,
-                }
-                if custom_fields:
-                    disk_payload["custom_fields"] = custom_fields
-                disk_payloads.append(disk_payload)
-
-            desired_disk_sizes = {
-                str(payload.get("name")): int(payload.get("size") or 0) for payload in disk_payloads
-            }
-            desired_disk_total = sum(int(payload.get("size") or 0) for payload in disk_payloads)
-
-            if disk_payloads:
-                bulk_result = await rest_bulk_reconcile_async(
-                    nb,
-                    "/api/virtualization/virtual-disks/",
-                    payloads=disk_payloads,
-                    lookup_fields=["virtual_machine", "name"],
-                    schema=NetBoxVirtualDiskSyncState,
-                    current_normalizer=lambda record: {
-                        "virtual_machine": record.get("virtual_machine"),
-                        "name": record.get("name"),
-                        "size": record.get("size") if record.get("size") is not None else 0,
-                        "storage": record.get("storage"),
-                        "description": record.get("description"),
-                        "tags": record.get("tags"),
-                        "custom_fields": record.get("custom_fields"),
-                    },
-                    base_query={"virtual_machine_id": vm_id},
-                    lookup_query_field_map={"virtual_machine": "virtual_machine_id"},
-                    strict_lookup=True,
-                    nullable_fields={"storage"},
-                )
-                disks_created = bulk_result.created
-                disks_updated = bulk_result.updated
-
-            vm_id_int = relation_id(vm_id)
-            if vm_id_int is not None:
-                disks_deleted = await _delete_stale_virtual_disks(
-                    nb,
-                    vm_id=vm_id_int,
-                    desired_disks=desired_disk_sizes,
-                )
-                parent_vm_disk_updated = await _sync_parent_vm_disk_total(
-                    nb,
-                    vm=vm,
-                    desired_disk_total=desired_disk_total,
-                )
-
-            if disks_created > 0:
-                created += 1
-            elif disks_updated > 0 or disks_deleted > 0 or parent_vm_disk_updated:
-                updated += 1
-            else:
-                skipped += 1
-
-            disk_summary = (
-                f"{len(disk_entries)} disks ({disks_created} created, "
-                f"{disks_updated} updated, {disks_deleted} deleted)"
-            )
-
-            if use_websocket and websocket:
-                await websocket.send_json(
-                    {
-                        "object": "virtual_disk",
-                        "type": "sync",
-                        "data": {
-                            "completed": True,
-                            "increment_count": "yes" if disks_created > 0 else "no",
-                            "rowid": f"{vm_name}-disks",
-                            "name": vm_name,
-                            "sync_status": completed_html,
-                            "disks": disk_summary,
-                        },
-                    }
-                )
-
-        except Exception as e:
-            logger.error(f"Error syncing disks for VM {vm_name}: {e}")
+    ready_to_sync: list[VmDiskFetchResult] = []
+    for fetch_result in fetch_results:
+        if fetch_result.failure_message:
             skipped += 1
-            if use_websocket and websocket:
-                await websocket.send_json(
-                    {
-                        "object": "virtual_disk",
-                        "type": "sync",
-                        "data": {
-                            "completed": True,
-                            "rowid": f"{vm_name}-disks",
-                            "name": vm_name,
-                            "sync_status": failed_html,
-                            "disks": str(e),
-                        },
-                    }
-                )
+            await _send_virtual_disk_payload(
+                websocket=websocket,
+                websocket_lock=websocket_lock,
+                use_websocket=use_websocket,
+                payload={
+                    "object": "virtual_disk",
+                    "type": "sync",
+                    "data": {
+                        "completed": True,
+                        "rowid": _virtual_disk_rowid(fetch_result.vm_name),
+                        "name": fetch_result.vm_name,
+                        "sync_status": failed_html,
+                        "disks": fetch_result.failure_message,
+                    },
+                },
+            )
+            continue
+        ready_to_sync.append(fetch_result)
+
+    write_semaphore = asyncio.Semaphore(_resolve_write_concurrency())
+
+    async def _sync_with_limit(fetch_result: VmDiskFetchResult) -> VmDiskSyncOutcome:
+        async with write_semaphore:
+            return await _sync_virtual_disks_for_vm(
+                nb=nb,
+                fetched_vm=fetch_result,
+                storage_index=storage_index,
+                tag_refs=tag_refs,
+                websocket=websocket,
+                websocket_lock=websocket_lock,
+                use_websocket=use_websocket,
+                completed_html=completed_html,
+                failed_html=failed_html,
+            )
+
+    sync_outcomes = await asyncio.gather(*[_sync_with_limit(result) for result in ready_to_sync])
+    for outcome in sync_outcomes:
+        if outcome.state == "created":
+            created += 1
+        elif outcome.state == "updated":
+            updated += 1
+        else:
+            skipped += 1
 
     result = {
         "count": total_vms,
@@ -633,7 +814,11 @@ async def create_virtual_disks(  # noqa: C901
 
     logger.info(f"Virtual disks sync complete: {result}")
 
-    if use_websocket and websocket:
-        await websocket.send_json({"object": "virtual_disk", "end": True})
+    await _send_virtual_disk_payload(
+        websocket=websocket,
+        websocket_lock=websocket_lock,
+        use_websocket=use_websocket,
+        payload={"object": "virtual_disk", "end": True},
+    )
 
     return result

--- a/tests/test_fetch_concurrency_kwarg.py
+++ b/tests/test_fetch_concurrency_kwarg.py
@@ -1,4 +1,4 @@
-"""Regression test for the `fetch_concurrency` kwarg name on `create_storages`.
+"""Regression tests for full-update fetch-concurrency plumbing.
 
 History: an earlier rev of `create_storages` used `fetch_max_concurrency`. The
 parameter was renamed to `fetch_concurrency`, but `app/full_update.py` continued
@@ -19,6 +19,7 @@ from pathlib import Path
 import pytest
 
 from proxbox_api.services.sync.storages import create_storages
+from proxbox_api.services.sync.virtual_disks import create_virtual_disks
 
 
 def test_create_storages_signature_uses_fetch_concurrency() -> None:
@@ -65,3 +66,25 @@ async def test_create_storages_accepts_fetch_concurrency_without_typeerror() -> 
         fetch_concurrency=4,
     )
     assert result == []
+
+
+def test_create_virtual_disks_signature_uses_fetch_max_concurrency() -> None:
+    sig = inspect.signature(create_virtual_disks)
+    assert "fetch_max_concurrency" in sig.parameters
+
+
+def test_full_update_calls_create_virtual_disks_with_fetch_max_concurrency() -> None:
+    full_update_path = (
+        Path(__file__).resolve().parent.parent / "proxbox_api" / "app" / "full_update.py"
+    )
+    source = full_update_path.read_text(encoding="utf-8")
+
+    matches = list(re.finditer(r"create_virtual_disks\s*\(", source))
+    assert matches, "expected at least one create_virtual_disks(...) call in full_update.py"
+
+    for match in matches:
+        window = source[match.start() : match.start() + 500]
+        assert "fetch_max_concurrency=fetch_max_concurrency" in window, (
+            f"create_virtual_disks call near offset {match.start()} is missing the "
+            "fetch_max_concurrency kwarg"
+        )

--- a/tests/test_virtual_disks_sync.py
+++ b/tests/test_virtual_disks_sync.py
@@ -90,6 +90,98 @@ def _make_virtual_disk_record(
     return record
 
 
+def test_create_virtual_disks_fetches_vm_configs_with_bounded_concurrency(monkeypatch):
+    active_fetches = 0
+    max_active_fetches = 0
+    two_fetches_started = asyncio.Event()
+    release_fetches = asyncio.Event()
+
+    async def _fake_rest_list(_nb, _path, query=None):
+        if _path == "/api/virtualization/virtual-machines/":
+            return [
+                {
+                    "id": 7,
+                    "name": "vm-101",
+                    "cluster": {"name": "cluster-a"},
+                    "custom_fields": {"proxmox_vm_id": 101},
+                },
+                {
+                    "id": 8,
+                    "name": "vm-102",
+                    "cluster": {"name": "cluster-a"},
+                    "custom_fields": {"proxmox_vm_id": 102},
+                },
+                {
+                    "id": 9,
+                    "name": "vm-103",
+                    "cluster": {"name": "cluster-a"},
+                    "custom_fields": {"proxmox_vm_id": 103},
+                },
+            ]
+        if _path == "/api/plugins/proxbox/storage/":
+            return []
+        if _path == "/api/virtualization/virtual-disks/":
+            return []
+        return []
+
+    async def _fake_resolve_vm_config(**kwargs):
+        nonlocal active_fetches, max_active_fetches
+        active_fetches += 1
+        max_active_fetches = max(max_active_fetches, active_fetches)
+        if active_fetches >= 2:
+            two_fetches_started.set()
+        await release_fetches.wait()
+        active_fetches -= 1
+        return {"scsi0": f"local-lvm:vm-{kwargs['vmid']}-disk-0,size=1G"}
+
+    async def _fake_bulk_reconcile(_nb, _path, *, payloads, **kwargs):
+        return SimpleNamespace(records=[], created=len(payloads), updated=0, unchanged=0, failed=0)
+
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.virtual_disks.rest_list_async",
+        _fake_rest_list,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.virtual_disks.resolve_vm_config",
+        _fake_resolve_vm_config,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.virtual_disks.rest_bulk_reconcile_async",
+        _fake_bulk_reconcile,
+    )
+
+    async def _run():
+        sync_task = asyncio.create_task(
+            create_virtual_disks(
+                netbox_session=object(),
+                pxs=[],
+                cluster_status=[],
+                cluster_resources=[
+                    {
+                        "cluster-a": [
+                            {"type": "qemu", "name": "vm-101", "vmid": "101", "node": "pve01"},
+                            {"type": "qemu", "name": "vm-102", "vmid": "102", "node": "pve01"},
+                            {"type": "qemu", "name": "vm-103", "vmid": "103", "node": "pve01"},
+                        ]
+                    }
+                ],
+                tag=None,
+                use_websocket=False,
+                use_css=False,
+                fetch_max_concurrency=2,
+            )
+        )
+        await asyncio.wait_for(two_fetches_started.wait(), timeout=1)
+        release_fetches.set()
+        result = await sync_task
+        return result
+
+    result = asyncio.run(_run())
+
+    assert max_active_fetches == 2
+    assert result == {"count": 3, "created": 3, "updated": 0, "skipped": 0}
+
+
 def test_create_virtual_disks_uses_custom_fields_proxmox_vm_id(monkeypatch):
     calls = {"resolve_vm_config": []}
     reconciled_payloads: list[dict] = []


### PR DESCRIPTION
## Summary

- parallelize the virtual-disk stage into a fetch phase and a bounded per-VM NetBox write phase
- reuse existing concurrency controls for VM-config fetches and NetBox write-heavy per-VM work
- expose the `fetch_max_concurrency` override on the virtual-disk routes and full-update wrappers, and update the concurrency docs

## Verification

- `uv run ruff check proxbox_api/services/sync/virtual_disks.py proxbox_api/routes/virtualization/virtual_machines/disks_vm.py proxbox_api/app/full_update.py tests/test_virtual_disks_sync.py tests/test_fetch_concurrency_kwarg.py`
- `uv run ruff format --check proxbox_api/services/sync/virtual_disks.py proxbox_api/routes/virtualization/virtual_machines/disks_vm.py proxbox_api/app/full_update.py tests/test_virtual_disks_sync.py tests/test_fetch_concurrency_kwarg.py`
- `uv run pytest tests/test_virtual_disks_sync.py tests/test_fetch_concurrency_kwarg.py -q`
- `uv run python -m compileall proxbox_api tests`
- `uv run python -c "import proxbox_api.main"`
- `uv run python -c "from proxbox_api.proxmox_to_netbox.proxmox_schema import load_proxmox_generated_openapi; assert load_proxmox_generated_openapi().get('paths')"`
- `uv run ty check proxbox_api/types proxbox_api/utils/retry.py proxbox_api/schemas/sync.py`
- `uv run pytest tests/test_api_routes.py tests/test_full_update_stream_branching.py tests/test_sse_stream_output.py tests/test_plugin_integration.py -q`

## Notes

- A full `uv run pytest tests -q` run was started, but it was too large to wait out interactively here; the branch was validated with the targeted sync-facing and route-facing suites above before handing off to CI.

Closes emersonfelipesp/netbox-proxbox#582
