### PR TITLE
feat: sync Proxmox SDN into NetBox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,15 @@ PROXBOX_RECONCILIATION_ENGINE=compare \
   uv run pytest tests/reconciliation -q
 ```
 
-If you edit `proxmox-mock/` (the local `proxmox-mock-api` dev package), run its own tests inside that directory. Note: `proxmox-sdk` is an **external pinned package** (`proxmox-sdk==0.0.11.post2`); there is no local `proxmox-sdk/` subdirectory in this repo.
+If you edit `proxmox-mock/` (the local `proxmox-mock-api` dev package), run its own tests inside that directory. Note: `proxmox-sdk` is an **external pinned package** (`proxmox-sdk==0.0.12`); there is no local `proxmox-sdk/` subdirectory in this repo.
+
+SDN support lives in `proxbox_api/routes/proxmox/sdn.py` and
+`proxbox_api/services/sync/sdn.py`. Keep it read-only against Proxmox: the
+`GET /proxmox/sdn/create/stream` stage may reconcile NetBox L2VPN,
+L2VPNTermination, RouteTarget, Prefix, and plugin metadata objects, but it must
+not apply, rollback, lock, or mutate Proxmox SDN configuration. Unsupported
+older clusters should emit skipped warnings rather than failing healthy
+endpoints.
 
 If you edit `nextjs-ui/`, also run:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Submodule layout and cross-repo links: `/root/personal-context/claude-reference/
 
 - **`netbox-proxbox` v0.0.20.post1** — the NetBox plugin that consumes this backend.
   Source: <https://github.com/emersonfelipesp/netbox-proxbox>. The current
-  pairing is `netbox-proxbox 0.0.20.post1` ↔ `proxbox-api 0.0.17.post2` ↔ `proxmox-sdk 0.0.11.post2`
+  pairing is `netbox-proxbox 0.0.20.post1` ↔ `proxbox-api 0.0.17.post2` ↔ `proxmox-sdk 0.0.12`
   ↔ `netbox-sdk 0.0.9.post2`. Operational-verb routes (start/stop/snapshot/migrate)
   require `proxbox-api >= 0.0.17`; firewall model scaffolding and intent tag
   helpers require `>= 0.0.13`; HA tab and runtime tunables alone require `>= 0.0.11`.
@@ -110,7 +110,7 @@ Open the nearest scoped guide for the code you are changing.
 
 - `proxbox_api/`: FastAPI package, session factories, schemas, routes, sync services, code generation, and shared utilities.
 - `proxbox-reconcile-rs/`: optional PyO3/maturin Rust package for VM operation-queue reconciliation parity testing and opt-in execution.
-- `proxmox-mock/`: Standalone `proxmox-mock-api` dev-dependency package (editable install from `pyproject.toml` `[tool.uv.sources]`). Used in tests as the mock Proxmox server. Note: `proxmox-sdk` is an **external pinned package** (`proxmox-sdk==0.0.11.post2` in `pyproject.toml`), not a local subdirectory.
+- `proxmox-mock/`: Standalone `proxmox-mock-api` dev-dependency package (editable install from `pyproject.toml` `[tool.uv.sources]`). Used in tests as the mock Proxmox server. Note: `proxmox-sdk` is an **external pinned package** (`proxmox-sdk==0.0.12` in `pyproject.toml`), not a local subdirectory.
 - `nextjs-ui/`: Next.js frontend used to manage one NetBox endpoint and multiple Proxmox endpoints.
 - `tests/`: Unit, integration, and end-to-end tests for the backend package.
 - `benchmarks/`: local benchmark helpers, including VM reconciliation queue datasets and timers.
@@ -173,7 +173,7 @@ Key route groups mounted in `proxbox_api/app/factory.py`:
 - **Proxmox operational verbs** (`proxbox_api/routes/proxmox_actions.py`, mounted at `/proxmox`): start, stop, snapshot, migrate, reboot, delete, backup, and snapshot-delete for QEMU and LXC guests. All gated by `ProxmoxEndpoint.allow_writes`.
 - **High-Availability** (`routes/proxmox/ha.py`, `/proxmox/cluster/ha/*`): status, resources, groups, rules, summary, disarm, arm, manager-status, CRS config.
 - **Firewall** (`routes/proxmox/firewall.py`, `/proxmox/firewall/*`): datacenter, node, and VM-level rules, security groups, IP sets, aliases, and options. Write endpoints gated by `allow_writes`.
-- **SDN** (`routes/proxmox/sdn.py`, `/proxmox/sdn/*`): fabrics, fabrics/all, route-maps, prefix-lists (PVE 9.2+; returns 501 on older).
+- **SDN** (`routes/proxmox/sdn.py`, `/proxmox/sdn/*`): controllers, zones, VNets, VNet subnets, fabrics, route-maps, prefix-lists, node runtime rows, and read-only `create/stream` NetBox reconciliation. Unsupported older clusters are skipped with warnings instead of failing the stream.
 - **Datacenter** (`routes/proxmox/datacenter.py`, `/proxmox/datacenter/*`): custom CPU models CRUD + datacenter options (PVE 9.2+).
 - **Access** (`routes/proxmox/access.py`, `/proxmox/access/*`): token info GET and token regeneration PUT (PVE 9.2+).
 - **Cloud** (`routes/cloud/`, `/cloud/*`): live QEMU Cloud-Init template discovery (`GET /cloud/vm/templates`), image factory, PVE templates, catalog, provision (REST + SSE stream), Firecracker provision (REST + SSE stream), versions, the **Cloud Image Build Pipeline** (`POST /cloud/templates/images`): bakes a Proxmox VM template from a base image + a verbatim `user_data_yaml` `#cloud-config` written as a `cicustom` user-data snippet (the only mechanism that runs a full `#cloud-config` at first boot), and the **Azure VHD Import Pipeline** (`POST /cloud/azure/vhd-imports`): preflights the destination node/storage/bridge/VMID, downloads an Azure-exported VHD, validates and converts it to QCOW2, creates the VM shell, imports the disk, and attaches the imported volid parsed from `qm importdisk` output with Linux or Windows-safe defaults. QEMU provisioning accepts optional `sockets`, `bridge`, `vlan_tag`, and `disk_gb` overrides and applies them through the Proxmox API during clone configuration. The Cloud Image Build Pipeline SSH execution path sets `qm ... --agent enabled=1` before templating so clones inherit Proxmox-side QEMU guest agent support. Execution remains gated by `PROXBOX_ENABLE_CLOUD_IMAGE_EXECUTION=true`; SSH identities stay restricted to `PROXBOX_SSH_KEY_DIR`; the runtime image bakes in `openssh-client`. Called by `netbox-packer` (cloud_config installer) and the NMS route `/cloud/azure-to-nmulticloud-migration`. See `routes/cloud/CLAUDE.md`.
@@ -249,7 +249,7 @@ while the Docker container is healthy on port `18800`.
 
 ## Dependencies
 
-- Runtime: `fastapi[standard]`, `proxmox-sdk==0.0.11.post2` (external PyPI package), `netbox-sdk==0.0.9.post1` (external PyPI package), `sqlmodel`, `aiosqlite`, `cryptography`, `bcrypt`, `asyncssh>=2.20.0,<3.0.0`
+- Runtime: `fastapi[standard]`, `proxmox-sdk==0.0.12` (external PyPI package), `netbox-sdk==0.0.9.post1` (external PyPI package), `sqlmodel`, `aiosqlite`, `cryptography`, `bcrypt`, `asyncssh>=2.20.0,<3.0.0`
 - Tests: `pytest`, `httpx`, `playwright`, `pytest-cov`, `pytest-asyncio`, `pytest-xdist`
 - Docs: `mkdocs`, `mkdocs-material`, `mkdocs-static-i18n`
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - **Bottom — downstream SDKs**:
   - **Write target** — `netbox-sdk` → `netbox · REST API` (4.5.x / 4.6.x). Async with a
     cached GET layer (60s TTL); concurrency capped by `PROXBOX_NETBOX_MAX_CONCURRENT`.
-  - **Read source** — `proxmox-sdk` → `proxmox · REST API` (8.1 / 8.2 / 8.3 / latest, per `SUPPORTED_PROXMOX_VERSIONS` in `proxbox_api/constants.py`). PVE 9.x route groups (HA rules, firewall writes, SDN fabrics, datacenter CPU models, access token regeneration, CRS config) are implemented and degrade gracefully on older clusters. Async, read-only for discovery, `mock | real` modes; concurrency capped by `PROXBOX_VM_SYNC_MAX_CONCURRENCY`.
+  - **Read source** — `proxmox-sdk` → `proxmox · REST API` (8.1 / 8.2 / 8.3 / latest, per `SUPPORTED_PROXMOX_VERSIONS` in `proxbox_api/constants.py`). PVE 9.x route groups (HA rules, firewall writes, SDN controllers/zones/VNets/subnets/fabrics, datacenter CPU models, access token regeneration, CRS config) are implemented and degrade gracefully on older clusters. Async, read-only for discovery, `mock | real` modes; concurrency capped by `PROXBOX_VM_SYNC_MAX_CONCURRENCY`.
   - **Firecracker host-agent** — `/cloud/firecracker/provision` and
     `/cloud/firecracker/provision/stream` call the selected host-agent VM to
     health-check KVM, read capacity, prepare kernel/rootfs assets, create the

--- a/docs/api/http-reference.md
+++ b/docs/api/http-reference.md
@@ -303,12 +303,18 @@ Implemented in `proxbox_api/routes/proxmox/firewall.py`. All read endpoints are 
 
 ### SDN (read-only, PVE 9.2+)
 
-Implemented in `proxbox_api/routes/proxmox/sdn.py`. All endpoints are read-only. Returns 501 (caught and skipped) on PVE < 9.2 clusters; healthy clusters still contribute their rows.
+Implemented in `proxbox_api/routes/proxmox/sdn.py`. All endpoints are read-only. Older clusters that do not expose a path are counted as skipped warnings; healthy clusters still contribute their rows.
 
+- `GET /proxmox/sdn/controllers` — List SDN controllers across all clusters. Returns `list[SdnControllerSchema]`.
+- `GET /proxmox/sdn/zones` — List SDN zones across all clusters. Returns `list[SdnZoneSchema]`.
+- `GET /proxmox/sdn/vnets` — List SDN VNets across all clusters. Returns `list[SdnVNetSchema]`.
+- `GET /proxmox/sdn/subnets` — List SDN VNet subnets across all clusters. Returns `list[SdnSubnetSchema]`.
 - `GET /proxmox/sdn/fabrics` — List SDN fabrics (WireGuard/BGP/VXLAN/OSPF) across all clusters. Returns `list[SdnFabricSchema]`.
 - `GET /proxmox/sdn/fabrics/all` — List all SDN fabrics including inherited ones across all clusters. Returns `list[SdnFabricSchema]`.
 - `GET /proxmox/sdn/route-maps` — List SDN route-map objects (BGP/EVPN route filtering) across all clusters. Returns `list[SdnRouteMapSchema]`.
 - `GET /proxmox/sdn/prefix-lists` — List SDN prefix-list objects (CIDR ranges for BGP/EVPN filtering) across all clusters. Returns `list[SdnPrefixListSchema]`.
+- `GET /proxmox/sdn/node-status` — List node-local zone content, bridge, MAC-VRF, and IP-VRF rows. Returns `list[SdnNodeStatusSchema]`.
+- `GET /proxmox/sdn/create/stream` — Server-Sent Events stage that reconciles read-only SDN state into NetBox: EVPN/VXLAN VNets to `vpn.L2VPN`, resolvable runtime targets to `vpn.L2VPNTermination`, EVPN import route targets to `ipam.RouteTarget`, valid subnets to `ipam.Prefix`, and all Proxmox-specific SDN rows to `netbox-proxbox` plugin metadata.
 
 ### Datacenter (PVE 9.2+)
 

--- a/docs/sync/workflows.md
+++ b/docs/sync/workflows.md
@@ -247,6 +247,31 @@ Core behavior:
 - Discovers Proxmox storage definitions.
 - Reconciles NetBox plugin storage records used by backup and snapshot flows.
 
+## SDN Sync Flow
+
+Endpoint:
+
+- `GET /proxmox/sdn/create/stream`
+
+Core behavior:
+
+- Reads Proxmox SDN controllers, zones, VNets, VNet subnets, fabrics, route
+  maps, prefix lists, node zone content, bridges, MAC-VRF, and IP-VRF rows.
+- Maps EVPN and VXLAN VNets into NetBox `vpn.L2VPN` records. EVPN
+  `rt-import` values are reconciled as `ipam.RouteTarget` import targets.
+- Maps valid SDN subnet CIDRs into NetBox `ipam.Prefix` records.
+- Creates `vpn.L2VPNTermination` records only when runtime rows expose an
+  explicit NetBox target or an unambiguous VLAN id. Existing terminations for a
+  different L2VPN are left untouched and recorded as binding conflicts.
+- Stores Proxmox-specific SDN metadata and raw payloads in `netbox-proxbox`
+  plugin inventory endpoints.
+- Treats missing or unsupported SDN Proxmox API paths as skipped warnings so
+  older clusters do not fail the sync stream.
+
+The route never writes SDN configuration back to Proxmox. It is intended to be
+called by the NetBox plugin's optional `sdn` stage after VM interface and IP
+address stages have already run.
+
 ## SSE Streaming Mode
 
 Each sync flow has a corresponding `/stream` endpoint that emits Server-Sent Events in real time:
@@ -254,6 +279,7 @@ Each sync flow has a corresponding `/stream` endpoint that emits Server-Sent Eve
 - `GET /full-update/stream`
 - `GET /dcim/devices/create/stream`
 - `GET /virtualization/virtual-machines/create/stream`
+- `GET /proxmox/sdn/create/stream`
 
 How it works:
 

--- a/proxbox_api/routes/proxmox/sdn.py
+++ b/proxbox_api/routes/proxmox/sdn.py
@@ -1,229 +1,214 @@
-"""Proxmox SDN (Software Defined Networking) endpoints (read-only).
-
-Surfaces PVE 9.2 SDN fabric, route-map, and prefix-list objects
-so operators can inspect WireGuard/BGP fabrics and their routing policy
-objects without leaving the Proxbox API surface.
-
-All endpoints are read-only.  SDN mutations require cluster-level
-access and remain intentionally out of scope for this proxy layer.
-"""
+"""Proxmox SDN read-only endpoints and sync stream."""
 
 from __future__ import annotations
 
+import asyncio
+
 from fastapi import APIRouter
+from fastapi.responses import StreamingResponse
 from proxmox_sdk.sdk.exceptions import ResourceException
-from pydantic import BaseModel
 
 from proxbox_api.logger import logger
 from proxbox_api.proxmox_async import resolve_async
+from proxbox_api.services.sync.sdn import (
+    SdnControllerSchema,
+    SdnFabricSchema,
+    SdnNodeStatusSchema,
+    SdnPrefixListSchema,
+    SdnRouteMapSchema,
+    SdnSubnetSchema,
+    SdnVNetSchema,
+    SdnZoneSchema,
+    _to_fabric,
+    _to_prefix_list,
+    _to_route_map,
+    collect_sdn_inventory,
+    sync_sdn_to_netbox,
+)
+from proxbox_api.session.netbox import NetBoxSessionDep
 from proxbox_api.session.proxmox import ProxmoxSessionsDep
+from proxbox_api.utils.streaming import WebSocketSSEBridge, sse_stream_generator
 
 router = APIRouter()
 
 
-class SdnFabricSchema(BaseModel):
-    """A single SDN fabric object."""
-
-    cluster_name: str | None = None
-    fabric: str | None = None
-    type: str | None = None
-    advertise_subnets: bool | None = None
-    disable_arp_nd_suppression: bool | None = None
-    vrf_vxlan: int | None = None
-    peers: str | None = None
-    asn: int | None = None
-    status: str = "ok"
-    error: str | None = None
+def _rows(raw: object) -> list[object]:
+    if isinstance(raw, list):
+        return raw
+    if hasattr(raw, "root"):
+        root = getattr(raw, "root")
+        return root if isinstance(root, list) else [root]
+    return [raw]
 
 
-class SdnRouteMapSchema(BaseModel):
-    """A single SDN route-map entry."""
-
-    cluster_name: str | None = None
-    name: str | None = None
-    action: str | None = None
-    match_peer: str | None = None
-    match_ip: str | None = None
-    set_community: str | None = None
-    order: int | None = None
-    status: str = "ok"
-    error: str | None = None
-
-
-class SdnPrefixListSchema(BaseModel):
-    """A single SDN prefix-list entry."""
-
-    cluster_name: str | None = None
-    name: str | None = None
-    cidr: str | None = None
-    action: str | None = None
-    le: int | None = None
-    ge: int | None = None
-    status: str = "ok"
-    error: str | None = None
-
-
-def _to_fabric(cluster_name: str, raw: object) -> SdnFabricSchema:
-    data: dict[str, object] = {}
-    if hasattr(raw, "model_dump"):
-        data = raw.model_dump(mode="python", by_alias=True, exclude_none=True)
-    elif isinstance(raw, dict):
-        data = dict(raw)
-    return SdnFabricSchema(
-        cluster_name=cluster_name,
-        fabric=str(data.get("fabric")) if data.get("fabric") is not None else None,
-        type=str(data.get("type")) if data.get("type") is not None else None,
-        advertise_subnets=bool(data.get("advertise_subnets"))
-        if "advertise_subnets" in data
-        else None,
-        disable_arp_nd_suppression=bool(data.get("disable_arp_nd_suppression"))
-        if "disable_arp_nd_suppression" in data
-        else None,
-        vrf_vxlan=int(data["vrf_vxlan"]) if isinstance(data.get("vrf_vxlan"), (int, str)) else None,
-        asn=int(data["asn"]) if isinstance(data.get("asn"), (int, str)) else None,
-        peers=str(data.get("peers")) if data.get("peers") is not None else None,
-    )
+async def _collect_legacy_sdn_path(
+    pxs: list[object],
+    *,
+    path: str,
+    mapper,
+    error_factory,
+) -> list[object]:
+    results: list[object] = []
+    for px in pxs:
+        cluster_name = getattr(px, "name", None)
+        try:
+            raw = await resolve_async(px.session(path).get())
+            for row in _rows(raw):
+                results.append(mapper(cluster_name, row))
+        except Exception as exc:  # noqa: BLE001
+            if isinstance(exc, ResourceException) and exc.status_code == 501:
+                logger.warning(
+                    "Cluster %s does not support /%s (PVE < 9.2) — skipping",
+                    cluster_name,
+                    path,
+                )
+                continue
+            logger.exception(
+                "Error fetching SDN path /%s for Proxmox cluster %s", path, cluster_name
+            )
+            results.append(error_factory(cluster_name, str(exc)))
+    return results
 
 
-def _to_route_map(cluster_name: str, raw: object) -> SdnRouteMapSchema:
-    data: dict[str, object] = {}
-    if hasattr(raw, "model_dump"):
-        data = raw.model_dump(mode="python", by_alias=True, exclude_none=True)
-    elif isinstance(raw, dict):
-        data = dict(raw)
-    return SdnRouteMapSchema(
-        cluster_name=cluster_name,
-        name=str(data.get("name")) if data.get("name") is not None else None,
-        action=str(data.get("action")) if data.get("action") is not None else None,
-        match_peer=str(data.get("match-peer") or data.get("match_peer"))
-        if (data.get("match-peer") or data.get("match_peer")) is not None
-        else None,
-        match_ip=str(data.get("match-ip") or data.get("match_ip"))
-        if (data.get("match-ip") or data.get("match_ip")) is not None
-        else None,
-        set_community=str(data.get("set-community") or data.get("set_community"))
-        if (data.get("set-community") or data.get("set_community")) is not None
-        else None,
-        order=int(data["order"]) if isinstance(data.get("order"), (int, str)) else None,
-    )
+@router.get("/sdn/controllers", response_model=list[SdnControllerSchema])
+async def sdn_controllers(pxs: ProxmoxSessionsDep) -> list[SdnControllerSchema]:
+    """List SDN controllers across configured Proxmox endpoints."""
+
+    inventories = await collect_sdn_inventory(pxs, include_node_runtime=False)
+    return [item for inventory in inventories for item in inventory.controllers]
 
 
-def _to_prefix_list(cluster_name: str, raw: object) -> SdnPrefixListSchema:
-    data: dict[str, object] = {}
-    if hasattr(raw, "model_dump"):
-        data = raw.model_dump(mode="python", by_alias=True, exclude_none=True)
-    elif isinstance(raw, dict):
-        data = dict(raw)
-    return SdnPrefixListSchema(
-        cluster_name=cluster_name,
-        name=str(data.get("name")) if data.get("name") is not None else None,
-        cidr=str(data.get("cidr")) if data.get("cidr") is not None else None,
-        action=str(data.get("action")) if data.get("action") is not None else None,
-        le=int(data["le"]) if isinstance(data.get("le"), (int, str)) else None,
-        ge=int(data["ge"]) if isinstance(data.get("ge"), (int, str)) else None,
-    )
+@router.get("/sdn/zones", response_model=list[SdnZoneSchema])
+async def sdn_zones(pxs: ProxmoxSessionsDep) -> list[SdnZoneSchema]:
+    """List SDN zones across configured Proxmox endpoints."""
+
+    inventories = await collect_sdn_inventory(pxs, include_node_runtime=False)
+    return [item for inventory in inventories for item in inventory.zones]
+
+
+@router.get("/sdn/vnets", response_model=list[SdnVNetSchema])
+async def sdn_vnets(pxs: ProxmoxSessionsDep) -> list[SdnVNetSchema]:
+    """List SDN VNets across configured Proxmox endpoints."""
+
+    inventories = await collect_sdn_inventory(pxs, include_node_runtime=False)
+    return [item for inventory in inventories for item in inventory.vnets]
+
+
+@router.get("/sdn/subnets", response_model=list[SdnSubnetSchema])
+async def sdn_subnets(pxs: ProxmoxSessionsDep) -> list[SdnSubnetSchema]:
+    """List SDN VNet subnets across configured Proxmox endpoints."""
+
+    inventories = await collect_sdn_inventory(pxs, include_node_runtime=False)
+    return [item for inventory in inventories for item in inventory.subnets]
 
 
 @router.get("/sdn/fabrics", response_model=list[SdnFabricSchema])
 async def sdn_fabrics(pxs: ProxmoxSessionsDep) -> list[SdnFabricSchema]:
-    """List SDN fabrics across all configured Proxmox clusters (PVE 9.2+).
+    """List SDN fabrics across configured Proxmox endpoints."""
 
-    Proxies ``GET /cluster/sdn/fabrics``.  Returns WireGuard and BGP
-    fabric objects (and any pre-existing VXLAN/OSPF fabrics).
-    """
-    results: list[SdnFabricSchema] = []
-    for px in pxs:
-        try:
-            raw = await resolve_async(px.session("cluster/sdn/fabrics").get())
-            rows = raw if isinstance(raw, list) else (raw.root if hasattr(raw, "root") else [raw])
-            for row in rows:
-                results.append(_to_fabric(px.name, row))
-        except Exception as exc:  # noqa: BLE001
-            if isinstance(exc, ResourceException) and exc.status_code == 501:
-                logger.warning(
-                    "Cluster %s does not support /cluster/sdn/fabrics (PVE < 9.2) — skipping",
-                    px.name,
-                )
-                continue
-            logger.exception("Error fetching SDN fabrics for Proxmox cluster %s", px.name)
-            results.append(SdnFabricSchema(cluster_name=px.name, status="error", error=str(exc)))
-    return results
+    return await _collect_legacy_sdn_path(
+        pxs,
+        path="cluster/sdn/fabrics",
+        mapper=_to_fabric,
+        error_factory=lambda cluster, error: SdnFabricSchema(
+            cluster_name=cluster,
+            status="error",
+            error=error,
+        ),
+    )
 
 
 @router.get("/sdn/fabrics/all", response_model=list[SdnFabricSchema])
 async def sdn_fabrics_all(pxs: ProxmoxSessionsDep) -> list[SdnFabricSchema]:
-    """List all SDN fabrics (including inherited) across all clusters (PVE 9.2+).
+    """List all SDN fabrics across configured Proxmox endpoints."""
 
-    Proxies ``GET /cluster/sdn/fabrics/all``.
-    """
-    results: list[SdnFabricSchema] = []
-    for px in pxs:
-        try:
-            raw = await resolve_async(px.session("cluster/sdn/fabrics/all").get())
-            rows = raw if isinstance(raw, list) else (raw.root if hasattr(raw, "root") else [raw])
-            for row in rows:
-                results.append(_to_fabric(px.name, row))
-        except Exception as exc:  # noqa: BLE001
-            if isinstance(exc, ResourceException) and exc.status_code == 501:
-                logger.warning(
-                    "Cluster %s does not support /cluster/sdn/fabrics/all (PVE < 9.2) — skipping",
-                    px.name,
-                )
-                continue
-            logger.exception("Error fetching all SDN fabrics for Proxmox cluster %s", px.name)
-            results.append(SdnFabricSchema(cluster_name=px.name, status="error", error=str(exc)))
-    return results
+    return await _collect_legacy_sdn_path(
+        pxs,
+        path="cluster/sdn/fabrics/all",
+        mapper=_to_fabric,
+        error_factory=lambda cluster, error: SdnFabricSchema(
+            cluster_name=cluster,
+            status="error",
+            error=error,
+        ),
+    )
 
 
 @router.get("/sdn/route-maps", response_model=list[SdnRouteMapSchema])
 async def sdn_route_maps(pxs: ProxmoxSessionsDep) -> list[SdnRouteMapSchema]:
-    """List SDN route-map objects across all clusters (PVE 9.2+).
+    """List SDN route-map objects across configured Proxmox endpoints."""
 
-    Proxies ``GET /cluster/sdn/route-maps``.  Route maps allow
-    fine-grained BGP/EVPN route filtering for SDN BGP fabric protocols.
-    """
-    results: list[SdnRouteMapSchema] = []
-    for px in pxs:
-        try:
-            raw = await resolve_async(px.session("cluster/sdn/route-maps").get())
-            rows = raw if isinstance(raw, list) else (raw.root if hasattr(raw, "root") else [raw])
-            for row in rows:
-                results.append(_to_route_map(px.name, row))
-        except Exception as exc:  # noqa: BLE001
-            if isinstance(exc, ResourceException) and exc.status_code == 501:
-                logger.warning(
-                    "Cluster %s does not support /cluster/sdn/route-maps (PVE < 9.2) — skipping",
-                    px.name,
-                )
-                continue
-            logger.exception("Error fetching SDN route-maps for Proxmox cluster %s", px.name)
-            results.append(SdnRouteMapSchema(cluster_name=px.name, status="error", error=str(exc)))
-    return results
+    return await _collect_legacy_sdn_path(
+        pxs,
+        path="cluster/sdn/route-maps",
+        mapper=_to_route_map,
+        error_factory=lambda cluster, error: SdnRouteMapSchema(
+            cluster_name=cluster,
+            status="error",
+            error=error,
+        ),
+    )
 
 
 @router.get("/sdn/prefix-lists", response_model=list[SdnPrefixListSchema])
 async def sdn_prefix_lists(pxs: ProxmoxSessionsDep) -> list[SdnPrefixListSchema]:
-    """List SDN prefix-list objects across all clusters (PVE 9.2+).
+    """List SDN prefix-list objects across configured Proxmox endpoints."""
 
-    Proxies ``GET /cluster/sdn/prefix-lists``.  Prefix lists define
-    CIDR ranges used by route maps for BGP/EVPN route filtering.
-    """
-    results: list[SdnPrefixListSchema] = []
-    for px in pxs:
-        try:
-            raw = await resolve_async(px.session("cluster/sdn/prefix-lists").get())
-            rows = raw if isinstance(raw, list) else (raw.root if hasattr(raw, "root") else [raw])
-            for row in rows:
-                results.append(_to_prefix_list(px.name, row))
-        except Exception as exc:  # noqa: BLE001
-            if isinstance(exc, ResourceException) and exc.status_code == 501:
-                logger.warning(
-                    "Cluster %s does not support /cluster/sdn/prefix-lists (PVE < 9.2) — skipping",
-                    px.name,
+    return await _collect_legacy_sdn_path(
+        pxs,
+        path="cluster/sdn/prefix-lists",
+        mapper=_to_prefix_list,
+        error_factory=lambda cluster, error: SdnPrefixListSchema(
+            cluster_name=cluster,
+            status="error",
+            error=error,
+        ),
+    )
+
+
+@router.get("/sdn/node-status", response_model=list[SdnNodeStatusSchema])
+async def sdn_node_status(pxs: ProxmoxSessionsDep) -> list[SdnNodeStatusSchema]:
+    """List node-local SDN runtime content, bridges, MAC-VRF, and IP-VRF rows."""
+
+    inventories = await collect_sdn_inventory(pxs, include_node_runtime=True)
+    return [item for inventory in inventories for item in inventory.node_status]
+
+
+@router.get("/sdn/create/stream", response_model=None)
+async def create_sdn_stream(
+    netbox_session: NetBoxSessionDep,
+    pxs: ProxmoxSessionsDep,
+):
+    """Stream read-only Proxmox SDN sync progress into NetBox."""
+
+    async def event_stream():
+        bridge = WebSocketSSEBridge()
+
+        async def _run_sync():
+            try:
+                return await sync_sdn_to_netbox(
+                    netbox_session=netbox_session,
+                    pxs=pxs,
+                    websocket=bridge,
+                    use_websocket=True,
                 )
-                continue
-            logger.exception("Error fetching SDN prefix-lists for Proxmox cluster %s", px.name)
-            results.append(
-                SdnPrefixListSchema(cluster_name=px.name, status="error", error=str(exc))
-            )
-    return results
+            finally:
+                await bridge.close()
+
+        sync_task = asyncio.create_task(_run_sync())
+        async for frame in sse_stream_generator(
+            bridge,
+            sync_task,
+            "sdn",
+            result_extractor=lambda result: result if isinstance(result, dict) else {},
+        ):
+            yield frame
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/proxbox_api/services/sync/sdn.py
+++ b/proxbox_api/services/sync/sdn.py
@@ -1,0 +1,1629 @@
+"""Read-only Proxmox SDN inventory and NetBox reconciliation."""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from proxmox_sdk.sdk.exceptions import ResourceException
+from pydantic import BaseModel, ConfigDict, Field
+
+from proxbox_api.logger import logger
+from proxbox_api.netbox_rest import rest_first_async, rest_reconcile_async_with_status
+from proxbox_api.proxmox_async import resolve_async
+from proxbox_api.services.sync.backup_routines import _get_netbox_endpoint_id
+
+if TYPE_CHECKING:
+    from proxbox_api.utils.streaming import WebSocketSSEBridge
+
+
+_UNSUPPORTED_STATUS_CODES = {404, 501}
+_SLUG_FRAGMENT_RE = re.compile(r"[^a-z0-9]+")
+_MANAGED_L2VPN_TYPES = {"evpn": "vxlan-evpn", "vxlan": "vxlan"}
+_TERMINATION_TARGET_TYPES = {"virtualization.vminterface", "dcim.interface", "ipam.vlan"}
+
+
+class _SdnSchema(BaseModel):
+    """Base schema for lenient SDN API payloads."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+
+class SdnFabricSchema(_SdnSchema):
+    """A single SDN fabric object."""
+
+    endpoint_id: int | None = None
+    cluster_name: str | None = None
+    fabric: str | None = None
+    type: str | None = None
+    advertise_subnets: bool | None = None
+    disable_arp_nd_suppression: bool | None = None
+    vrf_vxlan: int | None = None
+    peers: str | None = None
+    asn: int | None = None
+    status: str = "ok"
+    error: str | None = None
+    raw_config: dict[str, object] = Field(default_factory=dict)
+
+
+class SdnRouteMapSchema(_SdnSchema):
+    """A single SDN route-map entry."""
+
+    endpoint_id: int | None = None
+    cluster_name: str | None = None
+    name: str | None = None
+    action: str | None = None
+    match_peer: str | None = None
+    match_ip: str | None = None
+    set_community: str | None = None
+    order: int | None = None
+    status: str = "ok"
+    error: str | None = None
+    raw_config: dict[str, object] = Field(default_factory=dict)
+
+
+class SdnPrefixListSchema(_SdnSchema):
+    """A single SDN prefix-list entry."""
+
+    endpoint_id: int | None = None
+    cluster_name: str | None = None
+    name: str | None = None
+    cidr: str | None = None
+    action: str | None = None
+    le: int | None = None
+    ge: int | None = None
+    status: str = "ok"
+    error: str | None = None
+    raw_config: dict[str, object] = Field(default_factory=dict)
+
+
+class SdnControllerSchema(_SdnSchema):
+    """A single Proxmox SDN controller object."""
+
+    endpoint_id: int | None = None
+    cluster_name: str | None = None
+    controller: str | None = None
+    type: str | None = None
+    asn: int | None = None
+    peers: str | None = None
+    node: str | None = None
+    loopback: str | None = None
+    state: str | None = None
+    status: str = "ok"
+    error: str | None = None
+    raw_config: dict[str, object] = Field(default_factory=dict)
+
+
+class SdnZoneSchema(_SdnSchema):
+    """A single Proxmox SDN zone object."""
+
+    endpoint_id: int | None = None
+    cluster_name: str | None = None
+    zone: str | None = None
+    type: str | None = None
+    controller: str | None = None
+    vrf_vxlan: int | None = None
+    tag: int | None = None
+    mtu: int | None = None
+    dns: str | None = None
+    ipam: str | None = None
+    rt_import: str | None = None
+    state: str | None = None
+    pending: dict[str, object] | None = None
+    status: str = "ok"
+    error: str | None = None
+    raw_config: dict[str, object] = Field(default_factory=dict)
+
+
+class SdnVNetSchema(_SdnSchema):
+    """A single Proxmox SDN VNet object."""
+
+    endpoint_id: int | None = None
+    cluster_name: str | None = None
+    vnet: str | None = None
+    zone: str | None = None
+    type: str | None = None
+    tag: int | None = None
+    alias: str | None = None
+    vlanaware: bool | None = None
+    state: str | None = None
+    pending: dict[str, object] | None = None
+    status: str = "ok"
+    error: str | None = None
+    raw_config: dict[str, object] = Field(default_factory=dict)
+
+
+class SdnSubnetSchema(_SdnSchema):
+    """A single Proxmox SDN VNet subnet object."""
+
+    endpoint_id: int | None = None
+    cluster_name: str | None = None
+    vnet: str | None = None
+    zone: str | None = None
+    subnet: str | None = None
+    type: str | None = None
+    gateway: str | None = None
+    snat: bool | None = None
+    status: str = "ok"
+    error: str | None = None
+    raw_config: dict[str, object] = Field(default_factory=dict)
+
+
+class SdnNodeStatusSchema(_SdnSchema):
+    """Node-local SDN status, bridge, MAC-VRF, or IP-VRF row."""
+
+    endpoint_id: int | None = None
+    cluster_name: str | None = None
+    node: str | None = None
+    zone: str | None = None
+    vnet: str | None = None
+    kind: str
+    name: str | None = None
+    status: str = "ok"
+    error: str | None = None
+    raw_config: dict[str, object] = Field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class SdnInventory:
+    """Collected Proxmox SDN inventory for one endpoint."""
+
+    endpoint_id: int | None
+    endpoint_name: str
+    cluster_name: str
+    controllers: list[SdnControllerSchema] = field(default_factory=list)
+    zones: list[SdnZoneSchema] = field(default_factory=list)
+    vnets: list[SdnVNetSchema] = field(default_factory=list)
+    subnets: list[SdnSubnetSchema] = field(default_factory=list)
+    fabrics: list[SdnFabricSchema] = field(default_factory=list)
+    route_maps: list[SdnRouteMapSchema] = field(default_factory=list)
+    prefix_lists: list[SdnPrefixListSchema] = field(default_factory=list)
+    node_status: list[SdnNodeStatusSchema] = field(default_factory=list)
+    skipped_warnings: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class SdnSyncCounters:
+    """Counters emitted by the SDN SSE stage."""
+
+    controllers: int = 0
+    zones: int = 0
+    vnets: int = 0
+    subnets: int = 0
+    l2vpns: int = 0
+    route_targets: int = 0
+    terminations: int = 0
+    skipped: int = 0
+    stale: int = 0
+    plugin_metadata: int = 0
+    per_endpoint_errors: dict[str, int] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "controllers": self.controllers,
+            "zones": self.zones,
+            "vnets": self.vnets,
+            "subnets": self.subnets,
+            "l2vpns": self.l2vpns,
+            "route_targets": self.route_targets,
+            "terminations": self.terminations,
+            "skipped": self.skipped,
+            "stale": self.stale,
+            "plugin_metadata": self.plugin_metadata,
+            "per_endpoint_errors": self.per_endpoint_errors,
+        }
+
+    def record_endpoint_error(self, endpoint: str) -> None:
+        self.per_endpoint_errors[endpoint] = self.per_endpoint_errors.get(endpoint, 0) + 1
+
+
+def _to_mapping(raw: object) -> dict[str, object]:
+    if hasattr(raw, "model_dump"):
+        return raw.model_dump(mode="python", by_alias=True, exclude_none=True)
+    if isinstance(raw, dict):
+        return dict(raw)
+    if hasattr(raw, "root"):
+        nested = getattr(raw, "root")
+        return _to_mapping(nested)
+    return {}
+
+
+def _rows(raw: object) -> list[object]:
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        return raw
+    if hasattr(raw, "root"):
+        root = getattr(raw, "root")
+        return root if isinstance(root, list) else [root]
+    return [raw]
+
+
+def _value(data: dict[str, object], *keys: str) -> object:
+    for key in keys:
+        if key in data:
+            return data[key]
+        alt = key.replace("-", "_")
+        if alt in data:
+            return data[alt]
+        alt = key.replace("_", "-")
+        if alt in data:
+            return data[alt]
+    return None
+
+
+def _text(data: dict[str, object], *keys: str) -> str | None:
+    raw = _value(data, *keys)
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    return text or None
+
+
+def _int(data: dict[str, object], *keys: str) -> int | None:
+    raw = _value(data, *keys)
+    try:
+        return int(str(raw))
+    except (TypeError, ValueError):
+        return None
+
+
+def _bool(data: dict[str, object], *keys: str) -> bool | None:
+    raw = _value(data, *keys)
+    if raw is None:
+        return None
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, int):
+        return bool(raw)
+    if isinstance(raw, str):
+        normalized = raw.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return None
+
+
+def _raw_dict(data: dict[str, object]) -> dict[str, object]:
+    return {key: value for key, value in data.items() if value is not None}
+
+
+def _split_csv(value: object) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return [part.strip() for part in str(value).split(",") if part.strip()]
+
+
+def _slug(value: object) -> str:
+    text = str(value or "unknown").strip().lower()
+    slug = _SLUG_FRAGMENT_RE.sub("-", text).strip("-")
+    return slug or "unknown"
+
+
+def _relation_id(value: object) -> int | None:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, dict):
+        raw = value.get("id")
+        if isinstance(raw, int):
+            return raw
+    return None
+
+
+def _relation_ids(value: object) -> list[int]:
+    if not isinstance(value, list):
+        return []
+    ids: list[int] = []
+    for item in value:
+        record_id = _relation_id(item)
+        if record_id is not None:
+            ids.append(record_id)
+    return ids
+
+
+def _content_type_value(value: object) -> str | None:
+    if isinstance(value, str):
+        return value.strip().lower() or None
+    if isinstance(value, dict):
+        app_label = value.get("app_label")
+        model = value.get("model")
+        if app_label and model:
+            return f"{app_label}.{model}".lower()
+    return None
+
+
+def _netbox_status(state: str | None, pending: dict[str, object] | None = None) -> str:
+    normalized = (state or "").strip().lower()
+    if normalized == "deleted":
+        return "decommissioning"
+    if normalized in {"new", "pending"} or pending:
+        return "planned"
+    return "active"
+
+
+def _is_unsupported_sdn_error(error: Exception) -> bool:
+    if isinstance(error, ResourceException):
+        if error.status_code in _UNSUPPORTED_STATUS_CODES:
+            return True
+    message = str(error).lower()
+    return "no such api path" in message or "not implemented" in message
+
+
+async def _fetch_rows(px: object, path: str, inventory: SdnInventory) -> list[object]:
+    try:
+        raw = await resolve_async(px.session(path).get())
+    except Exception as error:  # noqa: BLE001
+        if _is_unsupported_sdn_error(error):
+            inventory.skipped_warnings.append(f"{inventory.cluster_name}: {path} unsupported")
+            return []
+        inventory.errors.append(f"{inventory.cluster_name}: {path}: {error}")
+        logger.warning("Error fetching Proxmox SDN path %s for %s: %s", path, px.name, error)
+        return []
+    return _rows(raw)
+
+
+def _node_names(px: object) -> list[str]:
+    names: list[str] = []
+    for row in getattr(px, "cluster_status", []) or []:
+        data = _to_mapping(row)
+        if _text(data, "type") != "node":
+            continue
+        name = _text(data, "name", "node")
+        if name and name not in names:
+            names.append(name)
+    fallback = getattr(px, "node_name", None) or getattr(px, "name", None)
+    if not names and fallback:
+        names.append(str(fallback))
+    return names
+
+
+def _to_fabric(
+    cluster_name: str,
+    raw: object,
+    endpoint_id: int | None = None,
+) -> SdnFabricSchema:
+    data = _to_mapping(raw)
+    return SdnFabricSchema(
+        endpoint_id=endpoint_id,
+        cluster_name=cluster_name,
+        fabric=_text(data, "fabric", "id", "name"),
+        type=_text(data, "type"),
+        advertise_subnets=_bool(data, "advertise-subnets", "advertise_subnets"),
+        disable_arp_nd_suppression=_bool(
+            data,
+            "disable-arp-nd-suppression",
+            "disable_arp_nd_suppression",
+        ),
+        vrf_vxlan=_int(data, "vrf-vxlan", "vrf_vxlan"),
+        asn=_int(data, "asn"),
+        peers=_text(data, "peers"),
+        raw_config=_raw_dict(data),
+    )
+
+
+def _to_route_map(
+    cluster_name: str,
+    raw: object,
+    endpoint_id: int | None = None,
+) -> SdnRouteMapSchema:
+    data = _to_mapping(raw)
+    return SdnRouteMapSchema(
+        endpoint_id=endpoint_id,
+        cluster_name=cluster_name,
+        name=_text(data, "name", "id"),
+        action=_text(data, "action"),
+        match_peer=_text(data, "match-peer", "match_peer"),
+        match_ip=_text(data, "match-ip", "match_ip"),
+        set_community=_text(data, "set-community", "set_community"),
+        order=_int(data, "order"),
+        raw_config=_raw_dict(data),
+    )
+
+
+def _to_prefix_list(
+    cluster_name: str,
+    raw: object,
+    endpoint_id: int | None = None,
+) -> SdnPrefixListSchema:
+    data = _to_mapping(raw)
+    return SdnPrefixListSchema(
+        endpoint_id=endpoint_id,
+        cluster_name=cluster_name,
+        name=_text(data, "name", "id"),
+        cidr=_text(data, "cidr"),
+        action=_text(data, "action"),
+        le=_int(data, "le"),
+        ge=_int(data, "ge"),
+        raw_config=_raw_dict(data),
+    )
+
+
+def _to_controller(
+    cluster_name: str,
+    raw: object,
+    endpoint_id: int | None = None,
+) -> SdnControllerSchema:
+    data = _to_mapping(raw)
+    return SdnControllerSchema(
+        endpoint_id=endpoint_id,
+        cluster_name=cluster_name,
+        controller=_text(data, "controller", "id", "name"),
+        type=_text(data, "type"),
+        asn=_int(data, "asn"),
+        peers=_text(data, "peers"),
+        node=_text(data, "node"),
+        loopback=_text(data, "loopback"),
+        state=_text(data, "state"),
+        raw_config=_raw_dict(data),
+    )
+
+
+def _to_zone(
+    cluster_name: str,
+    raw: object,
+    endpoint_id: int | None = None,
+) -> SdnZoneSchema:
+    data = _to_mapping(raw)
+    pending = _value(data, "pending")
+    return SdnZoneSchema(
+        endpoint_id=endpoint_id,
+        cluster_name=cluster_name,
+        zone=_text(data, "zone", "id", "name"),
+        type=_text(data, "type"),
+        controller=_text(data, "controller"),
+        vrf_vxlan=_int(data, "vrf-vxlan", "vrf_vxlan"),
+        tag=_int(data, "tag"),
+        mtu=_int(data, "mtu"),
+        dns=_text(data, "dns"),
+        ipam=_text(data, "ipam"),
+        rt_import=_text(data, "rt-import", "rt_import"),
+        state=_text(data, "state"),
+        pending=pending if isinstance(pending, dict) else None,
+        raw_config=_raw_dict(data),
+    )
+
+
+def _to_vnet(
+    cluster_name: str,
+    raw: object,
+    endpoint_id: int | None = None,
+) -> SdnVNetSchema:
+    data = _to_mapping(raw)
+    pending = _value(data, "pending")
+    return SdnVNetSchema(
+        endpoint_id=endpoint_id,
+        cluster_name=cluster_name,
+        vnet=_text(data, "vnet", "id", "name"),
+        zone=_text(data, "zone"),
+        type=_text(data, "type"),
+        tag=_int(data, "tag"),
+        alias=_text(data, "alias"),
+        vlanaware=_bool(data, "vlanaware", "vlan-aware", "vlan_aware"),
+        state=_text(data, "state"),
+        pending=pending if isinstance(pending, dict) else None,
+        raw_config=_raw_dict(data),
+    )
+
+
+def _to_subnet(
+    cluster_name: str,
+    vnet_name: str,
+    zone_name: str | None,
+    raw: object,
+    endpoint_id: int | None = None,
+) -> SdnSubnetSchema:
+    data = _to_mapping(raw)
+    return SdnSubnetSchema(
+        endpoint_id=endpoint_id,
+        cluster_name=cluster_name,
+        vnet=vnet_name,
+        zone=zone_name,
+        subnet=_text(data, "subnet", "cidr", "id"),
+        type=_text(data, "type"),
+        gateway=_text(data, "gateway"),
+        snat=_bool(data, "snat"),
+        raw_config=_raw_dict(data),
+    )
+
+
+def _to_node_status(
+    *,
+    cluster_name: str,
+    node: str,
+    kind: str,
+    raw: object,
+    endpoint_id: int | None = None,
+    zone: str | None = None,
+    vnet: str | None = None,
+) -> SdnNodeStatusSchema:
+    data = _to_mapping(raw)
+    name = _text(data, "name", "vnet", "zone", "ip", "mac", "route", "subdir")
+    return SdnNodeStatusSchema(
+        endpoint_id=endpoint_id,
+        cluster_name=cluster_name,
+        node=node,
+        zone=zone or _text(data, "zone"),
+        vnet=vnet or _text(data, "vnet"),
+        kind=kind,
+        name=name,
+        status=_text(data, "status") or "ok",
+        raw_config=_raw_dict(data),
+    )
+
+
+async def collect_sdn_inventory_for_session(  # noqa: C901
+    px: object,
+    *,
+    endpoint_id: int | None = None,
+    include_node_runtime: bool = True,
+) -> SdnInventory:
+    """Collect Proxmox SDN inventory for one session without mutating Proxmox."""
+
+    cluster_name = str(getattr(px, "cluster_name", None) or getattr(px, "name", None) or "default")
+    endpoint_name = str(getattr(px, "name", None) or cluster_name)
+    inventory = SdnInventory(
+        endpoint_id=endpoint_id,
+        endpoint_name=endpoint_name,
+        cluster_name=cluster_name,
+    )
+
+    for row in await _fetch_rows(px, "cluster/sdn/controllers", inventory):
+        inventory.controllers.append(_to_controller(cluster_name, row, endpoint_id))
+    for row in await _fetch_rows(px, "cluster/sdn/zones", inventory):
+        inventory.zones.append(_to_zone(cluster_name, row, endpoint_id))
+    for row in await _fetch_rows(px, "cluster/sdn/vnets", inventory):
+        inventory.vnets.append(_to_vnet(cluster_name, row, endpoint_id))
+    for row in await _fetch_rows(px, "cluster/sdn/fabrics", inventory):
+        inventory.fabrics.append(_to_fabric(cluster_name, row, endpoint_id))
+    for row in await _fetch_rows(px, "cluster/sdn/route-maps", inventory):
+        inventory.route_maps.append(_to_route_map(cluster_name, row, endpoint_id))
+    for row in await _fetch_rows(px, "cluster/sdn/prefix-lists", inventory):
+        inventory.prefix_lists.append(_to_prefix_list(cluster_name, row, endpoint_id))
+
+    vnet_zone = {vnet.vnet: vnet.zone for vnet in inventory.vnets if vnet.vnet}
+    for vnet in inventory.vnets:
+        if not vnet.vnet:
+            continue
+        path = f"cluster/sdn/vnets/{vnet.vnet}/subnets"
+        for row in await _fetch_rows(px, path, inventory):
+            inventory.subnets.append(
+                _to_subnet(cluster_name, vnet.vnet, vnet.zone, row, endpoint_id)
+            )
+
+    if not include_node_runtime:
+        return inventory
+
+    for node in _node_names(px):
+        for row in await _fetch_rows(px, f"nodes/{node}/sdn/zones", inventory):
+            inventory.node_status.append(
+                _to_node_status(
+                    cluster_name=cluster_name,
+                    node=node,
+                    kind="node-zone",
+                    raw=row,
+                    endpoint_id=endpoint_id,
+                )
+            )
+        for zone in [zone.zone for zone in inventory.zones if zone.zone]:
+            for kind, suffix in (
+                ("node-zone-bridge", "bridges"),
+                ("node-zone-content", "content"),
+                ("node-ip-vrf", "ip-vrf"),
+            ):
+                path = f"nodes/{node}/sdn/zones/{zone}/{suffix}"
+                for row in await _fetch_rows(px, path, inventory):
+                    inventory.node_status.append(
+                        _to_node_status(
+                            cluster_name=cluster_name,
+                            node=node,
+                            zone=zone,
+                            kind=kind,
+                            raw=row,
+                            endpoint_id=endpoint_id,
+                        )
+                    )
+        for vnet in [vnet.vnet for vnet in inventory.vnets if vnet.vnet]:
+            path = f"nodes/{node}/sdn/vnets/{vnet}/mac-vrf"
+            for row in await _fetch_rows(px, path, inventory):
+                inventory.node_status.append(
+                    _to_node_status(
+                        cluster_name=cluster_name,
+                        node=node,
+                        zone=vnet_zone.get(vnet),
+                        vnet=vnet,
+                        kind="node-mac-vrf",
+                        raw=row,
+                        endpoint_id=endpoint_id,
+                    )
+                )
+
+    return inventory
+
+
+async def collect_sdn_inventory(
+    pxs: list[object],
+    *,
+    include_node_runtime: bool = True,
+) -> list[SdnInventory]:
+    """Collect Proxmox SDN inventory for all sessions."""
+
+    return [
+        await collect_sdn_inventory_for_session(px, include_node_runtime=include_node_runtime)
+        for px in pxs
+    ]
+
+
+def _identity_normalizer(*fields: str):
+    def normalize(record: dict[str, object]) -> dict[str, object]:
+        normalized: dict[str, object] = {}
+        for field_name in fields:
+            value = record.get(field_name)
+            if field_name in {"endpoint", "l2vpn", "prefix"}:
+                value = _relation_id(value)
+            elif field_name in {"import_targets", "export_targets"}:
+                value = _relation_ids(value)
+            normalized[field_name] = value
+        return normalized
+
+    return normalize
+
+
+async def _reconcile(
+    nb: object,
+    path: str,
+    *,
+    lookup: dict[str, object],
+    payload: dict[str, object],
+    fields: tuple[str, ...],
+    lookup_query_field_map: dict[str, str] | None = None,
+) -> tuple[int | None, bool]:
+    result = await rest_reconcile_async_with_status(
+        nb,
+        path,
+        lookup=lookup,
+        payload=payload,
+        schema=dict,
+        current_normalizer=_identity_normalizer(*fields),
+        patchable_fields=set(fields),
+        lookup_query_field_map=lookup_query_field_map,
+    )
+    return _relation_id(result.record.serialize()), result.status in {"created", "updated"}
+
+
+async def _ensure_route_target(nb: object, rt_name: str) -> tuple[int | None, bool]:
+    payload = {
+        "name": rt_name,
+        "description": "Imported from Proxmox SDN EVPN route-target configuration.",
+    }
+    return await _reconcile(
+        nb,
+        "/api/ipam/route-targets/",
+        lookup={"name": rt_name},
+        payload=payload,
+        fields=("name", "description"),
+    )
+
+
+async def _ensure_l2vpn(
+    nb: object,
+    *,
+    endpoint_id: int,
+    endpoint_name: str,
+    cluster_name: str,
+    zone: SdnZoneSchema,
+    vnet: SdnVNetSchema,
+    import_target_ids: list[int],
+) -> tuple[int | None, bool]:
+    zone_name = zone.zone or "unknown"
+    vnet_name = vnet.vnet or "unknown"
+    slug = f"proxbox-{endpoint_id}-{_slug(cluster_name)}-{_slug(zone_name)}-{_slug(vnet_name)}"
+    payload: dict[str, object] = {
+        "name": f"Proxbox {endpoint_name} / {cluster_name} / {zone_name} / {vnet_name}",
+        "slug": slug,
+        "type": _MANAGED_L2VPN_TYPES[str(zone.type).lower()],
+        "status": _netbox_status(vnet.state or zone.state, vnet.pending or zone.pending),
+        "description": "Imported from Proxmox SDN VNet configuration.",
+        "import_targets": import_target_ids,
+        "export_targets": [],
+    }
+    if vnet.tag is not None:
+        payload["identifier"] = vnet.tag
+    return await _reconcile(
+        nb,
+        "/api/vpn/l2vpns/",
+        lookup={"slug": slug},
+        payload=payload,
+        fields=(
+            "name",
+            "slug",
+            "type",
+            "status",
+            "identifier",
+            "description",
+            "import_targets",
+            "export_targets",
+        ),
+    )
+
+
+def _valid_prefix(value: str | None) -> str | None:
+    if not value:
+        return None
+    try:
+        return str(ipaddress.ip_network(value, strict=False))
+    except ValueError:
+        return None
+
+
+async def _ensure_prefix(nb: object, subnet: SdnSubnetSchema) -> tuple[int | None, bool]:
+    prefix = _valid_prefix(subnet.subnet)
+    if prefix is None:
+        return None, False
+    payload = {
+        "prefix": prefix,
+        "status": "active",
+        "description": (
+            f"Imported from Proxmox SDN VNet {subnet.vnet or 'unknown'} "
+            f"on {subnet.cluster_name or 'unknown'}."
+        ),
+    }
+    return await _reconcile(
+        nb,
+        "/api/ipam/prefixes/",
+        lookup={"prefix": prefix},
+        payload=payload,
+        fields=("prefix", "status", "description"),
+    )
+
+
+async def _ensure_l2vpn_termination(
+    nb: object,
+    *,
+    l2vpn_id: int,
+    target_type: str,
+    target_id: int,
+) -> tuple[int | None, bool, str | None]:
+    existing = await rest_first_async(
+        nb,
+        "/api/vpn/l2vpn-terminations/",
+        query={
+            "assigned_object_type": target_type,
+            "assigned_object_id": target_id,
+            "limit": 2,
+        },
+    )
+    if existing is not None:
+        existing_data = _to_mapping(existing)
+        existing_l2vpn_id = _relation_id(existing_data.get("l2vpn"))
+        if existing_l2vpn_id not in {None, l2vpn_id}:
+            return (
+                _relation_id(existing_data),
+                False,
+                f"Target already terminates L2VPN {existing_l2vpn_id}.",
+            )
+
+    termination_id, changed = await _reconcile(
+        nb,
+        "/api/vpn/l2vpn-terminations/",
+        lookup={
+            "l2vpn": l2vpn_id,
+            "assigned_object_type": target_type,
+            "assigned_object_id": target_id,
+        },
+        payload={
+            "l2vpn": l2vpn_id,
+            "assigned_object_type": target_type,
+            "assigned_object_id": target_id,
+        },
+        fields=("l2vpn", "assigned_object_type", "assigned_object_id"),
+    )
+    return termination_id, changed, None
+
+
+async def _plugin_upsert(
+    nb: object,
+    path: str,
+    *,
+    lookup: dict[str, object],
+    payload: dict[str, object],
+    fields: tuple[str, ...],
+) -> bool:
+    _, changed = await _reconcile(
+        nb,
+        path,
+        lookup=lookup,
+        payload=payload,
+        fields=fields,
+    )
+    return changed
+
+
+async def _sync_plugin_inventory(  # noqa: C901
+    nb: object,
+    inventory: SdnInventory,
+    counters: SdnSyncCounters,
+    *,
+    vnet_l2vpn_ids: dict[tuple[str, str], int],
+    subnet_prefix_ids: dict[tuple[str, str], int],
+) -> None:
+    endpoint_id = inventory.endpoint_id
+    if endpoint_id is None:
+        counters.skipped += 1
+        return
+
+    for controller in inventory.controllers:
+        if not controller.controller:
+            counters.skipped += 1
+            continue
+        if await _plugin_upsert(
+            nb,
+            "/api/plugins/proxbox/sdn-controllers/",
+            lookup={
+                "endpoint": endpoint_id,
+                "cluster_name": inventory.cluster_name,
+                "controller_name": controller.controller,
+            },
+            payload={
+                "endpoint": endpoint_id,
+                "cluster_name": inventory.cluster_name,
+                "controller_name": controller.controller,
+                "controller_type": controller.type or "",
+                "asn": controller.asn,
+                "peers": _split_csv(controller.peers),
+                "nodes": _split_csv(controller.node),
+                "loopback": controller.loopback or "",
+                "state": controller.state or "",
+                "status": "active",
+                "raw_config": controller.raw_config,
+            },
+            fields=(
+                "endpoint",
+                "cluster_name",
+                "controller_name",
+                "controller_type",
+                "asn",
+                "peers",
+                "nodes",
+                "loopback",
+                "state",
+                "status",
+                "raw_config",
+            ),
+        ):
+            counters.plugin_metadata += 1
+
+    for fabric in inventory.fabrics:
+        if not fabric.fabric:
+            counters.skipped += 1
+            continue
+        if await _plugin_upsert(
+            nb,
+            "/api/plugins/proxbox/sdn-fabrics/",
+            lookup={
+                "endpoint": endpoint_id,
+                "cluster_name": inventory.cluster_name,
+                "fabric_name": fabric.fabric,
+            },
+            payload={
+                "endpoint": endpoint_id,
+                "cluster_name": inventory.cluster_name,
+                "fabric_name": fabric.fabric,
+                "fabric_type": fabric.type or "unknown",
+                "asn": fabric.asn,
+                "advertise_subnets": bool(fabric.advertise_subnets),
+                "disable_arp_nd_suppression": bool(fabric.disable_arp_nd_suppression),
+                "vrf_vxlan": fabric.vrf_vxlan,
+                "peers": _split_csv(fabric.peers),
+                "status": "active",
+                "raw_config": fabric.raw_config,
+            },
+            fields=(
+                "endpoint",
+                "cluster_name",
+                "fabric_name",
+                "fabric_type",
+                "asn",
+                "advertise_subnets",
+                "disable_arp_nd_suppression",
+                "vrf_vxlan",
+                "peers",
+                "status",
+                "raw_config",
+            ),
+        ):
+            counters.plugin_metadata += 1
+
+    for route_map in inventory.route_maps:
+        if not route_map.name:
+            counters.skipped += 1
+            continue
+        if await _plugin_upsert(
+            nb,
+            "/api/plugins/proxbox/sdn-route-maps/",
+            lookup={
+                "endpoint": endpoint_id,
+                "cluster_name": inventory.cluster_name,
+                "name": route_map.name,
+                "order": route_map.order or 0,
+            },
+            payload={
+                "endpoint": endpoint_id,
+                "cluster_name": inventory.cluster_name,
+                "name": route_map.name,
+                "action": route_map.action or "",
+                "match_peer": route_map.match_peer or "",
+                "match_ip": route_map.match_ip or "",
+                "set_community": route_map.set_community or "",
+                "order": route_map.order or 0,
+                "status": "active",
+                "raw_config": route_map.raw_config,
+            },
+            fields=(
+                "endpoint",
+                "cluster_name",
+                "name",
+                "action",
+                "match_peer",
+                "match_ip",
+                "set_community",
+                "order",
+                "status",
+                "raw_config",
+            ),
+        ):
+            counters.plugin_metadata += 1
+
+    for prefix_list in inventory.prefix_lists:
+        if not prefix_list.name:
+            counters.skipped += 1
+            continue
+        if await _plugin_upsert(
+            nb,
+            "/api/plugins/proxbox/sdn-prefix-lists/",
+            lookup={
+                "endpoint": endpoint_id,
+                "cluster_name": inventory.cluster_name,
+                "name": prefix_list.name,
+                "cidr": prefix_list.cidr or "",
+            },
+            payload={
+                "endpoint": endpoint_id,
+                "cluster_name": inventory.cluster_name,
+                "name": prefix_list.name,
+                "cidr": prefix_list.cidr or "",
+                "action": prefix_list.action or "",
+                "le": prefix_list.le,
+                "ge": prefix_list.ge,
+                "status": "active",
+                "raw_config": prefix_list.raw_config,
+            },
+            fields=(
+                "endpoint",
+                "cluster_name",
+                "name",
+                "cidr",
+                "action",
+                "le",
+                "ge",
+                "status",
+                "raw_config",
+            ),
+        ):
+            counters.plugin_metadata += 1
+
+    for zone in inventory.zones:
+        if not zone.zone:
+            counters.skipped += 1
+            continue
+        if await _plugin_upsert(
+            nb,
+            "/api/plugins/proxbox/sdn-zones/",
+            lookup={
+                "endpoint": endpoint_id,
+                "cluster_name": inventory.cluster_name,
+                "zone_name": zone.zone,
+            },
+            payload={
+                "endpoint": endpoint_id,
+                "cluster_name": inventory.cluster_name,
+                "zone_name": zone.zone,
+                "zone_type": zone.type or "",
+                "controller": zone.controller or "",
+                "vrf_vxlan": zone.vrf_vxlan,
+                "tag": zone.tag,
+                "mtu": zone.mtu,
+                "dns": zone.dns or "",
+                "ipam": zone.ipam or "",
+                "rt_import": _split_csv(zone.rt_import),
+                "state": zone.state or "",
+                "status": "active",
+                "raw_config": zone.raw_config,
+            },
+            fields=(
+                "endpoint",
+                "cluster_name",
+                "zone_name",
+                "zone_type",
+                "controller",
+                "vrf_vxlan",
+                "tag",
+                "mtu",
+                "dns",
+                "ipam",
+                "rt_import",
+                "state",
+                "status",
+                "raw_config",
+            ),
+        ):
+            counters.plugin_metadata += 1
+
+    for vnet in inventory.vnets:
+        if not vnet.vnet:
+            counters.skipped += 1
+            continue
+        l2vpn_id = vnet_l2vpn_ids.get((vnet.zone or "", vnet.vnet))
+        if await _plugin_upsert(
+            nb,
+            "/api/plugins/proxbox/sdn-vnets/",
+            lookup={
+                "endpoint": endpoint_id,
+                "cluster_name": inventory.cluster_name,
+                "vnet_name": vnet.vnet,
+            },
+            payload={
+                "endpoint": endpoint_id,
+                "cluster_name": inventory.cluster_name,
+                "zone_name": vnet.zone or "",
+                "vnet_name": vnet.vnet,
+                "vnet_type": vnet.type or "",
+                "tag": vnet.tag,
+                "alias": vnet.alias or "",
+                "vlanaware": bool(vnet.vlanaware),
+                "state": vnet.state or "",
+                "l2vpn": l2vpn_id,
+                "status": "active",
+                "raw_config": vnet.raw_config,
+            },
+            fields=(
+                "endpoint",
+                "cluster_name",
+                "zone_name",
+                "vnet_name",
+                "vnet_type",
+                "tag",
+                "alias",
+                "vlanaware",
+                "state",
+                "l2vpn",
+                "status",
+                "raw_config",
+            ),
+        ):
+            counters.plugin_metadata += 1
+
+    for subnet in inventory.subnets:
+        if not subnet.vnet or not subnet.subnet:
+            counters.skipped += 1
+            continue
+        prefix_id = subnet_prefix_ids.get((subnet.vnet, subnet.subnet))
+        skip_reason = "" if prefix_id else "Invalid or ambiguous subnet payload."
+        if prefix_id is None:
+            counters.skipped += 1
+        if await _plugin_upsert(
+            nb,
+            "/api/plugins/proxbox/sdn-subnets/",
+            lookup={
+                "endpoint": endpoint_id,
+                "cluster_name": inventory.cluster_name,
+                "vnet_name": subnet.vnet,
+                "subnet": subnet.subnet,
+            },
+            payload={
+                "endpoint": endpoint_id,
+                "cluster_name": inventory.cluster_name,
+                "zone_name": subnet.zone or "",
+                "vnet_name": subnet.vnet,
+                "subnet": subnet.subnet,
+                "subnet_type": subnet.type or "",
+                "gateway": subnet.gateway or "",
+                "snat": bool(subnet.snat),
+                "prefix": prefix_id,
+                "skip_reason": skip_reason,
+                "status": "active",
+                "raw_config": subnet.raw_config,
+            },
+            fields=(
+                "endpoint",
+                "cluster_name",
+                "zone_name",
+                "vnet_name",
+                "subnet",
+                "subnet_type",
+                "gateway",
+                "snat",
+                "prefix",
+                "skip_reason",
+                "status",
+                "raw_config",
+            ),
+        ):
+            counters.plugin_metadata += 1
+
+    for row in inventory.node_status:
+        source = "/".join(
+            part for part in (row.node, row.zone, row.vnet, row.kind, row.name) if part
+        )
+        if not source:
+            counters.skipped += 1
+            continue
+        if await _plugin_upsert(
+            nb,
+            "/api/plugins/proxbox/sdn-bindings/",
+            lookup={
+                "endpoint": endpoint_id,
+                "cluster_name": inventory.cluster_name,
+                "source_type": row.kind,
+                "source_name": source,
+            },
+            payload={
+                "endpoint": endpoint_id,
+                "cluster_name": inventory.cluster_name,
+                "source_type": row.kind,
+                "source_name": source,
+                "node": row.node or "",
+                "zone_name": row.zone or "",
+                "vnet_name": row.vnet or "",
+                "target_type": "",
+                "target_id": None,
+                "status": row.status or "active",
+                "conflict_reason": row.error or "",
+                "raw_config": row.raw_config,
+            },
+            fields=(
+                "endpoint",
+                "cluster_name",
+                "source_type",
+                "source_name",
+                "node",
+                "zone_name",
+                "vnet_name",
+                "target_type",
+                "target_id",
+                "status",
+                "conflict_reason",
+                "raw_config",
+            ),
+        ):
+            counters.plugin_metadata += 1
+
+
+async def _sync_netbox_l2vpn_objects(  # noqa: C901
+    nb: object,
+    inventory: SdnInventory,
+    counters: SdnSyncCounters,
+) -> tuple[dict[tuple[str, str], int], dict[tuple[str, str], int]]:
+    vnet_l2vpn_ids: dict[tuple[str, str], int] = {}
+    subnet_prefix_ids: dict[tuple[str, str], int] = {}
+
+    endpoint_id = inventory.endpoint_id
+    if endpoint_id is None:
+        counters.skipped += len(inventory.vnets)
+        return vnet_l2vpn_ids, subnet_prefix_ids
+
+    zones_by_name = {zone.zone: zone for zone in inventory.zones if zone.zone}
+
+    for vnet in inventory.vnets:
+        if not vnet.vnet or not vnet.zone:
+            counters.skipped += 1
+            continue
+        zone = zones_by_name.get(vnet.zone)
+        if zone is None or str(zone.type or "").lower() not in _MANAGED_L2VPN_TYPES:
+            continue
+
+        import_target_ids: list[int] = []
+        for rt_name in _split_csv(zone.rt_import):
+            try:
+                rt_id, changed = await _ensure_route_target(nb, rt_name)
+            except Exception as error:  # noqa: BLE001
+                counters.record_endpoint_error(inventory.cluster_name)
+                logger.warning("Could not sync RouteTarget %s: %s", rt_name, error)
+                continue
+            if rt_id is not None:
+                import_target_ids.append(rt_id)
+                if changed:
+                    counters.route_targets += 1
+
+        try:
+            l2vpn_id, changed = await _ensure_l2vpn(
+                nb,
+                endpoint_id=endpoint_id,
+                endpoint_name=inventory.endpoint_name,
+                cluster_name=inventory.cluster_name,
+                zone=zone,
+                vnet=vnet,
+                import_target_ids=import_target_ids,
+            )
+        except Exception as error:  # noqa: BLE001
+            counters.record_endpoint_error(inventory.cluster_name)
+            logger.warning("Could not sync L2VPN for %s/%s: %s", vnet.zone, vnet.vnet, error)
+            continue
+        if l2vpn_id is not None:
+            vnet_l2vpn_ids[(vnet.zone, vnet.vnet)] = l2vpn_id
+            if changed:
+                counters.l2vpns += 1
+
+    for subnet in inventory.subnets:
+        if not subnet.vnet or not subnet.subnet:
+            counters.skipped += 1
+            continue
+        prefix = _valid_prefix(subnet.subnet)
+        if prefix is None:
+            counters.skipped += 1
+            continue
+        try:
+            prefix_id, changed = await _ensure_prefix(nb, subnet)
+        except Exception as error:  # noqa: BLE001
+            counters.record_endpoint_error(inventory.cluster_name)
+            logger.warning("Could not sync Prefix for SDN subnet %s: %s", subnet.subnet, error)
+            continue
+        if prefix_id is not None:
+            subnet_prefix_ids[(subnet.vnet, subnet.subnet)] = prefix_id
+            if changed:
+                counters.subnets += 1
+
+    return vnet_l2vpn_ids, subnet_prefix_ids
+
+
+async def _record_binding(
+    nb: object,
+    *,
+    endpoint_id: int,
+    cluster_name: str,
+    source_type: str,
+    source_name: str,
+    target_type: str,
+    target_id: int | None,
+    raw_config: dict[str, object],
+    status: str = "active",
+    conflict_reason: str = "",
+) -> bool:
+    return await _plugin_upsert(
+        nb,
+        "/api/plugins/proxbox/sdn-bindings/",
+        lookup={
+            "endpoint": endpoint_id,
+            "cluster_name": cluster_name,
+            "source_type": source_type,
+            "source_name": source_name,
+        },
+        payload={
+            "endpoint": endpoint_id,
+            "cluster_name": cluster_name,
+            "source_type": source_type,
+            "source_name": source_name,
+            "node": "",
+            "zone_name": "",
+            "vnet_name": "",
+            "target_type": target_type,
+            "target_id": target_id,
+            "status": status,
+            "conflict_reason": conflict_reason,
+            "raw_config": raw_config,
+        },
+        fields=(
+            "endpoint",
+            "cluster_name",
+            "source_type",
+            "source_name",
+            "node",
+            "zone_name",
+            "vnet_name",
+            "target_type",
+            "target_id",
+            "status",
+            "conflict_reason",
+            "raw_config",
+        ),
+    )
+
+
+async def _resolve_termination_target(
+    nb: object,
+    row: SdnNodeStatusSchema,
+) -> tuple[str, int] | None:
+    raw = row.raw_config
+    explicit_type = _content_type_value(
+        _value(raw, "target_type", "assigned_object_type", "target-content-type")
+    )
+    explicit_id = _int(raw, "target_id", "assigned_object_id", "target-object-id")
+    if explicit_type in _TERMINATION_TARGET_TYPES and explicit_id is not None and explicit_id > 0:
+        return explicit_type, explicit_id
+
+    vlan_id = _int(raw, "vid", "vlan")
+    if vlan_id is None or vlan_id < 1 or vlan_id > 4094:
+        return None
+    vlan = await rest_first_async(
+        nb,
+        "/api/ipam/vlans/",
+        query={"vid": vlan_id, "limit": 2},
+    )
+    vlan_record_id = _relation_id(_to_mapping(vlan)) if vlan is not None else None
+    if vlan_record_id is None:
+        return None
+    return "ipam.vlan", vlan_record_id
+
+
+def _l2vpn_id_for_row(
+    row: SdnNodeStatusSchema,
+    vnet_l2vpn_ids: dict[tuple[str, str], int],
+) -> int | None:
+    if row.zone and row.vnet:
+        return vnet_l2vpn_ids.get((row.zone, row.vnet))
+    if not row.vnet:
+        return None
+    matches = [
+        l2vpn_id
+        for (_zone_name, vnet_name), l2vpn_id in vnet_l2vpn_ids.items()
+        if vnet_name == row.vnet
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
+async def _sync_l2vpn_terminations(
+    nb: object,
+    inventory: SdnInventory,
+    counters: SdnSyncCounters,
+    *,
+    vnet_l2vpn_ids: dict[tuple[str, str], int],
+) -> None:
+    endpoint_id = inventory.endpoint_id
+    if endpoint_id is None:
+        return
+
+    for row in inventory.node_status:
+        l2vpn_id = _l2vpn_id_for_row(row, vnet_l2vpn_ids)
+        if l2vpn_id is None:
+            continue
+        target = await _resolve_termination_target(nb, row)
+        if target is None:
+            continue
+        target_type, target_id = target
+        source_name = "/".join(
+            part
+            for part in (
+                row.node,
+                row.zone,
+                row.vnet,
+                row.kind,
+                row.name,
+                target_type,
+                str(target_id),
+            )
+            if part
+        )
+        try:
+            termination_id, changed, conflict_reason = await _ensure_l2vpn_termination(
+                nb,
+                l2vpn_id=l2vpn_id,
+                target_type=target_type,
+                target_id=target_id,
+            )
+        except Exception as error:  # noqa: BLE001
+            counters.record_endpoint_error(inventory.cluster_name)
+            logger.warning(
+                "Could not sync L2VPN termination for %s/%s: %s",
+                row.vnet,
+                target_id,
+                error,
+            )
+            continue
+        if conflict_reason:
+            counters.skipped += 1
+            if await _record_binding(
+                nb,
+                endpoint_id=endpoint_id,
+                cluster_name=inventory.cluster_name,
+                source_type="l2vpn-termination",
+                source_name=source_name,
+                target_type=target_type,
+                target_id=target_id,
+                status="conflict",
+                conflict_reason=conflict_reason,
+                raw_config={**row.raw_config, "l2vpn": l2vpn_id, "termination": termination_id},
+            ):
+                counters.plugin_metadata += 1
+            continue
+        if changed:
+            counters.terminations += 1
+        if await _record_binding(
+            nb,
+            endpoint_id=endpoint_id,
+            cluster_name=inventory.cluster_name,
+            source_type="l2vpn-termination",
+            source_name=source_name,
+            target_type=target_type,
+            target_id=target_id,
+            raw_config={**row.raw_config, "l2vpn": l2vpn_id, "termination": termination_id},
+        ):
+            counters.plugin_metadata += 1
+
+
+async def _record_object_bindings(
+    nb: object,
+    inventory: SdnInventory,
+    counters: SdnSyncCounters,
+    *,
+    vnet_l2vpn_ids: dict[tuple[str, str], int],
+    subnet_prefix_ids: dict[tuple[str, str], int],
+) -> None:
+    endpoint_id = inventory.endpoint_id
+    if endpoint_id is None:
+        return
+    for (zone_name, vnet_name), l2vpn_id in vnet_l2vpn_ids.items():
+        changed = await _record_binding(
+            nb,
+            endpoint_id=endpoint_id,
+            cluster_name=inventory.cluster_name,
+            source_type="vnet",
+            source_name=f"{zone_name}/{vnet_name}",
+            target_type="vpn.l2vpn",
+            target_id=l2vpn_id,
+            raw_config={"zone": zone_name, "vnet": vnet_name},
+        )
+        if changed:
+            counters.plugin_metadata += 1
+    for (vnet_name, subnet), prefix_id in subnet_prefix_ids.items():
+        changed = await _record_binding(
+            nb,
+            endpoint_id=endpoint_id,
+            cluster_name=inventory.cluster_name,
+            source_type="subnet",
+            source_name=f"{vnet_name}/{subnet}",
+            target_type="ipam.prefix",
+            target_id=prefix_id,
+            raw_config={"vnet": vnet_name, "subnet": subnet},
+        )
+        if changed:
+            counters.plugin_metadata += 1
+
+
+async def _emit(
+    bridge: WebSocketSSEBridge | None,
+    status: str,
+    message: str,
+    *,
+    result: dict[str, object] | None = None,
+) -> None:
+    if bridge is None:
+        return
+    payload: dict[str, object] = {
+        "step": "sdn",
+        "status": status,
+        "message": message,
+    }
+    if result is not None:
+        payload["result"] = result
+    await bridge.emit("step", payload)
+
+
+async def _resolve_plugin_endpoint_id(nb: object, px: object) -> int | None:
+    configured_id = getattr(px, "db_endpoint_id", None)
+    if configured_id is not None:
+        existing = await rest_first_async(
+            nb,
+            "/api/plugins/proxbox/endpoints/proxmox/",
+            query={"id": configured_id, "limit": 2},
+        )
+        if existing is not None:
+            return int(configured_id)
+    return await _get_netbox_endpoint_id(nb, px)
+
+
+async def sync_sdn_to_netbox(
+    *,
+    netbox_session: object,
+    pxs: list[object],
+    websocket: WebSocketSSEBridge | None = None,
+    use_websocket: bool = False,
+    include_node_runtime: bool = True,
+) -> dict[str, object]:
+    """Collect Proxmox SDN inventory and reconcile read-only NetBox state."""
+
+    del use_websocket
+    counters = SdnSyncCounters()
+
+    for px in pxs:
+        cluster_name = str(getattr(px, "cluster_name", None) or getattr(px, "name", None) or px)
+        await _emit(websocket, "processing", f"Collecting SDN inventory for {cluster_name}.")
+        try:
+            endpoint_id = await _resolve_plugin_endpoint_id(netbox_session, px)
+            inventory = await collect_sdn_inventory_for_session(
+                px,
+                endpoint_id=endpoint_id,
+                include_node_runtime=include_node_runtime,
+            )
+        except Exception as error:  # noqa: BLE001
+            counters.record_endpoint_error(cluster_name)
+            logger.warning("Could not collect SDN inventory for %s: %s", cluster_name, error)
+            continue
+
+        counters.controllers += len(inventory.controllers)
+        counters.zones += len(inventory.zones)
+        counters.vnets += len(inventory.vnets)
+        counters.skipped += len(inventory.skipped_warnings)
+        if inventory.errors:
+            for _ in inventory.errors:
+                counters.record_endpoint_error(inventory.cluster_name)
+
+        vnet_l2vpn_ids, subnet_prefix_ids = await _sync_netbox_l2vpn_objects(
+            netbox_session,
+            inventory,
+            counters,
+        )
+        try:
+            await _sync_l2vpn_terminations(
+                netbox_session,
+                inventory,
+                counters,
+                vnet_l2vpn_ids=vnet_l2vpn_ids,
+            )
+        except Exception as error:  # noqa: BLE001
+            counters.record_endpoint_error(inventory.cluster_name)
+            logger.warning("Could not sync SDN L2VPN terminations for %s: %s", cluster_name, error)
+        try:
+            await _sync_plugin_inventory(
+                netbox_session,
+                inventory,
+                counters,
+                vnet_l2vpn_ids=vnet_l2vpn_ids,
+                subnet_prefix_ids=subnet_prefix_ids,
+            )
+            await _record_object_bindings(
+                netbox_session,
+                inventory,
+                counters,
+                vnet_l2vpn_ids=vnet_l2vpn_ids,
+                subnet_prefix_ids=subnet_prefix_ids,
+            )
+        except Exception as error:  # noqa: BLE001
+            counters.record_endpoint_error(inventory.cluster_name)
+            logger.warning("Could not sync SDN plugin metadata for %s: %s", cluster_name, error)
+
+        await _emit(
+            websocket,
+            "completed",
+            f"Finished SDN sync for {cluster_name}.",
+            result=counters.as_dict(),
+        )
+
+    return {"ok": True, "counters": counters.as_dict()}
+
+
+__all__ = [
+    "SdnControllerSchema",
+    "SdnFabricSchema",
+    "SdnInventory",
+    "SdnNodeStatusSchema",
+    "SdnPrefixListSchema",
+    "SdnRouteMapSchema",
+    "SdnSubnetSchema",
+    "SdnSyncCounters",
+    "SdnVNetSchema",
+    "SdnZoneSchema",
+    "_netbox_status",
+    "_slug",
+    "_split_csv",
+    "_to_vnet",
+    "_to_zone",
+    "_valid_prefix",
+    "collect_sdn_inventory",
+    "collect_sdn_inventory_for_session",
+    "sync_sdn_to_netbox",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "fastapi[standard]==0.137.2",
-    "proxmox-sdk==0.0.11.post2",
+    "proxmox-sdk==0.0.12",
     "netbox-sdk==0.0.9.post2",
     "sqlmodel==0.0.38",
     "pydantic==2.13.3",
@@ -54,10 +54,10 @@ granian = [
     "granian>=2.7.4",
 ]
 pbs = [
-    "proxmox-sdk[pbs]==0.0.11.post2",
+    "proxmox-sdk[pbs]==0.0.12",
 ]
 pdm = [
-    "proxmox-sdk[pdm]==0.0.11.post2",
+    "proxmox-sdk[pdm]==0.0.12",
 ]
 
 [dependency-groups]

--- a/tests/test_sdn_sync_service.py
+++ b/tests/test_sdn_sync_service.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import pytest
+from proxmox_sdk.sdk.exceptions import ResourceException
+
+from proxbox_api.services.sync.sdn import (
+    SdnInventory,
+    SdnNodeStatusSchema,
+    SdnSubnetSchema,
+    SdnSyncCounters,
+    SdnVNetSchema,
+    SdnZoneSchema,
+    _netbox_status,
+    _split_csv,
+    _sync_l2vpn_terminations,
+    _sync_netbox_l2vpn_objects,
+    _to_vnet,
+    _to_zone,
+    _valid_prefix,
+    collect_sdn_inventory_for_session,
+)
+
+
+class _FakePx:
+    def __init__(self, payloads: dict[str, object]):
+        self.name = "pve-a"
+        self.cluster_name = "cluster-a"
+        self.cluster_status = [{"type": "node", "name": "node-a"}]
+        self._payloads = payloads
+
+    def session(self, path: str):
+        payload = self._payloads.get(path, [])
+
+        class _Resource:
+            async def get(self) -> object:
+                if isinstance(payload, Exception):
+                    raise payload
+                return payload
+
+        return _Resource()
+
+
+def test_sdn_zone_normalizer_reads_hyphenated_aliases():
+    zone = _to_zone(
+        "cluster-a",
+        {
+            "zone": "evpn-prod",
+            "type": "evpn",
+            "rt-import": "65000:100,65000:200",
+            "vrf-vxlan": "9000",
+            "pending": {"tag": 100},
+            "state": "new",
+        },
+        endpoint_id=17,
+    )
+
+    assert zone.endpoint_id == 17
+    assert zone.zone == "evpn-prod"
+    assert zone.type == "evpn"
+    assert zone.rt_import == "65000:100,65000:200"
+    assert zone.vrf_vxlan == 9000
+    assert _netbox_status(zone.state, zone.pending) == "planned"
+
+
+def test_sdn_vnet_normalizer_reads_tag_and_vlanaware():
+    vnet = _to_vnet(
+        "cluster-a",
+        {
+            "vnet": "tenant100",
+            "zone": "evpn-prod",
+            "type": "vnet",
+            "tag": "100100",
+            "vlanaware": "1",
+        },
+    )
+
+    assert vnet.vnet == "tenant100"
+    assert vnet.zone == "evpn-prod"
+    assert vnet.tag == 100100
+    assert vnet.vlanaware is True
+
+
+def test_sdn_prefix_and_rt_helpers():
+    assert _valid_prefix("10.0.0.1/24") == "10.0.0.0/24"
+    assert _valid_prefix("not-a-prefix") is None
+    assert _split_csv("65000:1, 65000:2") == ["65000:1", "65000:2"]
+
+
+@pytest.mark.asyncio
+async def test_collect_sdn_inventory_includes_cluster_and_node_runtime_rows():
+    px = _FakePx(
+        {
+            "cluster/sdn/controllers": [{"controller": "bgp1", "type": "evpn", "asn": 65000}],
+            "cluster/sdn/zones": [{"zone": "evpn-prod", "type": "evpn"}],
+            "cluster/sdn/vnets": [{"vnet": "tenant100", "zone": "evpn-prod", "tag": 100100}],
+            "cluster/sdn/vnets/tenant100/subnets": [{"subnet": "10.100.0.0/24"}],
+            "nodes/node-a/sdn/zones": [{"zone": "evpn-prod", "status": "available"}],
+            "nodes/node-a/sdn/zones/evpn-prod/content": [
+                {"vnet": "tenant100", "status": "available"}
+            ],
+            "nodes/node-a/sdn/zones/evpn-prod/bridges": [{"name": "tenant100"}],
+            "nodes/node-a/sdn/zones/evpn-prod/ip-vrf": [{"ip": "10.100.0.0/24"}],
+            "nodes/node-a/sdn/vnets/tenant100/mac-vrf": [{"mac": "00:11:22:33:44:55"}],
+        }
+    )
+
+    inventory = await collect_sdn_inventory_for_session(px, endpoint_id=17)
+
+    assert inventory.endpoint_id == 17
+    assert len(inventory.controllers) == 1
+    assert len(inventory.zones) == 1
+    assert len(inventory.vnets) == 1
+    assert len(inventory.subnets) == 1
+    assert {row.kind for row in inventory.node_status} >= {
+        "node-zone",
+        "node-zone-content",
+        "node-zone-bridge",
+        "node-ip-vrf",
+        "node-mac-vrf",
+    }
+
+
+@pytest.mark.asyncio
+async def test_collect_sdn_inventory_treats_unsupported_sdn_as_skipped():
+    unsupported = ResourceException(
+        status_code=501,
+        status_message="Not Implemented",
+        content="Method not implemented",
+    )
+    px = _FakePx({"cluster/sdn/controllers": unsupported})
+
+    inventory = await collect_sdn_inventory_for_session(px, include_node_runtime=False)
+
+    assert inventory.controllers == []
+    assert inventory.skipped_warnings
+    assert inventory.errors == []
+
+
+@pytest.mark.asyncio
+async def test_sdn_l2vpn_mapping_writes_route_targets_l2vpn_and_prefix(monkeypatch):
+    calls = []
+
+    async def _fake_reconcile(_nb, path, *, lookup, payload, fields, **_kwargs):
+        del fields
+        calls.append({"path": path, "lookup": lookup, "payload": payload})
+        ids = {
+            "/api/ipam/route-targets/": len(calls),
+            "/api/vpn/l2vpns/": 42,
+            "/api/ipam/prefixes/": 84,
+        }
+        return ids[path], True
+
+    import proxbox_api.services.sync.sdn as sdn_module
+
+    monkeypatch.setattr(sdn_module, "_reconcile", _fake_reconcile)
+
+    inventory = SdnInventory(
+        endpoint_id=17,
+        endpoint_name="pve-a",
+        cluster_name="cluster-a",
+        zones=[
+            SdnZoneSchema(
+                endpoint_id=17,
+                cluster_name="cluster-a",
+                zone="evpn-prod",
+                type="evpn",
+                rt_import="65000:100,65000:200",
+            )
+        ],
+        vnets=[
+            SdnVNetSchema(
+                endpoint_id=17,
+                cluster_name="cluster-a",
+                zone="evpn-prod",
+                vnet="tenant100",
+                tag=100100,
+            )
+        ],
+        subnets=[
+            SdnSubnetSchema(
+                endpoint_id=17,
+                cluster_name="cluster-a",
+                zone="evpn-prod",
+                vnet="tenant100",
+                subnet="10.100.0.1/24",
+            )
+        ],
+    )
+    counters = SdnSyncCounters()
+
+    vnet_l2vpn_ids, subnet_prefix_ids = await _sync_netbox_l2vpn_objects(
+        object(),
+        inventory,
+        counters,
+    )
+
+    assert vnet_l2vpn_ids == {("evpn-prod", "tenant100"): 42}
+    assert subnet_prefix_ids == {("tenant100", "10.100.0.1/24"): 84}
+    assert counters.route_targets == 2
+    assert counters.l2vpns == 1
+    assert counters.subnets == 1
+    l2vpn_call = next(call for call in calls if call["path"] == "/api/vpn/l2vpns/")
+    assert l2vpn_call["payload"]["name"] == "Proxbox pve-a / cluster-a / evpn-prod / tenant100"
+    assert l2vpn_call["payload"]["slug"] == "proxbox-17-cluster-a-evpn-prod-tenant100"
+    assert l2vpn_call["payload"]["type"] == "vxlan-evpn"
+    assert l2vpn_call["payload"]["identifier"] == 100100
+    assert l2vpn_call["payload"]["export_targets"] == []
+    prefix_call = next(call for call in calls if call["path"] == "/api/ipam/prefixes/")
+    assert prefix_call["payload"]["prefix"] == "10.100.0.0/24"
+
+
+@pytest.mark.asyncio
+async def test_sdn_l2vpn_termination_uses_explicit_target(monkeypatch):
+    calls = []
+
+    async def _fake_rest_first(_nb, _path, *, query):
+        del query
+        return None
+
+    async def _fake_reconcile(_nb, path, *, lookup, payload, fields, **_kwargs):
+        del lookup, fields
+        calls.append({"path": path, "payload": payload})
+        return 99 if path == "/api/vpn/l2vpn-terminations/" else 199, True
+
+    import proxbox_api.services.sync.sdn as sdn_module
+
+    monkeypatch.setattr(sdn_module, "rest_first_async", _fake_rest_first)
+    monkeypatch.setattr(sdn_module, "_reconcile", _fake_reconcile)
+
+    inventory = SdnInventory(
+        endpoint_id=17,
+        endpoint_name="pve-a",
+        cluster_name="cluster-a",
+        node_status=[
+            SdnNodeStatusSchema(
+                endpoint_id=17,
+                cluster_name="cluster-a",
+                node="node-a",
+                zone="evpn-prod",
+                vnet="tenant100",
+                kind="node-zone-content",
+                name="net0",
+                raw_config={
+                    "assigned_object_type": "ipam.vlan",
+                    "assigned_object_id": 7,
+                },
+            )
+        ],
+    )
+    counters = SdnSyncCounters()
+
+    await _sync_l2vpn_terminations(
+        object(),
+        inventory,
+        counters,
+        vnet_l2vpn_ids={("evpn-prod", "tenant100"): 42},
+    )
+
+    assert counters.terminations == 1
+    termination_call = next(
+        call for call in calls if call["path"] == "/api/vpn/l2vpn-terminations/"
+    )
+    assert termination_call["payload"] == {
+        "l2vpn": 42,
+        "assigned_object_type": "ipam.vlan",
+        "assigned_object_id": 7,
+    }
+    binding_call = next(
+        call for call in calls if call["path"] == "/api/plugins/proxbox/sdn-bindings/"
+    )
+    assert binding_call["payload"]["source_type"] == "l2vpn-termination"
+    assert binding_call["payload"]["target_type"] == "ipam.vlan"
+    assert binding_call["payload"]["target_id"] == 7
+
+
+@pytest.mark.asyncio
+async def test_sdn_l2vpn_termination_conflict_records_binding(monkeypatch):
+    calls = []
+
+    async def _fake_rest_first(_nb, _path, *, query):
+        del query
+        return {"id": 55, "l2vpn": {"id": 88}}
+
+    async def _fake_reconcile(_nb, path, *, lookup, payload, fields, **_kwargs):
+        del lookup, fields
+        calls.append({"path": path, "payload": payload})
+        return 199, True
+
+    import proxbox_api.services.sync.sdn as sdn_module
+
+    monkeypatch.setattr(sdn_module, "rest_first_async", _fake_rest_first)
+    monkeypatch.setattr(sdn_module, "_reconcile", _fake_reconcile)
+
+    inventory = SdnInventory(
+        endpoint_id=17,
+        endpoint_name="pve-a",
+        cluster_name="cluster-a",
+        node_status=[
+            SdnNodeStatusSchema(
+                endpoint_id=17,
+                cluster_name="cluster-a",
+                node="node-a",
+                zone="evpn-prod",
+                vnet="tenant100",
+                kind="node-zone-content",
+                name="net0",
+                raw_config={
+                    "assigned_object_type": "ipam.vlan",
+                    "assigned_object_id": 7,
+                },
+            )
+        ],
+    )
+    counters = SdnSyncCounters()
+
+    await _sync_l2vpn_terminations(
+        object(),
+        inventory,
+        counters,
+        vnet_l2vpn_ids={("evpn-prod", "tenant100"): 42},
+    )
+
+    assert counters.terminations == 0
+    assert counters.skipped == 1
+    assert all(call["path"] != "/api/vpn/l2vpn-terminations/" for call in calls)
+    binding_call = next(
+        call for call in calls if call["path"] == "/api/plugins/proxbox/sdn-bindings/"
+    )
+    assert binding_call["payload"]["status"] == "conflict"
+    assert "already terminates L2VPN 88" in binding_call["payload"]["conflict_reason"]

--- a/uv.lock
+++ b/uv.lock
@@ -1604,9 +1604,9 @@ requires-dist = [
     { name = "netbox-sdk", specifier = "==0.0.9.post2" },
     { name = "playwright", marker = "extra == 'playwright'", specifier = ">=1.58.0" },
     { name = "playwright", marker = "extra == 'test'", specifier = ">=1.58.0" },
-    { name = "proxmox-sdk", specifier = "==0.0.11.post2" },
-    { name = "proxmox-sdk", extras = ["pbs"], marker = "extra == 'pbs'", specifier = "==0.0.11.post2" },
-    { name = "proxmox-sdk", extras = ["pdm"], marker = "extra == 'pdm'", specifier = "==0.0.11.post2" },
+    { name = "proxmox-sdk", specifier = "==0.0.12" },
+    { name = "proxmox-sdk", extras = ["pbs"], marker = "extra == 'pbs'", specifier = "==0.0.12" },
+    { name = "proxmox-sdk", extras = ["pdm"], marker = "extra == 'pdm'", specifier = "==0.0.12" },
     { name = "pydantic", specifier = "==2.13.3" },
     { name = "pytest", marker = "extra == 'e2e'", specifier = ">=9.0.3" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3" },
@@ -1648,7 +1648,7 @@ dev = [{ name = "ruff", specifier = ">=0.15.8" }]
 
 [[package]]
 name = "proxmox-sdk"
-version = "0.0.11.post2"
+version = "0.0.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1657,9 +1657,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "slowapi" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/7f/032855ee8a4bbc54f586196023fab98eb1023ef034f310ed1cc978108b80/proxmox_sdk-0.0.11.post2.tar.gz", hash = "sha256:d47c27fcecc8cb14c7dadebf41514f2fba68ba9b161167c9451323abdb95029d", size = 3513650, upload-time = "2026-06-08T14:13:08.582Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/30/6e36fe33fca145d7f0fcd537276021e9358e1b1de209f52cc058a2c3e91f/proxmox_sdk-0.0.12.tar.gz", hash = "sha256:bb59b0a0d3cf72d7f32e48a7333ff3ab6060f20a113e3d7e6c478d9f36688253", size = 3513588, upload-time = "2026-06-15T15:40:53.253Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/d7/4ecbf1fde790755cd0729345625b6765f07d68c8ff291da9d06bf3df326a/proxmox_sdk-0.0.11.post2-py3-none-any.whl", hash = "sha256:92bbab3a8e03c795d1d3f168192a3cd01892279f024bac0a787f2334db82647c", size = 3727893, upload-time = "2026-06-08T14:13:06.964Z" },
+    { url = "https://files.pythonhosted.org/packages/85/8d/cdfcee1ffabdb8ffd53e02d1a05892ba1f8bb0783740aca0e7e01b072244/proxmox_sdk-0.0.12-py3-none-any.whl", hash = "sha256:d435193ac3be3af4f69421aca5cb30a101872f2c28c6d66047ae89588d6e4d93", size = 3727892, upload-time = "2026-06-15T15:40:51.504Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds read-only Proxmox SDN collection and NetBox reconciliation for the SDN portion of emersonfelipesp/netbox-proxbox#594.

- Adds `/proxmox/sdn/create/stream` and expanded read routes for controllers, zones, VNets, subnets, node runtime rows, fabrics, route maps, and prefix lists.
- Reconciles EVPN/VXLAN VNets into NetBox `vpn.L2VPN`, EVPN import RTs into `ipam.RouteTarget`, valid subnets into `ipam.Prefix`, and resolvable runtime targets into conflict-safe `vpn.L2VPNTermination` records.
- Stores Proxmox-specific SDN metadata through the netbox-proxbox plugin API, with unsupported older clusters counted as skipped warnings.
- Pins `proxmox-sdk` to `0.0.12` for generated SDN route coverage.

## Validation

- `uv lock --check`
- `uv run ruff check proxbox_api/services/sync/sdn.py proxbox_api/routes/proxmox/sdn.py tests/test_sdn_sync_service.py`
- `uv run python -m pytest tests/test_sdn_sync_service.py tests/test_pve91_501_graceful_handling.py -q`
- `uv run python -m compileall proxbox_api tests`
- `uv run python -c "import proxbox_api.main"`
- `uv run python -c "from proxbox_api.proxmox_to_netbox.proxmox_schema import load_proxmox_generated_openapi; assert load_proxmox_generated_openapi().get('paths')"`
- `uv run ty check proxbox_api/types proxbox_api/utils/retry.py proxbox_api/schemas/sync.py`