### PR TITLE
feat(sync): node-network → dcim.Interface reconcile + IP-adopt-by-host (#243)

### DIFF
--- a/proxbox_api/proxmox_to_netbox/models.py
+++ b/proxbox_api/proxmox_to_netbox/models.py
@@ -344,17 +344,29 @@ class NetBoxInterfaceSyncState(BaseModel):
     device: int
     name: str
     status: str = "active"
+    enabled: bool = True
     type: str
     bridge: int | None = None
+    lag: int | None = None
+    parent: int | None = None
     untagged_vlan: int | None = None
+    tagged_vlans: list[int] = Field(default_factory=list)
     mode: str | None = None
     tags: list[NetBoxTagRef] = Field(default_factory=list)
     custom_fields: dict[str, object] = Field(default_factory=dict)
 
-    @field_validator("device", "bridge", "untagged_vlan", mode="before")
+    @field_validator("device", "bridge", "lag", "parent", "untagged_vlan", mode="before")
     @classmethod
     def normalize_device(cls, value: object) -> object:
         return _relation_id(value)
+
+    @field_validator("tagged_vlans", mode="before")
+    @classmethod
+    def normalize_tagged_vlans(cls, value: object) -> list[int]:
+        if not value:
+            return []
+        items = value if isinstance(value, (list, tuple)) else [value]
+        return [vid for vid in (_relation_id(v) for v in items) if vid is not None]
 
     @field_validator("status", mode="before")
     @classmethod

--- a/proxbox_api/routes/dcim/__init__.py
+++ b/proxbox_api/routes/dcim/__init__.py
@@ -389,6 +389,25 @@ async def _emit_node_interface_event(websocket, use_websocket: bool, payload: di
         await websocket.send_json(payload)
 
 
+async def _emit_node_network_error(
+    websocket, use_websocket: bool, node_name: str, exc: Exception
+) -> None:
+    """Emit a node-level failure event mirroring the legacy per-interface error shape."""
+    await _emit_node_interface_event(
+        websocket,
+        use_websocket,
+        {
+            "object": "node_interface",
+            "data": {
+                "completed": False,
+                "rowid": node_name,
+                "name": node_name,
+                "error": str(exc),
+            },
+        },
+    )
+
+
 async def _sync_node_network_topology(
     netbox_session,
     tag_refs: list[dict[str, object]],
@@ -428,9 +447,18 @@ async def _sync_node_network_topology(
         raw_network = await resolve_async(
             proxmox_session.session(f"/nodes/{node_name}/network").get()
         )
+    except ProxboxException:
+        raise
     except Exception as exc:
-        logger.warning("Failed to fetch raw network for node %s: %s", node_name, exc)
-        return []
+        # A failed fetch means the node topology could not be reconciled at all.
+        # Surface it (stream event + raised error) instead of reporting a silent
+        # zero-interface success, matching the legacy per-interface path.
+        await _emit_node_network_error(websocket, use_websocket, node_name, exc)
+        raise ProxboxException(
+            message=f"Failed to fetch node network for '{node_name}'",
+            detail=f"{type(exc).__name__}: {getattr(exc, 'detail', str(exc))}",
+            python_exception=str(exc),
+        ) from exc
 
     try:
         results = await sync_node_network(
@@ -439,9 +467,15 @@ async def _sync_node_network_topology(
             list(raw_network or []),
             tag_refs,
         )
+    except ProxboxException:
+        raise
     except Exception as exc:
-        logger.warning("Failed to sync node network topology for %s: %s", node_name, exc)
-        return []
+        await _emit_node_network_error(websocket, use_websocket, node_name, exc)
+        raise ProxboxException(
+            message=f"Failed to reconcile node network topology for '{node_name}'",
+            detail=f"{type(exc).__name__}: {getattr(exc, 'detail', str(exc))}",
+            python_exception=str(exc),
+        ) from exc
 
     for result in results:
         await _emit_node_interface_event(
@@ -687,7 +721,13 @@ async def create_all_device_interfaces(
                 clusters_status=[cluster_status],
                 cluster_name=cluster_name,
             )
-            node_networks = await load_proxmox_node_network(proxmox_session, node_name)
+            # The full-topology path re-fetches the raw payload itself, so the
+            # normalized loader would be a wasted round-trip when the flag is on.
+            node_networks = (
+                []
+                if sync_full_topology
+                else await load_proxmox_node_network(proxmox_session, node_name)
+            )
             all_results.extend(
                 await _sync_node_interfaces_for_node(
                     netbox_session,

--- a/proxbox_api/routes/dcim/__init__.py
+++ b/proxbox_api/routes/dcim/__init__.py
@@ -6,7 +6,11 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import StreamingResponse
 
-from proxbox_api.dependencies import ProxboxTagDep, ResolvedSyncOverwriteFlagsDep
+from proxbox_api.dependencies import (
+    ProxboxTagDep,
+    ResolvedSyncBehaviorFlagsDep,
+    ResolvedSyncOverwriteFlagsDep,
+)
 from proxbox_api.exception import ProxboxException
 from proxbox_api.logger import logger
 from proxbox_api.netbox_rest import nested_tag_payload, rest_list_async, rest_patch_async
@@ -385,6 +389,80 @@ async def _emit_node_interface_event(websocket, use_websocket: bool, payload: di
         await websocket.send_json(payload)
 
 
+async def _sync_node_network_topology(
+    netbox_session,
+    tag_refs: list[dict[str, object]],
+    *,
+    node_name: str,
+    device_record: dict[str, object],
+    proxmox_session,
+    websocket=None,
+    use_websocket: bool = False,
+) -> list[dict]:
+    """Reconcile a node's full ``/nodes/{node}/network`` topology in one pass.
+
+    Feeds ``sync_node_network`` the **raw** ``/nodes/{node}/network`` payload
+    (hyphenated keys such as ``vlan-id``/``vlan-raw-device`` plus
+    ``bridge_ports``/``bond_slaves``/``options``/``active``/``cidr6``) obtained
+    via a direct proxmox-sdk call, not the normalized ``load_proxmox_node_network``
+    payload whose fields the topology reconcile does not surface.
+    """
+    from proxbox_api.proxmox_async import resolve_async
+    from proxbox_api.services.sync.network import sync_node_network
+
+    # sync_node_network writes dcim.Interface rows keyed by the NetBox device id.
+    # The caller already resolved the NetBox device for this node.
+    device_id = (
+        device_record.get("id")
+        if isinstance(device_record, dict)
+        else getattr(device_record, "id", None)
+    )
+    if device_id is None:
+        logger.warning(
+            "Skipping node network topology sync for %s: NetBox device not found",
+            node_name,
+        )
+        return []
+
+    try:
+        raw_network = await resolve_async(
+            proxmox_session.session(f"/nodes/{node_name}/network").get()
+        )
+    except Exception as exc:
+        logger.warning("Failed to fetch raw network for node %s: %s", node_name, exc)
+        return []
+
+    try:
+        results = await sync_node_network(
+            netbox_session,
+            {"id": device_id, "name": node_name},
+            list(raw_network or []),
+            tag_refs,
+        )
+    except Exception as exc:
+        logger.warning("Failed to sync node network topology for %s: %s", node_name, exc)
+        return []
+
+    for result in results:
+        await _emit_node_interface_event(
+            websocket,
+            use_websocket,
+            {
+                "object": "interface",
+                "data": {
+                    "completed": True,
+                    "rowid": result.get("name"),
+                    "name": result.get("name"),
+                    "netbox_id": result.get("id"),
+                    "device": node_name,
+                    "ip_address": (result.get("ip_addresses") or [None])[0],
+                },
+            },
+        )
+
+    return results
+
+
 async def _sync_node_interfaces_for_node(
     netbox_session: NetBoxAsyncSessionDep,
     tag_refs: list[dict[str, object]],
@@ -394,8 +472,18 @@ async def _sync_node_interfaces_for_node(
     node_networks: list[object],
     websocket=None,
     use_websocket: bool = False,
+    proxmox_session=None,
+    sync_full_topology: bool = False,
 ) -> list[dict]:
-    """Sync all interfaces for a single node and emit optional websocket updates."""
+    """Sync all interfaces for a single node and emit optional websocket updates.
+
+    When ``sync_full_topology`` is set (the ``sync_node_interfaces`` behavior
+    flag) and a ``proxmox_session`` is provided, the node's full
+    ``/nodes/{node}/network`` topology is reconciled via ``sync_node_network``
+    in a single pass. Otherwise the historical per-interface loop over the
+    caller-provided normalized ``node_networks`` payload is used, keeping
+    existing deployments unchanged.
+    """
     results: list[dict] = []
 
     await _emit_node_interface_event(
@@ -411,6 +499,31 @@ async def _sync_node_interfaces_for_node(
             },
         },
     )
+
+    if sync_full_topology and proxmox_session is not None:
+        results = await _sync_node_network_topology(
+            netbox_session,
+            tag_refs,
+            node_name=node_name,
+            device_record=device_record,
+            proxmox_session=proxmox_session,
+            websocket=websocket,
+            use_websocket=use_websocket,
+        )
+        await _emit_node_interface_event(
+            websocket,
+            use_websocket,
+            {
+                "object": "node_interface",
+                "data": {
+                    "completed": True,
+                    "rowid": node_name,
+                    "name": node_name,
+                    "count": len(results),
+                },
+            },
+        )
+        return results
 
     if not node_networks:
         await _emit_node_interface_event(
@@ -531,6 +644,7 @@ async def create_all_device_interfaces(
     pxs: list[object] | None = None,
     websocket=None,
     use_websocket: bool = False,
+    behavior_flags=None,
 ) -> list[dict]:
     """Sync all Proxmox node interfaces and their IP addresses across all clusters.
 
@@ -538,9 +652,13 @@ async def create_all_device_interfaces(
         netbox_session: NetBox async session.
         tag: Proxbox tag reference.
         clusters_status: All cluster status objects from Proxmox.
-        pxs: Proxmox sessions used to fetch per-node network payloads.
+        pxs: Proxmox sessions used to fetch per-node network payloads. Required
+            for the ``sync_node_interfaces`` full-topology path, which needs the
+            raw ``/nodes/{node}/network`` payload.
         websocket: Optional WebSocketSSEBridge for progress events.
         use_websocket: Whether to emit progress events.
+        behavior_flags: Resolved ``SyncBehaviorFlags``; ``sync_node_interfaces``
+            selects the full-topology reconcile.
 
     Returns:
         List of all synced interface records.
@@ -550,6 +668,8 @@ async def create_all_device_interfaces(
 
     if not clusters_status:
         return all_results
+
+    sync_full_topology = bool(getattr(behavior_flags, "sync_node_interfaces", False))
 
     for cluster_status in clusters_status:
         if not cluster_status or not cluster_status.node_list:
@@ -577,6 +697,8 @@ async def create_all_device_interfaces(
                     node_networks=node_networks,
                     websocket=websocket,
                     use_websocket=use_websocket,
+                    proxmox_session=proxmox_session,
+                    sync_full_topology=sync_full_topology,
                 )
             )
 
@@ -592,17 +714,21 @@ async def create_all_devices_interfaces(
     clusters_status: ClusterStatusDep,
     pxs: ProxmoxSessionsDep,
     tag: ProxboxTagDep,
+    behavior_flags: ResolvedSyncBehaviorFlagsDep,
 ):
     """Sync network interfaces for all Proxmox nodes (dcim.Device interfaces).
 
     Iterates through all cluster nodes and syncs their network interfaces
     and IP addresses to NetBox dcim.Interface and ipam.IPAddress records.
+    With the ``sync_node_interfaces`` behavior flag set, the full
+    ``/nodes/{node}/network`` topology is reconciled instead.
     """
     results = await create_all_device_interfaces(
         netbox_session=netbox_session,
         tag=tag,
         clusters_status=clusters_status,
         pxs=pxs,
+        behavior_flags=behavior_flags,
     )
     return results
 
@@ -613,6 +739,7 @@ async def create_all_devices_interfaces_stream(
     clusters_status: ClusterStatusDep,
     pxs: ProxmoxSessionsDep,
     tag: ProxboxTagDep,
+    behavior_flags: ResolvedSyncBehaviorFlagsDep,
 ):
     """Streaming endpoint for syncing all Proxmox node interfaces.
 
@@ -631,6 +758,7 @@ async def create_all_devices_interfaces_stream(
                     pxs=pxs,
                     websocket=bridge,
                     use_websocket=True,
+                    behavior_flags=behavior_flags,
                 )
             finally:
                 await bridge.close()

--- a/proxbox_api/schemas/sync.py
+++ b/proxbox_api/schemas/sync.py
@@ -287,6 +287,15 @@ class SyncBehaviorFlags(ProxboxBaseModel):
             "still honor the operator's opt-in."
         ),
     )
+    sync_node_interfaces: bool = Field(
+        default=False,
+        title="Sync Node Interfaces",
+        description=(
+            "When true, reconcile the node's full /nodes/{node}/network "
+            "topology (physical NICs, bridges, bonds, VLAN sub-interfaces) "
+            "into dcim.Interface, instead of only the in-use bridges."
+        ),
+    )
 
 
 def behavior_flags_from_query_params(

--- a/proxbox_api/services/sync/ip_ownership.py
+++ b/proxbox_api/services/sync/ip_ownership.py
@@ -43,6 +43,18 @@ def _relation_id_or_none(value: object) -> int | None:
         return None
 
 
+def _host_address(ip_addr: str) -> str:
+    """Return the host portion of a CIDR (drops the mask).
+
+    NetBox's ``address`` filter is exact-CIDR, so querying ``1.2.3.4/24`` will
+    NOT match an existing ``1.2.3.4/32`` record. Looking up adoptable records by
+    host (mask-agnostic) lets us adopt a pre-existing address regardless of its
+    stored mask — e.g. an operator-seeded ``/32`` — instead of failing to create
+    a duplicate under ENFORCE_GLOBAL_UNIQUE.
+    """
+    return ip_addr.split("/", 1)[0]
+
+
 async def _reconcile_interface_ip(
     nb,
     *,
@@ -80,7 +92,7 @@ async def _reconcile_interface_ip(
         existing = await rest_list_async(
             nb,
             "/api/ipam/ip-addresses/",
-            query={"address": ip_addr, "limit": 50},
+            query={"address": _host_address(ip_addr), "limit": 50},
         )
     except Exception as list_exc:
         # If ownership cannot be resolved, fall back to the interface-scoped

--- a/proxbox_api/services/sync/network.py
+++ b/proxbox_api/services/sync/network.py
@@ -338,10 +338,23 @@ async def sync_node_network(  # noqa: C901
     ``dcim.Interface`` records on the node device, including topology
     (bridge/bond membership, VLAN sub-interface parent), enabled state and IPs.
 
+    ``network_entries`` must be the **raw** ``/nodes/{node}/network`` payload
+    (a direct proxmox-sdk call), not the normalized ``ProxmoxNodeInterface`` SDK
+    model. The reconcile reads hyphenated keys (``vlan-id``,
+    ``vlan-raw-device``) and topology/state keys (``bridge_ports``,
+    ``bond_slaves``, ``options``, ``active``, ``cidr6``) that the normalized
+    model renames or drops.
+
     Two phases are required because the topology FKs (``bridge``/``lag``/
     ``parent``) reference *sibling* interfaces: phase 1 reconciles every
     interface's scalar fields + IPs (+ VLAN objects) and collects a name -> id
     map; phase 2 patches the cross-references once all ids are known.
+
+    A VLAN sub-interface (e.g. ``vmbr1.200``) is modeled as ``mode=tagged`` with
+    the VLAN in ``tagged_vlans`` because in Proxmox it is an 802.1Q-tagged
+    sub-interface carrying that single VID on its parent — distinct from the
+    legacy per-interface path (``sync_node_interface_and_ip``), which models a
+    bridge's ``untagged_vlan`` as ``mode=access``.
     """
     from proxbox_api.services.sync.mac_address import normalize_mac, reconcile_mac_for_interface
 

--- a/proxbox_api/services/sync/network.py
+++ b/proxbox_api/services/sync/network.py
@@ -246,6 +246,199 @@ async def sync_node_interface_and_ip(
     return result
 
 
+# Proxmox /network entry types that are not modeled as standalone NetBox
+# interfaces (loopback, and Open vSwitch internal plumbing / ifupdown aliases).
+_NODE_IFACE_SKIP_TYPES = {"loopback", "OVSPort", "OVSIntPort", "alias"}
+
+
+def _node_network_membership(
+    entries: list[dict],
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Map each member interface name -> its bridge / bond parent name.
+
+    Built from the `bridge_ports` and `bond_slaves` space-separated lists that
+    Proxmox returns on the parent interface entry.
+    """
+    member_bridge: dict[str, str] = {}
+    member_bond: dict[str, str] = {}
+    for entry in entries:
+        parent = str(entry.get("iface") or "")
+        for member in str(entry.get("bridge_ports") or "").split():
+            member_bridge[member] = parent
+        for member in str(entry.get("bond_slaves") or "").split():
+            member_bond[member] = parent
+    return member_bridge, member_bond
+
+
+def _node_iface_normalizer(record: dict) -> dict:
+    return {
+        "device": record.get("device"),
+        "name": record.get("name"),
+        "status": record.get("status"),
+        "enabled": record.get("enabled"),
+        "type": record.get("type"),
+        "bridge": record.get("bridge"),
+        "lag": record.get("lag"),
+        "parent": record.get("parent"),
+        "untagged_vlan": record.get("untagged_vlan"),
+        "tagged_vlans": record.get("tagged_vlans"),
+        "mode": record.get("mode"),
+        "tags": record.get("tags"),
+        "custom_fields": record.get("custom_fields"),
+    }
+
+
+def _record_id(record: object) -> int | None:
+    """Extract a NetBox record id from a RestRecord-like object or a dict."""
+    raw = getattr(record, "id", None) or (record.get("id") if isinstance(record, dict) else None)
+    return _relation_id_or_none(raw)
+
+
+async def sync_node_network(  # noqa: C901
+    nb,
+    device: dict,
+    network_entries: list[dict],
+    tag_refs: list[dict],
+    *,
+    now: datetime | None = None,
+) -> list[dict]:
+    """Reconcile a Proxmox node's full ``/nodes/{node}/network`` config into NetBox.
+
+    Models physical NICs, bridges, bonds and VLAN sub-interfaces as
+    ``dcim.Interface`` records on the node device, including topology
+    (bridge/bond membership, VLAN sub-interface parent), enabled state and IPs.
+
+    Two phases are required because the topology FKs (``bridge``/``lag``/
+    ``parent``) reference *sibling* interfaces: phase 1 reconciles every
+    interface's scalar fields + IPs (+ VLAN objects) and collects a name -> id
+    map; phase 2 patches the cross-references once all ids are known.
+    """
+    now = now or datetime.now(timezone.utc)
+    device_id = device.get("id")
+    entries = [
+        e
+        for e in (network_entries or [])
+        if e.get("iface") and e.get("iface") != "lo" and e.get("type") not in _NODE_IFACE_SKIP_TYPES
+    ]
+    member_bridge, member_bond = _node_network_membership(entries)
+
+    name_to_id: dict[str, int] = {}
+    vlan_id_for_iface: dict[str, int] = {}
+    results: list[dict] = []
+
+    # Phase 1 — scalar fields, IPs and VLAN objects.
+    for entry in entries:
+        iface = entry["iface"]
+        nb_type = NetBoxInterfaceType.from_proxmox(entry.get("type")).value
+        interface = await rest_reconcile_async(
+            nb,
+            "/api/dcim/interfaces/",
+            lookup={"device_id": device_id, "name": iface},
+            payload={
+                "device": device_id,
+                "name": iface,
+                "status": "active",
+                "enabled": bool(entry.get("active")),
+                "type": nb_type,
+                "tags": tag_refs,
+                "custom_fields": {"proxmox_last_updated": now.isoformat()},
+            },
+            schema=NetBoxInterfaceSyncState,
+            current_normalizer=_node_iface_normalizer,
+        )
+        iface_id = _record_id(interface)
+        if iface_id is not None:
+            name_to_id[iface] = iface_id
+        result: dict = {"id": iface_id, "name": iface}
+
+        if entry.get("type") == "vlan" and entry.get("vlan-id"):
+            try:
+                vid = int(entry["vlan-id"])
+                vlan_record = await rest_reconcile_async(
+                    nb,
+                    "/api/ipam/vlans/",
+                    lookup={"vid": vid},
+                    payload={
+                        "vid": vid,
+                        "name": f"VLAN {vid}",
+                        "status": "active",
+                        "tags": tag_refs,
+                    },
+                    schema=NetBoxVlanSyncState,
+                    current_normalizer=lambda record: {
+                        "vid": record.get("vid"),
+                        "name": record.get("name"),
+                        "status": record.get("status"),
+                        "tags": record.get("tags"),
+                        "custom_fields": record.get("custom_fields"),
+                    },
+                )
+                vlan_nb_id = _record_id(vlan_record)
+                if vlan_nb_id is not None:
+                    vlan_id_for_iface[iface] = vlan_nb_id
+            except Exception as vlan_exc:  # noqa: BLE001
+                logger.warning("Failed to sync VLAN for node interface %s: %s", iface, vlan_exc)
+
+        for cidr_field in ("cidr", "cidr6"):
+            cidr = entry.get(cidr_field)
+            if not cidr or iface_id is None:
+                continue
+            try:
+                await _reconcile_interface_ip(
+                    nb,
+                    ip_addr=cidr,
+                    interface_id=iface_id,
+                    tag_refs=tag_refs,
+                    now=now,
+                    dns_name=None,
+                    interface_name=iface,
+                    assigned_object_type="dcim.interface",
+                    interface_lookup_field="interface_id",
+                )
+                result.setdefault("ip_addresses", []).append(cidr)
+            except Exception as ip_exc:  # noqa: BLE001
+                logger.warning("Failed to sync IP %s on node interface %s: %s", cidr, iface, ip_exc)
+        results.append(result)
+
+    # Phase 2 — topology cross-references, now that every interface has an id.
+    for entry in entries:
+        iface = entry["iface"]
+        if iface not in name_to_id:
+            continue
+        patch: dict = {}
+        bridge_parent = member_bridge.get(iface)
+        if bridge_parent and bridge_parent in name_to_id:
+            patch["bridge"] = name_to_id[bridge_parent]
+        bond_parent = member_bond.get(iface)
+        if bond_parent and bond_parent in name_to_id:
+            patch["lag"] = name_to_id[bond_parent]
+        if entry.get("type") == "vlan":
+            raw_device = entry.get("vlan-raw-device")
+            if raw_device and raw_device in name_to_id:
+                patch["parent"] = name_to_id[raw_device]
+            if iface in vlan_id_for_iface:
+                patch["mode"] = "tagged"
+                patch["tagged_vlans"] = [vlan_id_for_iface[iface]]
+        if not patch:
+            continue
+        await rest_reconcile_async(
+            nb,
+            "/api/dcim/interfaces/",
+            lookup={"device_id": device_id, "name": iface},
+            payload={
+                "device": device_id,
+                "name": iface,
+                "type": NetBoxInterfaceType.from_proxmox(entry.get("type")).value,
+                **patch,
+            },
+            schema=NetBoxInterfaceSyncState,
+            current_normalizer=_node_iface_normalizer,
+            patchable_fields=frozenset(patch),
+        )
+
+    return results
+
+
 def _resolve_vm_interface_identity(
     interface_name: str,
     interface_config: dict,

--- a/proxbox_api/services/sync/network.py
+++ b/proxbox_api/services/sync/network.py
@@ -390,6 +390,14 @@ async def sync_node_network(  # noqa: C901
             },
             schema=NetBoxInterfaceSyncState,
             current_normalizer=_node_iface_normalizer,
+            # Phase 1 owns only scalar fields. Topology FKs and VLAN membership
+            # (bridge/lag/parent/mode/tagged_vlans) are reconciled in phase 2;
+            # never let phase 1 clear them on re-sync. NetBoxInterfaceSyncState
+            # defaults tagged_vlans to [] (survives exclude_none), so without
+            # this whitelist a re-sync would PATCH away phase 2's VLAN membership.
+            patchable_fields=frozenset(
+                {"device", "name", "status", "enabled", "type", "tags", "custom_fields"}
+            ),
         )
         iface_id = _record_id(interface)
         if iface_id is not None:

--- a/proxbox_api/services/sync/network.py
+++ b/proxbox_api/services/sync/network.py
@@ -270,6 +270,20 @@ def _node_network_membership(
     return member_bridge, member_bond
 
 
+def _hwaddress_from_options(entry: dict) -> str | None:
+    """Extract a MAC from a Proxmox interface entry's ``options`` (``hwaddress ...``).
+
+    Proxmox exposes a MAC in /network only for bridges/bonds carrying an explicit
+    ``hwaddress`` option; physical NIC MACs are not present in the network API
+    (they require ethtool/sysfs via the hardware-discovery path).
+    """
+    for opt in entry.get("options") or []:
+        parts = str(opt).split()
+        if len(parts) == 2 and parts[0].lower() == "hwaddress":
+            return parts[1]
+    return None
+
+
 def _node_iface_normalizer(record: dict) -> dict:
     return {
         "device": record.get("device"),
@@ -313,6 +327,8 @@ async def sync_node_network(  # noqa: C901
     interface's scalar fields + IPs (+ VLAN objects) and collects a name -> id
     map; phase 2 patches the cross-references once all ids are known.
     """
+    from proxbox_api.services.sync.mac_address import normalize_mac, reconcile_mac_for_interface
+
     now = now or datetime.now(timezone.utc)
     device_id = device.get("id")
     entries = [
@@ -398,6 +414,25 @@ async def sync_node_network(  # noqa: C901
                 result.setdefault("ip_addresses", []).append(cidr)
             except Exception as ip_exc:  # noqa: BLE001
                 logger.warning("Failed to sync IP %s on node interface %s: %s", cidr, iface, ip_exc)
+
+        # MAC (bridges/bonds only — see _hwaddress_from_options). NetBox 4.5+
+        # stores it as a dcim.MACAddress referenced by primary_mac_address.
+        mac = normalize_mac(_hwaddress_from_options(entry))
+        if mac and iface_id is not None:
+            try:
+                await reconcile_mac_for_interface(
+                    nb,
+                    mac=mac,
+                    assigned_object_type="dcim.interface",
+                    assigned_object_id=iface_id,
+                    interface_list_path="/api/dcim/interfaces/",
+                    tag_refs=tag_refs,
+                )
+                result["mac_address"] = mac
+            except Exception as mac_exc:  # noqa: BLE001
+                logger.warning(
+                    "Failed to sync MAC %s on node interface %s: %s", mac, iface, mac_exc
+                )
         results.append(result)
 
     # Phase 2 — topology cross-references, now that every interface has an id.

--- a/proxbox_api/services/sync/network.py
+++ b/proxbox_api/services/sync/network.py
@@ -270,6 +270,22 @@ def _node_network_membership(
     return member_bridge, member_bond
 
 
+def _is_network_id(cidr: str) -> bool:
+    """True if ``cidr`` is a subnet's network address (host bits all zero).
+
+    NetBox refuses to assign such an address to an interface. Mirrors its
+    leniency for host-style prefixes (/31,/32 and /127,/128), where the
+    "network" address is a valid assignable host.
+    """
+    try:
+        iface = _ip_interface(cidr)
+    except ValueError:
+        return False
+    return iface.ip == iface.network.network_address and iface.network.prefixlen < (
+        iface.max_prefixlen - 1
+    )
+
+
 def _hwaddress_from_options(entry: dict) -> str | None:
     """Extract a MAC from a Proxmox interface entry's ``options`` (``hwaddress ...``).
 
@@ -398,6 +414,11 @@ async def sync_node_network(  # noqa: C901
         for cidr_field in ("cidr", "cidr6"):
             cidr = entry.get(cidr_field)
             if not cidr or iface_id is None:
+                continue
+            if _is_network_id(cidr):
+                # e.g. Proxmox reporting a node's v6 as the ::/64 base; NetBox
+                # won't assign a network ID to an interface.
+                logger.debug("Skipping network-ID address %s on node interface %s", cidr, iface)
                 continue
             try:
                 await _reconcile_interface_ip(

--- a/tests/test_ip_adopt_by_host.py
+++ b/tests/test_ip_adopt_by_host.py
@@ -1,0 +1,94 @@
+"""Regression: adopt a pre-existing unassigned IP by host, regardless of mask.
+
+NetBox's `address` filter is exact-CIDR, so `1.2.3.4/24` does not match an
+existing `1.2.3.4/32`. With ENFORCE_GLOBAL_UNIQUE the duplicate create then
+fails and the address silently never attaches. The adoption lookup must query
+by host so an operator-seeded `/32` is adopted onto the interface (and its mask
+normalized), while still never reassigning a foreign-owned address.
+"""
+
+from types import SimpleNamespace
+
+from proxbox_api.services.sync import ip_ownership
+
+
+def _mocks(monkeypatch, existing):
+    captured = {"list_query": None, "reconcile": []}
+
+    async def fake_list(nb, path, *, query=None):
+        captured["list_query"] = query
+        return existing
+
+    async def fake_reconcile(nb, path, *, lookup, payload, **kw):
+        captured["reconcile"].append({"lookup": lookup, "payload": payload})
+        return SimpleNamespace(id=lookup.get("id", 99))
+
+    monkeypatch.setattr(ip_ownership, "rest_list_async", fake_list)
+    monkeypatch.setattr(ip_ownership, "rest_reconcile_async", fake_reconcile)
+    return captured
+
+
+async def test_adopts_existing_unassigned_slash32_as_slash24(monkeypatch):
+    from datetime import datetime, timezone
+
+    existing = [
+        {
+            "id": 1,
+            "address": "141.94.139.106/32",
+            "assigned_object_type": None,
+            "assigned_object_id": None,
+        }
+    ]
+    cap = _mocks(monkeypatch, existing)
+
+    result = await ip_ownership._reconcile_interface_ip(
+        object(),
+        ip_addr="141.94.139.106/24",
+        interface_id=5,
+        tag_refs=[],
+        now=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        dns_name=None,
+        interface_name="vmbr0",
+        assigned_object_type="dcim.interface",
+        interface_lookup_field="interface_id",
+    )
+
+    # Lookup is by host (mask stripped) so the /32 is found.
+    assert cap["list_query"]["address"] == "141.94.139.106"
+    # Adopted by id (not a create-by-address), assigned to this interface, mask -> /24.
+    assert len(cap["reconcile"]) == 1
+    assert cap["reconcile"][0]["lookup"] == {"id": 1}
+    payload = cap["reconcile"][0]["payload"]
+    assert payload["address"] == "141.94.139.106/24"
+    assert payload["assigned_object_id"] == 5
+    assert result == 1
+
+
+async def test_never_adopts_foreign_owned_address(monkeypatch):
+    from datetime import datetime, timezone
+
+    # Same host, but already owned by a different interface -> must NOT be reused.
+    existing = [
+        {
+            "id": 7,
+            "address": "141.94.139.106/32",
+            "assigned_object_type": "dcim.interface",
+            "assigned_object_id": 999,
+        }
+    ]
+    cap = _mocks(monkeypatch, existing)
+
+    await ip_ownership._reconcile_interface_ip(
+        object(),
+        ip_addr="141.94.139.106/24",
+        interface_id=5,
+        tag_refs=[],
+        now=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        dns_name=None,
+        interface_name="vmbr0",
+        assigned_object_type="dcim.interface",
+        interface_lookup_field="interface_id",
+    )
+
+    # Falls through to the interface-scoped create path (never reconciles id=7).
+    assert all(c["lookup"] != {"id": 7} for c in cap["reconcile"])

--- a/tests/test_ip_no_cross_object_match.py
+++ b/tests/test_ip_no_cross_object_match.py
@@ -25,8 +25,15 @@ def _run_resolve(monkeypatch, existing_for_address):
 
     async def _fake_rest_list(nb, path, query=None):
         query = query or {}
-        # Address ownership lookup performed by _reconcile_interface_ip.
-        if query.get("address") == _ADDR and "vminterface_id" not in query and "tag" not in query:
+        # Address ownership lookup performed by _reconcile_interface_ip. The
+        # lookup is mask-agnostic (queries by host) so a differently-masked
+        # pre-existing record is still found and adopted.
+        host = _ADDR.split("/", 1)[0]
+        if (
+            query.get("address") in {_ADDR, host}
+            and "vminterface_id" not in query
+            and "tag" not in query
+        ):
             return list(existing_for_address)
         # cleanup_stale_ips_for_interface (vminterface_id + tag) -> nothing stale.
         return []

--- a/tests/test_node_interfaces_wiring.py
+++ b/tests/test_node_interfaces_wiring.py
@@ -1,0 +1,115 @@
+"""Tests for the node-interface route wiring behind the ``sync_node_interfaces`` flag.
+
+Verifies that ``create_all_device_interfaces``:
+- routes to ``sync_node_network`` with the RAW ``/nodes/{node}/network`` payload
+  and the NetBox-resolved device record when the flag is on;
+- keeps the historical per-interface path (``sync_node_interface_and_ip``) when
+  the flag is off.
+"""
+
+from types import SimpleNamespace
+
+import proxbox_api.services.sync.network as network
+from proxbox_api.routes import dcim
+
+RAW_NETWORK = [
+    {"iface": "vmbr0", "type": "bridge", "active": 1, "bridge_ports": "eno1"},
+    {"iface": "eno1", "type": "eth", "active": 1},
+]
+
+
+def _fake_proxmox_session(captured):
+    class _Req:
+        def __init__(self, path):
+            self._path = path
+
+        def get(self, **kwargs):
+            captured["path"] = self._path
+            return RAW_NETWORK
+
+    return SimpleNamespace(name="cluster-a", session=lambda path: _Req(path))
+
+
+def _cluster_status():
+    node = SimpleNamespace(name="pve01", id="node/pve01")
+    return [SimpleNamespace(name="cluster-a", node_list=[node])]
+
+
+async def test_flag_on_routes_to_sync_node_network_with_raw_payload(monkeypatch):
+    captured: dict = {}
+    calls: dict = {"network": [], "per_iface": 0}
+
+    async def fake_resolve_device(nb, node_name, *, clusters_status, cluster_name):
+        assert node_name == "pve01"
+        return {"id": 42, "name": "pve01"}
+
+    async def fake_load_node_network(session, node):
+        # The normalized loader is still called for the node, but its result is
+        # unused on the full-topology path (the raw payload is fetched instead).
+        return []
+
+    async def fake_sync_node_network(nb, device, network_entries, tag_refs, **kw):
+        calls["network"].append({"device": device, "entries": network_entries})
+        return [{"id": 10, "name": "vmbr0"}, {"id": 11, "name": "eno1"}]
+
+    async def fake_per_iface(*args, **kwargs):
+        calls["per_iface"] += 1
+        return {}
+
+    monkeypatch.setattr(dcim, "_resolve_netbox_device_by_name", fake_resolve_device)
+    monkeypatch.setattr(dcim, "load_proxmox_node_network", fake_load_node_network)
+    monkeypatch.setattr(network, "sync_node_network", fake_sync_node_network)
+    monkeypatch.setattr(dcim, "sync_node_interface_and_ip", fake_per_iface)
+    monkeypatch.setattr(dcim, "nested_tag_payload", lambda tag: [])
+
+    results = await dcim.create_all_device_interfaces(
+        netbox_session=object(),
+        tag=object(),
+        clusters_status=_cluster_status(),
+        pxs=[_fake_proxmox_session(captured)],
+        behavior_flags=SimpleNamespace(sync_node_interfaces=True),
+    )
+
+    assert captured["path"] == "/nodes/pve01/network"
+    assert calls["per_iface"] == 0
+    assert len(calls["network"]) == 1
+    # Raw payload (hyphenated/topology keys preserved) and resolved device record.
+    assert calls["network"][0]["device"] == {"id": 42, "name": "pve01"}
+    assert calls["network"][0]["entries"] == RAW_NETWORK
+    assert len(results) == 2
+
+
+async def test_flag_off_keeps_per_interface_path(monkeypatch):
+    calls: dict = {"network": 0, "per_iface": 0}
+
+    async def fake_resolve_device(nb, node_name, *, clusters_status, cluster_name):
+        return {"id": 42, "name": node_name}
+
+    async def fake_load_node_network(session, node):
+        return [{"iface": "vmbr0", "type": "bridge"}]
+
+    async def fake_sync_node_network(*args, **kwargs):
+        calls["network"] += 1
+        return []
+
+    async def fake_per_iface(*args, **kwargs):
+        calls["per_iface"] += 1
+        return {"id": 1, "name": "vmbr0"}
+
+    monkeypatch.setattr(dcim, "_resolve_netbox_device_by_name", fake_resolve_device)
+    monkeypatch.setattr(dcim, "load_proxmox_node_network", fake_load_node_network)
+    monkeypatch.setattr(network, "sync_node_network", fake_sync_node_network)
+    monkeypatch.setattr(dcim, "sync_node_interface_and_ip", fake_per_iface)
+    monkeypatch.setattr(dcim, "nested_tag_payload", lambda tag: [])
+
+    await dcim.create_all_device_interfaces(
+        netbox_session=object(),
+        tag=object(),
+        clusters_status=_cluster_status(),
+        pxs=[SimpleNamespace(name="cluster-a")],
+        behavior_flags=SimpleNamespace(sync_node_interfaces=False),
+    )
+
+    # Full-topology reconcile untouched; the per-interface path handled the node.
+    assert calls["network"] == 0
+    assert calls["per_iface"] == 1

--- a/tests/test_node_interfaces_wiring.py
+++ b/tests/test_node_interfaces_wiring.py
@@ -9,8 +9,20 @@ Verifies that ``create_all_device_interfaces``:
 
 from types import SimpleNamespace
 
+import pytest
+
 import proxbox_api.services.sync.network as network
+from proxbox_api.exception import ProxboxException
 from proxbox_api.routes import dcim
+
+
+class _CapturingWebSocket:
+    def __init__(self):
+        self.events: list[dict] = []
+
+    async def send_json(self, payload):
+        self.events.append(payload)
+
 
 RAW_NETWORK = [
     {"iface": "vmbr0", "type": "bridge", "active": 1, "bridge_ports": "eno1"},
@@ -44,9 +56,9 @@ async def test_flag_on_routes_to_sync_node_network_with_raw_payload(monkeypatch)
         return {"id": 42, "name": "pve01"}
 
     async def fake_load_node_network(session, node):
-        # The normalized loader is still called for the node, but its result is
-        # unused on the full-topology path (the raw payload is fetched instead).
-        return []
+        # The full-topology path re-fetches the raw payload itself, so the
+        # normalized loader is skipped entirely when the flag is on.
+        raise AssertionError("load_proxmox_node_network must not run on the full-topology path")
 
     async def fake_sync_node_network(nb, device, network_entries, tag_refs, **kw):
         calls["network"].append({"device": device, "entries": network_entries})
@@ -113,3 +125,41 @@ async def test_flag_off_keeps_per_interface_path(monkeypatch):
     # Full-topology reconcile untouched; the per-interface path handled the node.
     assert calls["network"] == 0
     assert calls["per_iface"] == 1
+
+
+async def test_flag_on_topology_failure_raises_and_emits_error_event(monkeypatch):
+    """A failed topology reconcile must surface, not report a silent count:0 success."""
+
+    async def fake_resolve_device(nb, node_name, *, clusters_status, cluster_name):
+        return {"id": 42, "name": node_name}
+
+    async def fake_sync_node_network(*args, **kwargs):
+        raise RuntimeError("netbox exploded")
+
+    monkeypatch.setattr(dcim, "_resolve_netbox_device_by_name", fake_resolve_device)
+    monkeypatch.setattr(network, "sync_node_network", fake_sync_node_network)
+    monkeypatch.setattr(dcim, "nested_tag_payload", lambda tag: [])
+
+    websocket = _CapturingWebSocket()
+
+    with pytest.raises(ProxboxException):
+        await dcim.create_all_device_interfaces(
+            netbox_session=object(),
+            tag=object(),
+            clusters_status=_cluster_status(),
+            pxs=[_fake_proxmox_session({})],
+            websocket=websocket,
+            use_websocket=True,
+            behavior_flags=SimpleNamespace(sync_node_interfaces=True),
+        )
+
+    # The node-level failure is visible in the stream as a completed:False error.
+    error_events = [
+        e
+        for e in websocket.events
+        if e.get("object") == "node_interface"
+        and e.get("data", {}).get("completed") is False
+        and "error" in e.get("data", {})
+    ]
+    assert error_events, "expected a completed:False node_interface error event"
+    assert error_events[-1]["data"]["error"] == "netbox exploded"

--- a/tests/test_node_network_sync.py
+++ b/tests/test_node_network_sync.py
@@ -1,0 +1,119 @@
+"""Tests for node-network -> dcim.Interface sync (sync_node_network).
+
+Drives the orchestrator on Merkeb-shaped /nodes/{node}/network data with the
+NetBox REST calls mocked, and asserts the two-phase behaviour: scalar fields +
+type mapping + enabled in phase 1, and topology cross-references (bridge / lag /
+vlan parent + tagged VLAN) in phase 2.
+"""
+
+from types import SimpleNamespace
+
+from proxbox_api.services.sync import network
+
+# Subset of a real `pvesh get /nodes/<node>/network` payload.
+NETWORK = [
+    {"iface": "eno1", "type": "eth", "active": 1},
+    {"iface": "eno2", "type": "eth", "active": 1},
+    {"iface": "eno3", "type": "eth"},  # inactive
+    {
+        "iface": "vmbr0",
+        "type": "bridge",
+        "active": 1,
+        "bridge_ports": "eno1",
+        "cidr": "141.94.139.106/24",
+        "gateway": "141.94.139.254",
+        "cidr6": "2001:41d0:403:4a6a::/64",
+    },
+    {"iface": "vmbr1", "type": "bridge", "active": 1, "bridge_ports": "eno2"},
+    {
+        "iface": "vmbr1.200",
+        "type": "vlan",
+        "active": 1,
+        "cidr": "10.16.200.3/24",
+        "vlan-id": "200",
+        "vlan-raw-device": "vmbr1",
+    },
+    {"iface": "lo", "type": "loopback"},  # must be skipped
+]
+
+
+def _install_mocks(monkeypatch):
+    iface_ids: dict[str, int] = {}
+    next_id = [10]
+    iface_calls: list[dict] = []
+    ip_calls: list[dict] = []
+
+    async def fake_reconcile(nb, path, *, lookup, payload, schema, current_normalizer, **kw):
+        if path == "/api/dcim/interfaces/":
+            name = lookup["name"]
+            iface_ids.setdefault(name, next_id[0])
+            if iface_ids[name] == next_id[0]:
+                next_id[0] += 1
+            iface_calls.append(
+                {"name": name, "payload": payload, "patchable": kw.get("patchable_fields")}
+            )
+            return SimpleNamespace(id=iface_ids[name])
+        if path == "/api/ipam/vlans/":
+            return SimpleNamespace(id=900 + int(lookup["vid"]))
+        raise AssertionError(f"unexpected path {path}")
+
+    async def fake_ip(nb, *, ip_addr, interface_id, **kw):
+        ip_calls.append({"ip": ip_addr, "interface_id": interface_id})
+        return 1
+
+    monkeypatch.setattr(network, "rest_reconcile_async", fake_reconcile)
+    monkeypatch.setattr(network, "_reconcile_interface_ip", fake_ip)
+    return iface_ids, iface_calls, ip_calls
+
+
+async def test_sync_node_network_maps_types_enabled_and_topology(monkeypatch):
+    iface_ids, iface_calls, ip_calls = _install_mocks(monkeypatch)
+
+    await network.sync_node_network(
+        nb=object(), device={"id": 1}, network_entries=NETWORK, tag_refs=[]
+    )
+
+    # `lo` is skipped entirely.
+    assert "lo" not in iface_ids
+
+    # Phase-1 create payloads (first call per interface).
+    phase1 = {}
+    for c in iface_calls:
+        if c["patchable"] is None and c["name"] not in phase1:
+            phase1[c["name"]] = c["payload"]
+
+    # Type mapping: eth -> other, bridge -> bridge, vlan -> virtual.
+    assert phase1["eno1"]["type"] == "other"
+    assert phase1["vmbr0"]["type"] == "bridge"
+    assert phase1["vmbr1.200"]["type"] == "virtual"
+
+    # enabled reflects Proxmox `active`.
+    assert phase1["eno1"]["enabled"] is True
+    assert phase1["eno3"]["enabled"] is False
+
+    # Phase-2 topology patches (patchable_fields set).
+    patches = {c["name"]: c["payload"] for c in iface_calls if c["patchable"] is not None}
+
+    # Bridge membership: eno1 -> vmbr0, eno2 -> vmbr1.
+    assert patches["eno1"]["bridge"] == iface_ids["vmbr0"]
+    assert patches["eno2"]["bridge"] == iface_ids["vmbr1"]
+
+    # VLAN sub-interface: parent = raw device, tagged with its VLAN object.
+    assert patches["vmbr1.200"]["parent"] == iface_ids["vmbr1"]
+    assert patches["vmbr1.200"]["mode"] == "tagged"
+    assert patches["vmbr1.200"]["tagged_vlans"] == [900 + 200]
+
+    # IPs: both families on vmbr0, plus the VLAN sub-interface address.
+    by_iface = {}
+    for c in ip_calls:
+        by_iface.setdefault(c["interface_id"], []).append(c["ip"])
+    assert sorted(by_iface[iface_ids["vmbr0"]]) == ["141.94.139.106/24", "2001:41d0:403:4a6a::/64"]
+    assert by_iface[iface_ids["vmbr1.200"]] == ["10.16.200.3/24"]
+
+
+async def test_sync_node_network_skips_when_no_entries(monkeypatch):
+    _install_mocks(monkeypatch)
+    result = await network.sync_node_network(
+        nb=object(), device={"id": 1}, network_entries=[], tag_refs=[]
+    )
+    assert result == []

--- a/tests/test_node_network_sync.py
+++ b/tests/test_node_network_sync.py
@@ -23,6 +23,7 @@ NETWORK = [
         "cidr": "141.94.139.106/24",
         "gateway": "141.94.139.254",
         "cidr6": "2001:41d0:403:4a6a::/64",
+        "options": ["hwaddress a0:42:3f:4c:61:aa"],
     },
     {"iface": "vmbr1", "type": "bridge", "active": 1, "bridge_ports": "eno2"},
     {
@@ -61,13 +62,25 @@ def _install_mocks(monkeypatch):
         ip_calls.append({"ip": ip_addr, "interface_id": interface_id})
         return 1
 
+    mac_calls: list[dict] = []
+
+    async def fake_mac(nb, *, mac, assigned_object_type, assigned_object_id, **kw):
+        mac_calls.append(
+            {"mac": mac, "type": assigned_object_type, "interface_id": assigned_object_id}
+        )
+        return 1, "created"
+
     monkeypatch.setattr(network, "rest_reconcile_async", fake_reconcile)
     monkeypatch.setattr(network, "_reconcile_interface_ip", fake_ip)
-    return iface_ids, iface_calls, ip_calls
+    # sync_node_network imports these from mac_address at call time.
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.mac_address.reconcile_mac_for_interface", fake_mac
+    )
+    return iface_ids, iface_calls, ip_calls, mac_calls
 
 
 async def test_sync_node_network_maps_types_enabled_and_topology(monkeypatch):
-    iface_ids, iface_calls, ip_calls = _install_mocks(monkeypatch)
+    iface_ids, iface_calls, ip_calls, mac_calls = _install_mocks(monkeypatch)
 
     await network.sync_node_network(
         nb=object(), device={"id": 1}, network_entries=NETWORK, tag_refs=[]
@@ -109,6 +122,15 @@ async def test_sync_node_network_maps_types_enabled_and_topology(monkeypatch):
         by_iface.setdefault(c["interface_id"], []).append(c["ip"])
     assert sorted(by_iface[iface_ids["vmbr0"]]) == ["141.94.139.106/24", "2001:41d0:403:4a6a::/64"]
     assert by_iface[iface_ids["vmbr1.200"]] == ["10.16.200.3/24"]
+
+    # MAC: only the bridge with an `hwaddress` option gets one, normalized to
+    # NetBox canonical form and assigned to the dcim.interface.
+    assert len(mac_calls) == 1
+    assert mac_calls[0] == {
+        "mac": "A0:42:3F:4C:61:AA",
+        "type": "dcim.interface",
+        "interface_id": iface_ids["vmbr0"],
+    }
 
 
 async def test_sync_node_network_skips_when_no_entries(monkeypatch):

--- a/tests/test_node_network_sync.py
+++ b/tests/test_node_network_sync.py
@@ -116,11 +116,12 @@ async def test_sync_node_network_maps_types_enabled_and_topology(monkeypatch):
     assert patches["vmbr1.200"]["mode"] == "tagged"
     assert patches["vmbr1.200"]["tagged_vlans"] == [900 + 200]
 
-    # IPs: both families on vmbr0, plus the VLAN sub-interface address.
+    # IPs: vmbr0 gets its v4; the v6 (2001:...::/64) is a network ID and is
+    # skipped (NetBox won't assign it). VLAN sub-interface gets its address.
     by_iface = {}
     for c in ip_calls:
         by_iface.setdefault(c["interface_id"], []).append(c["ip"])
-    assert sorted(by_iface[iface_ids["vmbr0"]]) == ["141.94.139.106/24", "2001:41d0:403:4a6a::/64"]
+    assert by_iface[iface_ids["vmbr0"]] == ["141.94.139.106/24"]
     assert by_iface[iface_ids["vmbr1.200"]] == ["10.16.200.3/24"]
 
     # MAC: only the bridge with an `hwaddress` option gets one, normalized to
@@ -131,6 +132,20 @@ async def test_sync_node_network_maps_types_enabled_and_topology(monkeypatch):
         "type": "dcim.interface",
         "interface_id": iface_ids["vmbr0"],
     }
+
+
+def test_is_network_id():
+    # Subnet network addresses (host bits zero) are network IDs.
+    assert network._is_network_id("2001:41d0:403:4a6a::/64") is True
+    assert network._is_network_id("10.0.0.0/24") is True
+    # Real host addresses are not.
+    assert network._is_network_id("141.94.139.106/24") is False
+    assert network._is_network_id("10.16.200.3/24") is False
+    # Host-style prefixes are assignable even at the "network" address.
+    assert network._is_network_id("10.0.0.0/32") is False
+    assert network._is_network_id("10.0.0.0/31") is False
+    assert network._is_network_id("2001:db8::/128") is False
+    assert network._is_network_id("2001:db8::/127") is False
 
 
 async def test_sync_node_network_skips_when_no_entries(monkeypatch):

--- a/tests/test_node_network_sync.py
+++ b/tests/test_node_network_sync.py
@@ -89,11 +89,18 @@ async def test_sync_node_network_maps_types_enabled_and_topology(monkeypatch):
     # `lo` is skipped entirely.
     assert "lo" not in iface_ids
 
-    # Phase-1 create payloads (first call per interface).
+    # Phase-1 vs phase-2 calls carry disjoint patchable_fields whitelists:
+    # phase 1 owns the scalar fields (incl. `enabled`); phase 2 owns the
+    # topology cross-references. Detect phase 1 by its `enabled` whitelist entry.
+    def _is_phase1(call):
+        return call["patchable"] is not None and "enabled" in call["patchable"]
+
     phase1 = {}
+    phase1_patchable = {}
     for c in iface_calls:
-        if c["patchable"] is None and c["name"] not in phase1:
+        if _is_phase1(c) and c["name"] not in phase1:
             phase1[c["name"]] = c["payload"]
+            phase1_patchable[c["name"]] = c["patchable"]
 
     # Type mapping: eth -> other, bridge -> bridge, vlan -> virtual.
     assert phase1["eno1"]["type"] == "other"
@@ -104,8 +111,14 @@ async def test_sync_node_network_maps_types_enabled_and_topology(monkeypatch):
     assert phase1["eno1"]["enabled"] is True
     assert phase1["eno3"]["enabled"] is False
 
-    # Phase-2 topology patches (patchable_fields set).
-    patches = {c["name"]: c["payload"] for c in iface_calls if c["patchable"] is not None}
+    # Phase 1 must NEVER be allowed to touch topology / VLAN membership, or a
+    # re-sync would clear the VLANs that phase 2 assigns (the desired payload
+    # carries tagged_vlans=[] via the schema default). Its whitelist is scalar-only.
+    for name, patchable in phase1_patchable.items():
+        assert {"bridge", "lag", "parent", "mode", "tagged_vlans"}.isdisjoint(patchable), name
+
+    # Phase-2 topology patches (scalar `enabled` field absent from the whitelist).
+    patches = {c["name"]: c["payload"] for c in iface_calls if c["patchable"] and not _is_phase1(c)}
 
     # Bridge membership: eno1 -> vmbr0, eno2 -> vmbr1.
     assert patches["eno1"]["bridge"] == iface_ids["vmbr0"]


### PR DESCRIPTION
Implements the core of #243. **Draft** — engine + schema + tests are done and validated against a real node; wiring into the default sync flow + an opt-in flag are the remaining items (below).

## What this adds

**1. `sync_node_network()`** (`services/sync/network.py`) — reconciles a node's full `GET /nodes/{node}/network` into `dcim.Interface` records on the node device:
- physical NICs, bridges, bonds, VLAN sub-interfaces (loopback / OVS plumbing / aliases skipped)
- type mapping (`eth→other`, `bridge→bridge`, `bond→lag`, `vlan→virtual`)
- topology, two-phase so FKs resolve sibling ids: bridge membership (`bridge_ports`→`bridge`), bond membership (`bond_slaves`→`lag`), VLAN sub-interface `parent` + `mode=tagged` + a created NetBox VLAN object in `tagged_vlans`
- `enabled` from Proxmox `active`; IPs (v4 `cidr` + v6 `cidr6`), skipping subnet network-IDs (host bits zero) that NetBox refuses to assign
- **MAC**: bridges/bonds that carry an `hwaddress` option get a `dcim.MACAddress` + `primary_mac_address` (via the existing `reconcile_mac_for_interface`). Physical-NIC MACs are **not** in the network API (need `ethtool`/hardware-discovery) — noted follow-up.

Extends `NetBoxInterfaceSyncState` with `enabled`/`lag`/`parent`/`tagged_vlans`.

**2. IP adoption by host (`ip_ownership.py`)** — `_reconcile_interface_ip` looked up adoptable IPs by exact CIDR, so an existing record with a different mask (e.g. an operator-seeded `/32` vs a synced `/24`) was missed; `ENFORCE_GLOBAL_UNIQUE` then rejected the create and the address silently never attached. The lookup now matches by **host** (mask-agnostic), adopting the existing record and normalizing its mask. The no-steal guarantee is preserved (only *unassigned* records are adopted). This is shared with VM-interface IP sync.

## Verified live (Proxmox VE 8.4)

Ran against a real node end-to-end:
- All 7 interfaces created with correct types, `enabled`, and topology (`eno1→vmbr0`, `eno2→vmbr1`, `vmbr1.200` `parent=vmbr1` `mode=tagged` vid 200, "VLAN 200" created).
- The node's public IP — pre-existing in NetBox as an unassigned `/32` — was **adopted onto `vmbr0` and normalized to `/24`** (not duplicated).
- `vmbr0` got its `hwaddress` MAC `a0:42:3f:4c:61:aa` as primary.
- The node's v6 (reported as the `::/64` base) was skipped as a network ID — the final run completed with **zero warnings**.

## Tests

`tests/test_node_network_sync.py` (types/enabled/topology/tagged-VLAN/IPs/MAC, mocked), `tests/test_ip_adopt_by_host.py` (adopt `/32`→`/24`; never adopt foreign-owned), plus the existing IP-ownership tests updated to the host-based lookup. `ruff`/`ty` clean (no new diagnostics in gated paths). Full IP/interface/network subset: green.

## Open items

1. **Wiring** behind an opt-in flag (e.g. `sync_node_interfaces`) into the node-sync path — needs your call on flag naming + the SDK network-model field shape.
2. **Physical-NIC MACs** via the `hardware_discovery`/ethtool path (not exposed by the network API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
