### PR TITLE
fix(sync): scope bulk reconcile lookups by id (VM interfaces 503, VLAN site/tenant)

### DIFF
--- a/proxbox_api/services/sync/network.py
+++ b/proxbox_api/services/sync/network.py
@@ -461,6 +461,11 @@ async def bulk_reconcile_vlans(
             "/api/ipam/vlans/",
             payloads=vlan_payloads,
             lookup_fields=["vid", "site", "tenant"],
+            # NetBox's `site`/`tenant` filters match by slug, but the payload
+            # carries their NetBox ids. Without this remap the id is silently
+            # ignored, so the existence check is not scoped to site/tenant and
+            # the reconcile can match/patch the wrong VLAN (or recreate one).
+            lookup_query_field_map={"site": "site_id", "tenant": "tenant_id"},
             schema=NetBoxVlanSyncState,
             current_normalizer=lambda record: {
                 "vid": record.get("vid"),
@@ -529,6 +534,11 @@ async def bulk_reconcile_vm_interfaces(
             "/api/virtualization/interfaces/",
             payloads=interface_payloads,
             lookup_fields=["name", "virtual_machine"],
+            # NetBox's `virtual_machine` filter matches by VM *name*; the payload
+            # carries the VM id, so without this remap the id is silently ignored
+            # and the existence check is not scoped to the VM. The reconcile then
+            # tries to re-create existing interfaces (HTTP 400 "already exists").
+            lookup_query_field_map={"virtual_machine": "virtual_machine_id"},
             schema=NetBoxVirtualMachineInterfaceSyncState,
             patchable_fields=frozenset(_vm_interface_patchable),
             current_normalizer=lambda record: {

--- a/tests/test_network_reconcile_lookup_scope.py
+++ b/tests/test_network_reconcile_lookup_scope.py
@@ -1,0 +1,52 @@
+"""Regression tests: bulk reconcile must scope existence checks by id.
+
+NetBox relation filters differ in what they match:
+- ``virtual_machine`` (VMInterface) matches by VM *name*.
+- ``site`` / ``tenant`` (VLAN) match by *slug*.
+
+proxbox carries the NetBox *id* in those payload fields, so the lookup query
+must be remapped to the id-based filter (``*_id``) via ``lookup_query_field_map``.
+Without it NetBox silently ignores the unscoped filter and the reconcile fails:
+for VM interfaces it re-creates existing rows (HTTP 400 "already exists"); for
+VLANs it can match the wrong VLAN across sites/tenants.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from proxbox_api.services.sync import network
+
+
+def _capture_reconcile_kwargs(monkeypatch) -> dict:
+    captured: dict = {}
+
+    async def _fake_bulk_reconcile(_nb, _path, *, payloads, **kwargs):
+        captured["path"] = _path
+        captured["payloads"] = payloads
+        captured.update(kwargs)
+        return SimpleNamespace(records=[], created=0, updated=0, unchanged=0, failed=0)
+
+    monkeypatch.setattr(network, "rest_bulk_reconcile_async", _fake_bulk_reconcile)
+    return captured
+
+
+async def test_vm_interface_reconcile_scopes_lookup_by_virtual_machine_id(monkeypatch):
+    captured = _capture_reconcile_kwargs(monkeypatch)
+
+    await network.bulk_reconcile_vm_interfaces(
+        MagicMock(), [{"name": "ens18", "virtual_machine": 8}]
+    )
+
+    assert captured["path"] == "/api/virtualization/interfaces/"
+    assert captured["lookup_fields"] == ["name", "virtual_machine"]
+    assert captured["lookup_query_field_map"] == {"virtual_machine": "virtual_machine_id"}
+
+
+async def test_vlan_reconcile_scopes_lookup_by_site_and_tenant_id(monkeypatch):
+    captured = _capture_reconcile_kwargs(monkeypatch)
+
+    await network.bulk_reconcile_vlans(MagicMock(), [{"vid": 200, "site": 3, "tenant": 5}])
+
+    assert captured["path"] == "/api/ipam/vlans/"
+    assert captured["lookup_fields"] == ["vid", "site", "tenant"]
+    assert captured["lookup_query_field_map"] == {"site": "site_id", "tenant": "tenant_id"}


### PR DESCRIPTION
## Summary

Bulk reconcile builds NetBox existence-check queries from `lookup_fields`, but two relation fields are queried with the wrong filter semantics, so the lookup is **not scoped to the parent object**:

| Reconciler | `lookup_fields` | NetBox filter matches by | payload carries |
|---|---|---|---|
| VM interfaces (`/api/virtualization/interfaces/`) | `virtual_machine` | **name** (`to_field_name="name"`) | the VM **id** |
| VLANs (`/api/ipam/vlans/`) | `site`, `tenant` | **slug** | the **id** |

NetBox silently ignores a filter whose value doesn't resolve, so e.g. `?name=ens18&virtual_machine=8` returns *all* `ens18` interfaces across every VM. The reconcile can't match the existing row and:

- **VM interfaces** → tries to **create** → `HTTP 400 {"__all__":["Interface with this Virtual machine and Name already exists."]}` → the `vm-interfaces` sync stage fails with **`503`**. Interface sync becomes non-idempotent (works once on an empty NetBox, fails every re-sync).
- **VLANs** → can match/patch the **wrong VLAN** across sites/tenants (latent unless the endpoint has a site/tenant set).

## Fix

Remap the lookup query fields to their id-based filters via the existing `lookup_query_field_map`:

```python
# VM interfaces
lookup_query_field_map={"virtual_machine": "virtual_machine_id"}
# VLANs
lookup_query_field_map={"site": "site_id", "tenant": "tenant_id"}
```

This is the same mechanism `virtual_disks.py` (`virtual_machine -> virtual_machine_id`) and `device_ensure.py` (`site -> site_id`) already use — these two call sites were just missed. No change to `rest_bulk_reconcile_async`, payloads, or normalizers.

## Verification

- Reproduced against a real NetBox 4.6 + Proxmox VE 8.4: before, `vm-interfaces` failed with the 503 above; after, the reconcile matches existing interfaces and the sync completes.
- Confirmed via NetBox's own `VMInterfaceFilterSet` / `VLANFilterSet` that `virtual_machine`/`site`/`tenant` ignore an id value while `*_id` matches.

## Tests

`tests/test_network_reconcile_lookup_scope.py` — asserts `bulk_reconcile_vm_interfaces` and `bulk_reconcile_vlans` pass the correct `lookup_query_field_map` to `rest_bulk_reconcile_async`.

Likely the same root cause behind #223 (interfaces mapping to the wrong VM across clusters): an interface lookup not scoped by VM id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
