### PR TITLE
chore: reconcile main remote histories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,10 +25,10 @@ Submodule layout and cross-repo links: `/root/personal-context/claude-reference/
 
 ### Companion repos (cross-link map)
 
-- **`netbox-proxbox` v0.0.20.post1** — the NetBox plugin that consumes this backend.
+- **`netbox-proxbox` v0.0.21** — the NetBox plugin that consumes this backend.
   Source: <https://github.com/emersonfelipesp/netbox-proxbox>. The current
-  pairing is `netbox-proxbox 0.0.20.post1` ↔ `proxbox-api 0.0.17.post2` ↔ `proxmox-sdk 0.0.11.post2`
-  ↔ `netbox-sdk 0.0.9.post2`. Operational-verb routes (start/stop/snapshot/migrate)
+  pairing is `netbox-proxbox 0.0.21` ↔ `proxbox-api 0.0.18.post5` ↔ `proxmox-sdk 0.0.12`
+  ↔ `netbox-sdk 0.0.10`. Operational-verb routes (start/stop/snapshot/migrate)
   require `proxbox-api >= 0.0.17`; firewall model scaffolding and intent tag
   helpers require `>= 0.0.13`; HA tab and runtime tunables alone require `>= 0.0.11`.
   Firecracker Cloud uses the plugin for host pools, host-agent inventory, image
@@ -110,7 +110,7 @@ Open the nearest scoped guide for the code you are changing.
 
 - `proxbox_api/`: FastAPI package, session factories, schemas, routes, sync services, code generation, and shared utilities.
 - `proxbox-reconcile-rs/`: optional PyO3/maturin Rust package for VM operation-queue reconciliation parity testing and opt-in execution.
-- `proxmox-mock/`: Standalone `proxmox-mock-api` dev-dependency package (editable install from `pyproject.toml` `[tool.uv.sources]`). Used in tests as the mock Proxmox server. Note: `proxmox-sdk` is an **external pinned package** (`proxmox-sdk==0.0.11.post2` in `pyproject.toml`), not a local subdirectory.
+- `proxmox-mock/`: Standalone `proxmox-mock-api` dev-dependency package (editable install from `pyproject.toml` `[tool.uv.sources]`). Used in tests as the mock Proxmox server. Note: `proxmox-sdk` is an **external pinned package** (`proxmox-sdk==0.0.12` in `pyproject.toml`), not a local subdirectory.
 - `nextjs-ui/`: Next.js frontend used to manage one NetBox endpoint and multiple Proxmox endpoints.
 - `tests/`: Unit, integration, and end-to-end tests for the backend package.
 - `benchmarks/`: local benchmark helpers, including VM reconciliation queue datasets and timers.
@@ -249,7 +249,7 @@ while the Docker container is healthy on port `18800`.
 
 ## Dependencies
 
-- Runtime: `fastapi[standard]`, `proxmox-sdk==0.0.11.post2` (external PyPI package), `netbox-sdk==0.0.9.post1` (external PyPI package), `sqlmodel`, `aiosqlite`, `cryptography`, `bcrypt`, `asyncssh>=2.20.0,<3.0.0`
+- Runtime: `fastapi[standard]`, `proxmox-sdk==0.0.12` (external PyPI package), `netbox-sdk==0.0.10` (external PyPI package), `sqlmodel`, `aiosqlite`, `cryptography`, `bcrypt`, `asyncssh>=2.20.0,<3.0.0`
 - Tests: `pytest`, `httpx`, `playwright`, `pytest-cov`, `pytest-asyncio`, `pytest-xdist`
 - Docs: `mkdocs`, `mkdocs-material`, `mkdocs-static-i18n`
 

--- a/proxmox-mock/uv.lock
+++ b/proxmox-mock/uv.lock
@@ -647,16 +647,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.13.1"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "fastapi[standard]==0.137.2",
-    "proxmox-sdk==0.0.11.post2",
-    "netbox-sdk==0.0.9.post2",
+    "proxmox-sdk==0.0.12",
+    "netbox-sdk==0.0.10",
     "sqlmodel==0.0.38",
     "pydantic==2.13.3",
     "httpx>=0.28.1",
@@ -54,10 +54,10 @@ granian = [
     "granian>=2.7.4",
 ]
 pbs = [
-    "proxmox-sdk[pbs]==0.0.11.post2",
+    "proxmox-sdk[pbs]==0.0.12",
 ]
 pdm = [
-    "proxmox-sdk[pdm]==0.0.11.post2",
+    "proxmox-sdk[pdm]==0.0.12",
 ]
 
 [dependency-groups]

--- a/tests/test_proxmox_sdk_dependency.py
+++ b/tests/test_proxmox_sdk_dependency.py
@@ -1,9 +1,64 @@
-"""Tests for proxmox-sdk dependency wiring."""
+"""Tests for SDK dependency wiring."""
 
 from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROXBOX_API_VERSION = "0.0.18.post5"
+PROXMOX_SDK_VERSION = "0.0.12"
+NETBOX_SDK_VERSION = "0.0.10"
+
+
+def _pyproject() -> dict:
+    return tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+
+def _lockfile() -> dict:
+    return tomllib.loads((REPO_ROOT / "uv.lock").read_text(encoding="utf-8"))
 
 
 def test_proxmox_sdk_mock_entrypoint_is_importable() -> None:
     import proxmox_sdk.mock_main
 
     assert proxmox_sdk.mock_main.app is not None
+
+
+def test_certified_stack_dependency_pins_are_declared() -> None:
+    project = _pyproject()["project"]
+
+    assert project["version"] == PROXBOX_API_VERSION
+    assert f"proxmox-sdk=={PROXMOX_SDK_VERSION}" in project["dependencies"]
+    assert f"netbox-sdk=={NETBOX_SDK_VERSION}" in project["dependencies"]
+    assert f"proxmox-sdk[pbs]=={PROXMOX_SDK_VERSION}" in project["optional-dependencies"]["pbs"]
+    assert f"proxmox-sdk[pdm]=={PROXMOX_SDK_VERSION}" in project["optional-dependencies"]["pdm"]
+
+
+def test_certified_stack_dependency_pins_are_locked() -> None:
+    packages = {package["name"]: package for package in _lockfile()["package"]}
+    proxbox_api = packages["proxbox-api"]
+
+    assert proxbox_api["version"] == PROXBOX_API_VERSION
+    assert packages["proxmox-sdk"]["version"] == PROXMOX_SDK_VERSION
+    assert packages["netbox-sdk"]["version"] == NETBOX_SDK_VERSION
+
+    locked_specs = {
+        item["name"]: item["specifier"]
+        for item in proxbox_api["metadata"]["requires-dist"]
+        if item["name"] in {"proxmox-sdk", "netbox-sdk"} and "extras" not in item
+    }
+    assert locked_specs == {
+        "proxmox-sdk": f"=={PROXMOX_SDK_VERSION}",
+        "netbox-sdk": f"=={NETBOX_SDK_VERSION}",
+    }
+
+    extra_specs = {
+        tuple(item.get("extras", [])): item["specifier"]
+        for item in proxbox_api["metadata"]["requires-dist"]
+        if item["name"] == "proxmox-sdk" and item.get("extras")
+    }
+    assert extra_specs == {
+        ("pbs",): f"=={PROXMOX_SDK_VERSION}",
+        ("pdm",): f"=={PROXMOX_SDK_VERSION}",
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -1368,7 +1368,7 @@ wheels = [
 
 [[package]]
 name = "netbox-sdk"
-version = "0.0.9.post2"
+version = "0.0.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1377,9 +1377,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/80/cc9fdf865ea21a98ea95529d1ebaaee3a29f050500a3665a5a6f2f0f5337/netbox_sdk-0.0.9.post2.tar.gz", hash = "sha256:f3df0818a2fc2408d2c98d2135ddc05454a6911d0c3c9fe1de1b5c100c3dc406", size = 2432116, upload-time = "2026-06-08T15:30:46.661Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/65/f07ffbad956530737fcc256a5c7b9986795fc40f9a3772857f36d4753061/netbox_sdk-0.0.10.tar.gz", hash = "sha256:a1107dd30afcdbd80ac6b280194df718b77109d8ba4a2c739944c68e1db7bd2a", size = 2444686, upload-time = "2026-06-15T15:58:04.965Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/27/e40dcec034f8c0a3c7e1adeb6b33da40d8c59d1a763c02f722c97a198128/netbox_sdk-0.0.9.post2-py3-none-any.whl", hash = "sha256:bf0e3bef3dec05361a4d236f0b8c676e87a03437519edf87eae053a367299e4b", size = 2489585, upload-time = "2026-06-08T15:30:45.268Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f6/991368dd87c3ba5f7671eafe5b9fdaa9509ec28e19d24acc893e16ad833f/netbox_sdk-0.0.10-py3-none-any.whl", hash = "sha256:f43225502acc399ac2abe44163f93237e2e5ad2b5dd77847a0ee2367d5e2d914", size = 2494540, upload-time = "2026-06-15T15:58:03.623Z" },
 ]
 
 [[package]]
@@ -1601,12 +1601,12 @@ requires-dist = [
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6.1" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.7.6" },
     { name = "mkdocs-static-i18n", marker = "extra == 'docs'", specifier = ">=1.3.1" },
-    { name = "netbox-sdk", specifier = "==0.0.9.post2" },
+    { name = "netbox-sdk", specifier = "==0.0.10" },
     { name = "playwright", marker = "extra == 'playwright'", specifier = ">=1.58.0" },
     { name = "playwright", marker = "extra == 'test'", specifier = ">=1.58.0" },
-    { name = "proxmox-sdk", specifier = "==0.0.11.post2" },
-    { name = "proxmox-sdk", extras = ["pbs"], marker = "extra == 'pbs'", specifier = "==0.0.11.post2" },
-    { name = "proxmox-sdk", extras = ["pdm"], marker = "extra == 'pdm'", specifier = "==0.0.11.post2" },
+    { name = "proxmox-sdk", specifier = "==0.0.12" },
+    { name = "proxmox-sdk", extras = ["pbs"], marker = "extra == 'pbs'", specifier = "==0.0.12" },
+    { name = "proxmox-sdk", extras = ["pdm"], marker = "extra == 'pdm'", specifier = "==0.0.12" },
     { name = "pydantic", specifier = "==2.13.3" },
     { name = "pytest", marker = "extra == 'e2e'", specifier = ">=9.0.3" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3" },
@@ -1648,7 +1648,7 @@ dev = [{ name = "ruff", specifier = ">=0.15.8" }]
 
 [[package]]
 name = "proxmox-sdk"
-version = "0.0.11.post2"
+version = "0.0.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1657,9 +1657,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "slowapi" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/7f/032855ee8a4bbc54f586196023fab98eb1023ef034f310ed1cc978108b80/proxmox_sdk-0.0.11.post2.tar.gz", hash = "sha256:d47c27fcecc8cb14c7dadebf41514f2fba68ba9b161167c9451323abdb95029d", size = 3513650, upload-time = "2026-06-08T14:13:08.582Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/30/6e36fe33fca145d7f0fcd537276021e9358e1b1de209f52cc058a2c3e91f/proxmox_sdk-0.0.12.tar.gz", hash = "sha256:bb59b0a0d3cf72d7f32e48a7333ff3ab6060f20a113e3d7e6c478d9f36688253", size = 3513588, upload-time = "2026-06-15T15:40:53.253Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/d7/4ecbf1fde790755cd0729345625b6765f07d68c8ff291da9d06bf3df326a/proxmox_sdk-0.0.11.post2-py3-none-any.whl", hash = "sha256:92bbab3a8e03c795d1d3f168192a3cd01892279f024bac0a787f2334db82647c", size = 3727893, upload-time = "2026-06-08T14:13:06.964Z" },
+    { url = "https://files.pythonhosted.org/packages/85/8d/cdfcee1ffabdb8ffd53e02d1a05892ba1f8bb0783740aca0e7e01b072244/proxmox_sdk-0.0.12-py3-none-any.whl", hash = "sha256:d435193ac3be3af4f69421aca5cb30a101872f2c28c6d66047ae89588d6e4d93", size = 3727892, upload-time = "2026-06-15T15:40:51.504Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1781,16 +1781,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.13.1"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Reconciles the divergent `proxbox-api` `main` histories between GitHub and Gitea after the SDN backend merge.

- Preserves the GitHub `main` history containing the Proxmox SDN sync merge.
- Preserves the Gitea `main` history containing the certified SDK pin updates.
- Resolves the only conflicts to the certified stack pins:
  - `proxmox-sdk==0.0.12`
  - `netbox-sdk==0.0.10`
- Keeps the SDN route/service documentation from the backend SDN merge.
- Adds the Gitea-side dependency contract test coverage for the certified SDK stack.

After this PR merges, Gitea `main` can fast-forward to the reconciliation merge commit without force-pushing.

## Verification

- `uv sync --extra test`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python -m pytest tests/test_proxmox_sdk_dependency.py tests/test_sdn_sync_service.py tests/test_pve91_501_graceful_handling.py -q`
- `uv run python -m compileall proxbox_api tests/test_proxmox_sdk_dependency.py tests/test_sdn_sync_service.py tests/test_pve91_501_graceful_handling.py`

Notes:
- A full local `uv run python -m pytest -q` was started but stopped after several minutes because it was still at 1%; this repository’s full matrix is left to CI for the PR.
- `uv run ty check proxbox_api` reports pre-existing unrelated diagnostics across the repository, so it is not used as the reconciliation gate.
