### PR TITLE
Promote develop to main: stabilize CI image preparation

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -35,12 +35,16 @@ ci.yml (push/PR — dev mode E2E only)
 ├── test-free-threaded (continue-on-error)
 ├── docker-bind-smoke  (raw + granian bind-host startup checks)
 ├── setup             (generates E2E matrix)
-├── build-netbox-image (logs in to Docker Hub, then only uploads an artifact when the public NetBox image cannot be pulled)
-└── e2e-docker        (logs in to Docker Hub; needs: test + setup + build-netbox-image; transport × NetBox version matrix)
+├── build-netbox-image (pulls or source-builds each NetBox version once, then uploads a short-lived image artifact)
+├── prepare-e2e-service-images (PostgreSQL + Redis + nginx via mirror.gcr.io/library)
+├── prepare-proxmox-image (builds local proxmox-mock/ image per pve/pbs/pdm service marker)
+├── build-proxbox-image (builds each proxbox-api Docker target once per dependency mode)
+└── e2e-docker        (loads prepared image artifacts; needs: test + setup + image-prep jobs; transport × NetBox version matrix)
     - dev mode:  netbox-proxbox from the `develop` branch tarball (always-latest plugin; avoids stale-pin drift and chicken-and-egg with unreleased plugin tags)
-                 proxbox-api built from local checkout with DEV_OVERRIDES (netbox-sdk + proxmox-sdk from GitHub)
-    - pypi mode: netbox-proxbox from PyPI; proxbox-api built from local checkout without overrides
-    - NetBox image handling: each E2E job pulls the public image first and only downloads the source-built artifact when the registry pull fails. Both `build-netbox-image` and `e2e-docker` authenticate to Docker Hub (`DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN`, `continue-on-error`) so the existence check does not flap on the anonymous rate limit and fall back to the source build.
+                 proxbox-api artifact built from local checkout with DEV_OVERRIDES (netbox-sdk + proxmox-sdk from GitHub)
+    - pypi mode: netbox-proxbox from PyPI; proxbox-api artifact built from local checkout without overrides
+    - NetBox image handling: `build-netbox-image` pulls the public image when available and falls back to a source build when the registry image is missing. E2E jobs always download/load the prepared artifact instead of pulling the registry image again.
+    - Docker Hub quota control: official Python/PostgreSQL/Redis/nginx/Ubuntu bases use `mirror.gcr.io/library`; Proxmox mock images are built from the local `proxmox-mock/` package instead of pulling `emersonfelipesp/proxmox-sdk`.
     - NetBox readiness waits up to 20 minutes for migrations/search indexing, then checks `/api/status/` before creating tokens.
     - Docker-backed Proxmox E2E uses pytest marker `mock_http`; the separate in-process MockBackend pass uses `mock_backend`.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ on:
 
 env:
   PROXBOX_ENCRYPTION_KEY: proxbox-ci-only-encryption-key-not-a-secret
+  CI_OFFICIAL_IMAGE_PREFIX: mirror.gcr.io/library
 
 jobs:
   test:
@@ -102,7 +103,10 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build raw image
-        run: docker build --target raw -t proxbox-api:bind-smoke .
+        run: |
+          docker build --target raw \
+            --build-arg "PYTHON_BASE_IMAGE=${CI_OFFICIAL_IMAGE_PREFIX}/python:3.13-alpine" \
+            -t proxbox-api:bind-smoke .
 
       # We verify success by reading uvicorn's startup log instead of curling
       # the published port. Docker's userland port proxy cannot forward an
@@ -159,7 +163,10 @@ jobs:
           echo "TIMEOUT"; docker logs pb-default; exit 1
 
       - name: Build granian image
-        run: docker build --target granian -t proxbox-api:bind-smoke-granian .
+        run: |
+          docker build --target granian \
+            --build-arg "PYTHON_BASE_IMAGE=${CI_OFFICIAL_IMAGE_PREFIX}/python:3.13-alpine" \
+            -t proxbox-api:bind-smoke-granian .
 
       - name: Granian image tolerates Compose list-form quoted value (regression for #52)
         run: |
@@ -299,7 +306,7 @@ jobs:
           git clone --depth 1 --branch "${NETBOX_VERSION}" \
             https://github.com/netbox-community/netbox.git /tmp/netbox-docker/.netbox
           docker build \
-            --build-arg "FROM=ubuntu:26.04" \
+            --build-arg "FROM=${CI_OFFICIAL_IMAGE_PREFIX}/ubuntu:26.04" \
             --build-arg "NETBOX_PATH=.netbox" \
             -t "${NETBOX_IMAGE}" \
             /tmp/netbox-docker
@@ -329,9 +336,12 @@ jobs:
       - name: Pull and save E2E service images
         run: |
           set -eux
-          docker pull postgres:16-alpine
-          docker pull redis:7-alpine
-          docker pull nginx:1.27-alpine
+          docker pull "${CI_OFFICIAL_IMAGE_PREFIX}/postgres:16-alpine"
+          docker pull "${CI_OFFICIAL_IMAGE_PREFIX}/redis:7-alpine"
+          docker pull "${CI_OFFICIAL_IMAGE_PREFIX}/nginx:1.27-alpine"
+          docker tag "${CI_OFFICIAL_IMAGE_PREFIX}/postgres:16-alpine" postgres:16-alpine
+          docker tag "${CI_OFFICIAL_IMAGE_PREFIX}/redis:7-alpine" redis:7-alpine
+          docker tag "${CI_OFFICIAL_IMAGE_PREFIX}/nginx:1.27-alpine" nginx:1.27-alpine
           docker save postgres:16-alpine redis:7-alpine nginx:1.27-alpine \
             | gzip > /tmp/e2e-service-images.tar.gz
 
@@ -343,7 +353,7 @@ jobs:
           retention-days: 1
 
   prepare-proxmox-image:
-    name: Prepare Proxmox mock image [${{ matrix.service }}]
+    name: Build Proxmox mock image [${{ matrix.service }}]
     runs-on: ubuntu-latest
     needs: setup
     strategy:
@@ -351,19 +361,18 @@ jobs:
       matrix:
         service: ${{ fromJSON(needs.setup.outputs.proxmox_services) }}
     env:
-      PROXMOX_OPENAPI_IMAGE: emersonfelipesp/proxmox-sdk:latest-${{ matrix.service }}
+      PROXMOX_OPENAPI_IMAGE: proxbox-e2e-proxmox-mock:${{ matrix.service }}
     steps:
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        continue-on-error: true
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v6
 
-      - name: Pull and save Proxmox mock image
+      - name: Build and save Proxmox mock image
         run: |
           set -eux
-          docker pull "${PROXMOX_OPENAPI_IMAGE}"
+          docker build -f proxmox-mock/Dockerfile \
+            --build-arg "PYTHON_BASE_IMAGE=${CI_OFFICIAL_IMAGE_PREFIX}/python:3.13-slim-bookworm" \
+            -t "${PROXMOX_OPENAPI_IMAGE}" \
+            proxmox-mock
           docker save "${PROXMOX_OPENAPI_IMAGE}" | gzip > /tmp/proxmox-sdk-image.tar.gz
 
       - name: Upload Proxmox mock image artifact
@@ -405,6 +414,7 @@ jobs:
         run: |
           set -eux
           docker build --target "${{ matrix.proxbox_docker_target }}" \
+            --build-arg "PYTHON_BASE_IMAGE=${CI_OFFICIAL_IMAGE_PREFIX}/python:3.13-alpine" \
             ${DEV_OVERRIDES:+--build-arg "DEV_OVERRIDES=${DEV_OVERRIDES}"} \
             -t "${PROXBOX_IMAGE}" .
           docker save "${PROXBOX_IMAGE}" | gzip > /tmp/proxbox-image.tar.gz
@@ -441,7 +451,7 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     env:
       NETBOX_IMAGE: netboxcommunity/netbox:${{ matrix.netbox_version }}
-      PROXMOX_OPENAPI_IMAGE: emersonfelipesp/proxmox-sdk:latest-${{ matrix.proxmox_service }}
+      PROXMOX_OPENAPI_IMAGE: proxbox-e2e-proxmox-mock:${{ matrix.proxmox_service }}
       PROXBOX_IMAGE: proxbox-e2e:${{ matrix.netbox_proxbox_mode }}-${{ matrix.proxbox_docker_target }}
       PROXBOX_SKIP_NETBOX_BOOTSTRAP: "1"
       UV_HTTP_TIMEOUT: "120"
@@ -549,9 +559,10 @@ jobs:
           docker run -d --name proxmox-e2e-mock --network proxbox-e2e -p "${HOST_BIND}18006:8000" \
             -e PROXMOX_API_MODE=mock \
             -e PROXMOX_MOCK_SCHEMA_VERSION=latest \
+            -e PROXMOX_MOCK_SERVICE="${{ matrix.proxmox_service }}" \
             -e PROXMOX_MOCK_BIND_HOST="${PROXMOX_MOCK_BIND_HOST}" \
             "${PROXMOX_OPENAPI_IMAGE}" \
-            sh -c 'exec uvicorn ${APP_MODULE} --host "${PROXMOX_MOCK_BIND_HOST}" --port "${PORT:-8000}"'
+            sh -c 'exec uvicorn proxmox_mock.main:app --host "${PROXMOX_MOCK_BIND_HOST}" --port "${PORT:-8000}"'
 
           mkdir -p .ci-tls
           cat > .ci-tls/netbox-openssl.cnf <<'EOF'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,8 @@ jobs:
     outputs:
       matrix: ${{ steps.gen.outputs.matrix }}
       netbox_versions: ${{ steps.gen.outputs.netbox_versions }}
+      proxmox_services: ${{ steps.gen.outputs.proxmox_services }}
+      proxbox_image_matrix: ${{ steps.gen.outputs.proxbox_image_matrix }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -245,9 +247,16 @@ jobs:
               for ver in netbox_versions
               for service in proxmox_services
           ]
+          proxbox_image_includes = [
+              {"netbox_proxbox_mode": mode, "proxbox_docker_target": target}
+              for mode in modes
+              for target in sorted({entry["proxbox_docker_target"] for entry in base})
+          ]
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
               fh.write(f"matrix={json.dumps({'include': includes})}\n")
               fh.write(f"netbox_versions={json.dumps(netbox_versions)}\n")
+              fh.write(f"proxmox_services={json.dumps(proxmox_services)}\n")
+              fh.write(f"proxbox_image_matrix={json.dumps({'include': proxbox_image_includes})}\n")
           PYEOF
         env:
           INPUT_NETBOX_PROXBOX_MODE: ${{ inputs.netbox_proxbox_mode || 'dev' }}
@@ -306,15 +315,126 @@ jobs:
           path: /tmp/netbox-image.tar.gz
           retention-days: 1
 
+  prepare-e2e-service-images:
+    name: Prepare E2E service images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        continue-on-error: true
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Pull and save E2E service images
+        run: |
+          set -eux
+          docker pull postgres:16-alpine
+          docker pull redis:7-alpine
+          docker pull nginx:1.27-alpine
+          docker save postgres:16-alpine redis:7-alpine nginx:1.27-alpine \
+            | gzip > /tmp/e2e-service-images.tar.gz
+
+      - name: Upload E2E service image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-service-images
+          path: /tmp/e2e-service-images.tar.gz
+          retention-days: 1
+
+  prepare-proxmox-image:
+    name: Prepare Proxmox mock image [${{ matrix.service }}]
+    runs-on: ubuntu-latest
+    needs: setup
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ${{ fromJSON(needs.setup.outputs.proxmox_services) }}
+    env:
+      PROXMOX_OPENAPI_IMAGE: emersonfelipesp/proxmox-sdk:latest-${{ matrix.service }}
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        continue-on-error: true
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Pull and save Proxmox mock image
+        run: |
+          set -eux
+          docker pull "${PROXMOX_OPENAPI_IMAGE}"
+          docker save "${PROXMOX_OPENAPI_IMAGE}" | gzip > /tmp/proxmox-sdk-image.tar.gz
+
+      - name: Upload Proxmox mock image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: proxmox-sdk-image-${{ matrix.service }}
+          path: /tmp/proxmox-sdk-image.tar.gz
+          retention-days: 1
+
+  build-proxbox-image:
+    name: Build Proxbox image [${{ matrix.netbox_proxbox_mode }}/${{ matrix.proxbox_docker_target }}]
+    runs-on: ubuntu-latest
+    needs: setup
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.setup.outputs.proxbox_image_matrix) }}
+    env:
+      PROXBOX_IMAGE: proxbox-e2e:${{ matrix.netbox_proxbox_mode }}-${{ matrix.proxbox_docker_target }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        continue-on-error: true
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Resolve dev SDK overrides
+        run: |
+          if [ "${{ matrix.netbox_proxbox_mode }}" = "dev" ]; then
+            echo 'DEV_OVERRIDES=git+https://github.com/emersonfelipesp/netbox-sdk.git@main git+https://github.com/emersonfelipesp/proxmox-sdk.git@main' >> "$GITHUB_ENV"
+          else
+            echo "DEV_OVERRIDES=" >> "$GITHUB_ENV"
+          fi
+
+      - name: Build Proxbox API image
+        run: |
+          set -eux
+          docker build --target "${{ matrix.proxbox_docker_target }}" \
+            ${DEV_OVERRIDES:+--build-arg "DEV_OVERRIDES=${DEV_OVERRIDES}"} \
+            -t "${PROXBOX_IMAGE}" .
+          docker save "${PROXBOX_IMAGE}" | gzip > /tmp/proxbox-image.tar.gz
+
+      - name: Upload Proxbox API image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: proxbox-image-${{ matrix.netbox_proxbox_mode }}-${{ matrix.proxbox_docker_target }}
+          path: /tmp/proxbox-image.tar.gz
+          retention-days: 1
+
   e2e-docker:
     name: E2E Docker / PX:${{ matrix.proxmox_service }} NB:${{ matrix.netbox_transport }} PB:${{ matrix.proxbox_transport }} [${{ matrix.network_stack }}] [${{ matrix.netbox_version }}] (${{ matrix.netbox_proxbox_mode }})
     runs-on: ubuntu-latest
-    needs: [test, setup, build-netbox-image]
+    needs:
+      - test
+      - setup
+      - build-netbox-image
+      - prepare-e2e-service-images
+      - prepare-proxmox-image
+      - build-proxbox-image
     if: |
       always() &&
       !cancelled() &&
       needs.test.result == 'success' &&
-      needs.setup.result == 'success'
+      needs.setup.result == 'success' &&
+      needs.build-netbox-image.result == 'success' &&
+      needs.prepare-e2e-service-images.result == 'success' &&
+      needs.prepare-proxmox-image.result == 'success' &&
+      needs.build-proxbox-image.result == 'success'
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -322,20 +442,12 @@ jobs:
     env:
       NETBOX_IMAGE: netboxcommunity/netbox:${{ matrix.netbox_version }}
       PROXMOX_OPENAPI_IMAGE: emersonfelipesp/proxmox-sdk:latest-${{ matrix.proxmox_service }}
+      PROXBOX_IMAGE: proxbox-e2e:${{ matrix.netbox_proxbox_mode }}-${{ matrix.proxbox_docker_target }}
       PROXBOX_SKIP_NETBOX_BOOTSTRAP: "1"
       UV_HTTP_TIMEOUT: "120"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Log in to Docker Hub
-        # Authenticated pulls avoid the low anonymous Docker Hub rate limit for
-        # the service/base images this e2e matrix pulls.
-        uses: docker/login-action@v3
-        continue-on-error: true
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -355,38 +467,37 @@ jobs:
             echo "target=netbox-proxbox" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Resolve dev SDK overrides
-        run: |
-          if [ "${{ matrix.netbox_proxbox_mode }}" = "dev" ]; then
-            echo 'DEV_OVERRIDES=git+https://github.com/emersonfelipesp/netbox-sdk.git@main git+https://github.com/emersonfelipesp/proxmox-sdk.git@main' >> "$GITHUB_ENV"
-          else
-            echo "DEV_OVERRIDES=" >> "$GITHUB_ENV"
-          fi
-
-      - name: Resolve NetBox image source
-        id: netbox_image
-        run: |
-          for attempt in 1 2 3 4 5; do
-            if docker pull "${NETBOX_IMAGE}" 2>/dev/null; then
-              echo "source=registry" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            echo "Registry pull attempt ${attempt}/5 failed for ${NETBOX_IMAGE}; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          echo "source=artifact" >> "$GITHUB_OUTPUT"
-
-      - name: Download NetBox image artifact (if built from source)
-        if: steps.netbox_image.outputs.source == 'artifact'
+      - name: Download NetBox image artifact
         uses: actions/download-artifact@v4
         with:
           name: netbox-image-${{ matrix.netbox_version }}
-          path: /tmp/
+          path: /tmp/e2e-images/netbox/
 
-      - name: Load NetBox image from artifact
-        if: steps.netbox_image.outputs.source == 'artifact'
+      - name: Download Proxmox mock image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: proxmox-sdk-image-${{ matrix.proxmox_service }}
+          path: /tmp/e2e-images/proxmox/
+
+      - name: Download E2E service image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: e2e-service-images
+          path: /tmp/e2e-images/services/
+
+      - name: Download Proxbox API image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: proxbox-image-${{ matrix.netbox_proxbox_mode }}-${{ matrix.proxbox_docker_target }}
+          path: /tmp/e2e-images/proxbox/
+
+      - name: Load Docker image artifacts
         run: |
-          docker load < /tmp/netbox-image.tar.gz
+          set -eux
+          docker load < /tmp/e2e-images/netbox/netbox-image.tar.gz
+          docker load < /tmp/e2e-images/proxmox/proxmox-sdk-image.tar.gz
+          docker load < /tmp/e2e-images/services/e2e-service-images.tar.gz
+          docker load < /tmp/e2e-images/proxbox/proxbox-image.tar.gz
 
       - name: Start E2E stack
         run: |
@@ -434,8 +545,6 @@ jobs:
 
           docker run -d --name netbox-e2e-redis --network proxbox-e2e \
             redis:7-alpine
-
-          docker pull "${PROXMOX_OPENAPI_IMAGE}"
 
           docker run -d --name proxmox-e2e-mock --network proxbox-e2e -p "${HOST_BIND}18006:8000" \
             -e PROXMOX_API_MODE=mock \
@@ -683,13 +792,9 @@ jobs:
           echo "NETBOX_TOKEN_ID=$TOKEN_ID" >> "$GITHUB_ENV"
           echo "NETBOX_API_TOKEN=$TOKEN_VALUE" >> "$GITHUB_ENV"
 
-      - name: Build and start Proxbox API backend container
+      - name: Start Proxbox API backend container
         run: |
           set -eux
-          docker build --target "${{ matrix.proxbox_docker_target }}" \
-            ${DEV_OVERRIDES:+--build-arg "DEV_OVERRIDES=${DEV_OVERRIDES}"} \
-            -t "proxbox-e2e:${{ matrix.proxbox_transport }}" .
-
           if [ "${{ matrix.network_stack }}" = "ipv6" ]; then
             PROXBOX_BIND_HOST_VALUE="::"
           else
@@ -702,7 +807,7 @@ jobs:
             -e PROXBOX_ENCRYPTION_KEY \
             -e SSL_CERT_FILE=/ci-tls/ca.crt \
             -v "$GITHUB_WORKSPACE/.ci-tls:/ci-tls:ro" \
-            "proxbox-e2e:${{ matrix.proxbox_transport }}"
+            "${PROXBOX_IMAGE}"
 
           for i in $(seq 1 120); do
             if curl ${{ matrix.proxbox_curl_flags }} -fsS --max-time 5 "${{ matrix.proxbox_base_url }}/" >/dev/null 2>&1; then

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -33,6 +33,7 @@ permissions:
 env:
   PROXBOX_ENCRYPTION_KEY: proxbox-ci-only-encryption-key-not-a-secret
   PROXBOX_SKIP_NETBOX_BOOTSTRAP: "1"
+  CI_OFFICIAL_IMAGE_PREFIX: mirror.gcr.io/library
 
 jobs:
   prepare-release:
@@ -409,7 +410,7 @@ jobs:
             git clone --depth 1 --branch "${NETBOX_VERSION}" \
               https://github.com/netbox-community/netbox.git /tmp/netbox-docker/.netbox
             docker build \
-              --build-arg "FROM=ubuntu:26.04" \
+              --build-arg "FROM=${CI_OFFICIAL_IMAGE_PREFIX}/ubuntu:26.04" \
               --build-arg "NETBOX_PATH=.netbox" \
               -t "${NETBOX_IMAGE}" \
               /tmp/netbox-docker
@@ -434,6 +435,7 @@ jobs:
             "${NETBOX_IMAGE}" -ec "uv pip install --no-cache-dir '${NETBOX_PROXBOX_TARGET}' && mkdir -p /etc/netbox/config && printf 'PLUGINS = [\"netbox_proxbox\"]\\n' > /etc/netbox/config/plugins.py && i=0 && until /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py migrate --no-input; do i=\$((i+1)); if [ \$i -ge 120 ]; then echo 'migrate exhausted retries'; exit 1; fi; sleep 2; done && /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py runserver 0.0.0.0:8000 --insecure"
 
           docker build --target raw \
+            --build-arg "PYTHON_BASE_IMAGE=${CI_OFFICIAL_IMAGE_PREFIX}/python:3.13-alpine" \
             --build-arg "DEV_OVERRIDES=${DEV_OVERRIDES}" \
             -t proxbox-e2e:raw .
 
@@ -697,7 +699,7 @@ jobs:
             git clone --depth 1 --branch "${NETBOX_VERSION}" \
               https://github.com/netbox-community/netbox.git /tmp/netbox-docker/.netbox
             docker build \
-              --build-arg "FROM=ubuntu:26.04" \
+              --build-arg "FROM=${CI_OFFICIAL_IMAGE_PREFIX}/ubuntu:26.04" \
               --build-arg "NETBOX_PATH=.netbox" \
               -t "${NETBOX_IMAGE}" \
               /tmp/netbox-docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Build dependencies and the app into a virtualenv with uv from the checked-out repo.
-FROM python:3.13-alpine AS builder
+ARG PYTHON_BASE_IMAGE=python:3.13-alpine
+
+FROM ${PYTHON_BASE_IMAGE} AS builder
 
 WORKDIR /app
 
@@ -34,7 +36,7 @@ RUN uv pip install --python /app/.venv/bin/python ./proxbox-reconcile-rs && \
     /app/.venv/bin/python -c "from proxbox_api.services.sync.reconciliation.rust_bridge import rust_available; assert rust_available()"
 
 # Application tree + venv only (shared by Python-only runtime images).
-FROM python:3.13-alpine AS runtime-base
+FROM ${PYTHON_BASE_IMAGE} AS runtime-base
 
 WORKDIR /app
 
@@ -54,7 +56,7 @@ EXPOSE 8000
 VOLUME ["/data"]
 
 # Application tree + venv only (shared by PyO3/Rust runtime images).
-FROM python:3.13-alpine AS runtime-base-pyo3-rust
+FROM ${PYTHON_BASE_IMAGE} AS runtime-base-pyo3-rust
 
 WORKDIR /app
 

--- a/docs/development/ci-e2e-workflows.md
+++ b/docs/development/ci-e2e-workflows.md
@@ -51,10 +51,15 @@ flowchart TD
 CI prepares Docker images once as short-lived workflow artifacts, then every
 E2E matrix leg loads those artifacts before starting the stack. This keeps the
 large NetBox-version matrix from repeatedly pulling Docker Hub images or
-rebuilding Proxbox API targets. The NetBox prep job pulls the public image when
-available and falls back to a source build when the registry image is missing.
-The fallback source build follows the current upstream `netbox-docker` base
-image, `ubuntu:26.04`, so the package set matches the upstream Dockerfile.
+rebuilding Proxbox API targets. Official Python, PostgreSQL, Redis, nginx, and
+NetBox fallback base images are pulled through `mirror.gcr.io/library` to avoid
+Docker Hub quota failures. The Proxmox mock image is built from the checked-out
+`proxmox-mock/` package for each `pve`, `pbs`, and `pdm` service marker. The
+NetBox prep job pulls the public image when available and falls back to a
+source build when the registry image is missing. The fallback source build
+follows the current upstream `netbox-docker` base image, `ubuntu:26.04`, via the
+mirror-backed image reference, so the package set matches the upstream
+Dockerfile.
 
 ## E2E Stack
 
@@ -90,6 +95,9 @@ Important E2E rules:
 - `/api/status/` must be ready before tokens and endpoints are configured.
 - Docker images are loaded from prepared artifacts; E2E matrix jobs do not pull
   Docker Hub images or rebuild Proxbox API containers directly.
+- Proxmox mock containers use the local schema-driven mock package and expose
+  `PROXMOX_MOCK_SERVICE` so PBS/PDM service smoke tests can verify the active
+  service marker without pulling external mock images.
 - Docker-backed Proxmox tests run with the `mock_http` marker.
 - The in-process `MockBackend` pass runs separately with the `mock_backend`
   marker.

--- a/docs/development/ci-e2e-workflows.md
+++ b/docs/development/ci-e2e-workflows.md
@@ -25,7 +25,10 @@ flowchart TD
     Free[test-free-threaded\ncontinue-on-error]
     Bind[Docker bind-host smoke\nraw + granian]
     Setup[setup\nbuild E2E matrix]
-    BuildNB[build-netbox-image\nonly if registry pull fails]
+    BuildNB[build-netbox-image\npull or source-build NetBox once]
+    BuildSvc[prepare-e2e-service-images\nPostgreSQL + Redis + nginx]
+    BuildPM[prepare-proxmox-image\nProxmox mock images]
+    BuildPB[build-proxbox-image\nProxbox API targets]
     E2E[e2e-docker\ntransport x NetBox version matrix]
 
     Push --> Core
@@ -34,15 +37,24 @@ flowchart TD
     Push --> Bind
     Push --> Setup
     Setup --> BuildNB
+    Setup --> BuildPM
+    Setup --> BuildPB
+    Push --> BuildSvc
     Core --> E2E
     Setup --> E2E
     BuildNB --> E2E
+    BuildSvc --> E2E
+    BuildPM --> E2E
+    BuildPB --> E2E
 ```
 
-The E2E jobs pull the public NetBox image first. They only download the
-source-built NetBox image artifact when that registry pull fails. The fallback
-source build follows the current upstream `netbox-docker` base image,
-`ubuntu:26.04`, so the package set matches the upstream Dockerfile.
+CI prepares Docker images once as short-lived workflow artifacts, then every
+E2E matrix leg loads those artifacts before starting the stack. This keeps the
+large NetBox-version matrix from repeatedly pulling Docker Hub images or
+rebuilding Proxbox API targets. The NetBox prep job pulls the public image when
+available and falls back to a source build when the registry image is missing.
+The fallback source build follows the current upstream `netbox-docker` base
+image, `ubuntu:26.04`, so the package set matches the upstream Dockerfile.
 
 ## E2E Stack
 
@@ -76,6 +88,8 @@ Important E2E rules:
 
 - NetBox readiness waits up to 20 minutes for migrations/search indexing.
 - `/api/status/` must be ready before tokens and endpoints are configured.
+- Docker images are loaded from prepared artifacts; E2E matrix jobs do not pull
+  Docker Hub images or rebuild Proxbox API containers directly.
 - Docker-backed Proxmox tests run with the `mock_http` marker.
 - The in-process `MockBackend` pass runs separately with the `mock_backend`
   marker.

--- a/docs/pt-BR/development/ci-e2e-workflows.md
+++ b/docs/pt-BR/development/ci-e2e-workflows.md
@@ -25,7 +25,10 @@ flowchart TD
     Free[test-free-threaded\ncontinue-on-error]
     Bind[Docker bind-host smoke\nraw + granian]
     Setup[setup\ngera matriz E2E]
-    BuildNB[build-netbox-image\nso se pull do registro falhar]
+    BuildNB[build-netbox-image\npull ou build NetBox uma vez]
+    BuildSvc[prepare-e2e-service-images\nPostgreSQL + Redis + nginx]
+    BuildPM[prepare-proxmox-image\nimagens mock Proxmox]
+    BuildPB[build-proxbox-image\ntargets Proxbox API]
     E2E[e2e-docker\nmatriz transporte x versao NetBox]
 
     Push --> Core
@@ -34,13 +37,28 @@ flowchart TD
     Push --> Bind
     Push --> Setup
     Setup --> BuildNB
+    Setup --> BuildPM
+    Setup --> BuildPB
+    Push --> BuildSvc
     Core --> E2E
     Setup --> E2E
     BuildNB --> E2E
+    BuildSvc --> E2E
+    BuildPM --> E2E
+    BuildPB --> E2E
 ```
 
-Os jobs E2E tentam baixar primeiro a imagem publica do NetBox. Eles so baixam o
-artefato de imagem construido a partir do codigo-fonte quando esse pull falha.
+O CI prepara imagens Docker uma vez como artefatos temporarios do workflow, e
+cada job da matriz E2E carrega esses artefatos antes de subir a stack. Isso
+evita pulls repetidos do Docker Hub e rebuilds do Proxbox API em uma matriz
+grande de versoes do NetBox. Imagens oficiais de Python, PostgreSQL, Redis,
+nginx e a base fallback do NetBox sao baixadas por `mirror.gcr.io/library` para
+evitar falhas por cota do Docker Hub. A imagem mock do Proxmox e construida a
+partir do pacote local `proxmox-mock/` para cada marcador de servico `pve`,
+`pbs` e `pdm`. O job do NetBox baixa a imagem publica quando disponivel e faz
+fallback para build a partir do codigo-fonte quando a imagem do registro nao
+existe. Esse build fallback segue a base atual do `netbox-docker`,
+`ubuntu:26.04`, usando a referencia via mirror.
 
 ## Stack E2E
 
@@ -56,7 +74,7 @@ flowchart LR
         NB[Container NetBox\nnetbox-proxbox instalado]
         NGINX[nginx HTTPS opcional]
         API[Container proxbox-api\ntarget raw, nginx ou granian]
-        PM[Container mock Proxmox\nproxmox-sdk:latest]
+        PM[Container mock Proxmox\nproxmox-mock local]
         PG[(PostgreSQL)]
         RD[(Redis)]
     end
@@ -75,6 +93,11 @@ Regras importantes do E2E:
 
 - A prontidao do NetBox aguarda ate 20 minutos por migracoes/indexacao.
 - `/api/status/` precisa estar pronto antes de configurar tokens e endpoints.
+- Imagens Docker sao carregadas a partir de artefatos preparados; os jobs da
+  matriz E2E nao fazem pull do Docker Hub nem rebuild direto dos conteineres
+  Proxbox API.
+- Containers mock do Proxmox usam o pacote local de mock schema-driven e expoem
+  `PROXMOX_MOCK_SERVICE` para validar o marcador ativo em testes PBS/PDM.
 - Testes Docker com mock Proxmox usam o marker `mock_http`.
 - A passagem em processo com `MockBackend` roda separadamente com o marker
   `mock_backend`.

--- a/proxmox-mock/Dockerfile
+++ b/proxmox-mock/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.13-slim-bookworm AS builder
+ARG PYTHON_BASE_IMAGE=python:3.13-slim-bookworm
+
+FROM ${PYTHON_BASE_IMAGE} AS builder
 
 WORKDIR /app
 
@@ -15,7 +17,7 @@ RUN uv venv --seed /app/.venv && \
     /app/.venv/bin/python -m pip install --upgrade pip && \
     /app/.venv/bin/pip install .
 
-FROM python:3.13-slim-bookworm AS runtime
+FROM ${PYTHON_BASE_IMAGE} AS runtime
 
 WORKDIR /app
 

--- a/proxmox-mock/proxmox_mock/app.py
+++ b/proxmox-mock/proxmox_mock/app.py
@@ -15,9 +15,10 @@ def create_mock_app() -> FastAPI:
     """Build the standalone Proxmox mock API app."""
 
     version_tag = os.environ.get("PROXMOX_MOCK_SCHEMA_VERSION", DEFAULT_PROXMOX_OPENAPI_TAG)
+    service = os.environ.get("PROXMOX_MOCK_SERVICE", "pve").strip().lower() or "pve"
 
     app = FastAPI(
-        title="Proxmox Mock API",
+        title=f"Proxmox Mock API ({service})",
         description="Schema-driven in-memory FastAPI mock for the generated Proxmox API.",
         version=__version__,
     )
@@ -25,7 +26,8 @@ def create_mock_app() -> FastAPI:
     @app.get("/")
     async def root() -> dict[str, object]:
         return {
-            "message": "Schema-driven Proxmox mock API",
+            "message": f"Schema-driven Proxmox mock API ({service})",
+            "service": service,
             "schema_version": version_tag,
             "package_version": __version__,
         }

--- a/tests/test_proxmox_mock_dependency.py
+++ b/tests/test_proxmox_mock_dependency.py
@@ -1,7 +1,20 @@
 from __future__ import annotations
 
+from fastapi.testclient import TestClient
+
 
 def test_proxmox_mock_package_is_importable() -> None:
     import proxmox_mock.main
 
     assert proxmox_mock.main.app is not None
+
+
+def test_proxmox_mock_root_reports_configured_service(monkeypatch) -> None:
+    from proxmox_mock.app import create_mock_app
+
+    monkeypatch.setenv("PROXMOX_MOCK_SERVICE", "pbs")
+
+    response = TestClient(create_mock_app()).get("/")
+
+    assert response.status_code == 200
+    assert response.json()["service"] == "pbs"

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -49,21 +49,32 @@ def test_netbox_e2e_readiness_is_long_enough_for_migrations_and_api_status():
     assert publish_workflow.count("NetBox API did not become ready") >= 2
 
 
-def test_ci_downloads_netbox_image_artifact_only_when_registry_pull_fails():
+def test_ci_e2e_loads_prepared_image_artifacts_before_stack_start():
     workflow = _read(CI_WORKFLOW_PATH)
-    e2e_image_block = workflow.split("Resolve NetBox image source", 1)[1]
+    e2e_block = workflow.split("e2e-docker:", 1)[1]
 
+    assert "prepare-e2e-service-images:" in workflow
+    assert "prepare-proxmox-image:" in workflow
+    assert "build-proxbox-image:" in workflow
+    assert "proxbox_image_matrix" in workflow
     _assert_order(
-        e2e_image_block,
-        'if docker pull "${NETBOX_IMAGE}" 2>/dev/null; then',
-        "Download NetBox image artifact (if built from source)",
-        "docker load < /tmp/netbox-image.tar.gz",
+        e2e_block,
+        "Download NetBox image artifact",
+        "Download Proxmox mock image artifact",
+        "Download E2E service image artifact",
+        "Download Proxbox API image artifact",
+        "Load Docker image artifacts",
         "Start E2E stack",
     )
-    assert "if: steps.netbox_image.outputs.source == 'artifact'" in workflow
-    download_step = workflow.split("Download NetBox image artifact (if built from source)", 1)[1]
-    download_step = download_step.split("Load NetBox image from artifact", 1)[0]
-    assert "continue-on-error: true" not in download_step
+    assert "Resolve NetBox image source" not in workflow
+    assert 'docker pull "${PROXMOX_OPENAPI_IMAGE}"' not in e2e_block
+
+    start_backend_block = e2e_block.split("Start Proxbox API backend container", 1)[1]
+    start_backend_block = start_backend_block.split(
+        "Verify Proxbox API reaches NetBox with requested transport", 1
+    )[0]
+    assert "docker build" not in start_backend_block
+    assert '"${PROXBOX_IMAGE}"' in start_backend_block
 
 
 def test_netbox_source_build_fallback_uses_current_upstream_base_image():

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -56,6 +56,8 @@ def test_ci_e2e_loads_prepared_image_artifacts_before_stack_start():
     assert "prepare-e2e-service-images:" in workflow
     assert "prepare-proxmox-image:" in workflow
     assert "build-proxbox-image:" in workflow
+    assert "proxbox-e2e-proxmox-mock:${{ matrix.service }}" in workflow
+    assert "emersonfelipesp/proxmox-sdk:latest-${{ matrix.service }}" not in workflow
     assert "proxbox_image_matrix" in workflow
     _assert_order(
         e2e_block,
@@ -83,8 +85,25 @@ def test_netbox_source_build_fallback_uses_current_upstream_base_image():
 
     assert "FROM=ubuntu:24.04" not in ci_workflow
     assert "FROM=ubuntu:24.04" not in publish_workflow
-    assert ci_workflow.count('--build-arg "FROM=ubuntu:26.04"') == 1
-    assert publish_workflow.count('--build-arg "FROM=ubuntu:26.04"') == 2
+    assert "FROM=ubuntu:26.04" not in ci_workflow
+    assert "FROM=ubuntu:26.04" not in publish_workflow
+    assert ci_workflow.count('--build-arg "FROM=${CI_OFFICIAL_IMAGE_PREFIX}/ubuntu:26.04"') == 1
+    assert (
+        publish_workflow.count('--build-arg "FROM=${CI_OFFICIAL_IMAGE_PREFIX}/ubuntu:26.04"') == 2
+    )
+
+
+def test_ci_docker_builds_use_mirror_backed_python_base_images():
+    workflow = _read(CI_WORKFLOW_PATH)
+
+    assert "CI_OFFICIAL_IMAGE_PREFIX: mirror.gcr.io/library" in workflow
+    assert (
+        '--build-arg "PYTHON_BASE_IMAGE=${CI_OFFICIAL_IMAGE_PREFIX}/python:3.13-alpine"' in workflow
+    )
+    assert (
+        '--build-arg "PYTHON_BASE_IMAGE=${CI_OFFICIAL_IMAGE_PREFIX}/python:3.13-slim-bookworm"'
+        in workflow
+    )
 
 
 def test_publish_workflow_routes_tags_to_testpypi_and_rcs_to_pypi():


### PR DESCRIPTION
Follow-up for SDN completion issue emersonfelipesp/netbox-proxbox#594.

## Summary

- prepares NetBox, Proxmox mock, shared service, and Proxbox API Docker images once as short-lived workflow artifacts
- changes the E2E matrix to load prepared images instead of pulling Docker Hub images or rebuilding Proxbox API per matrix job
- updates static workflow tests and developer docs for the artifact-based CI contract

## Why

The latest production `main` CI reached the NetBox v4.6.4 E2E path but many matrix jobs failed while rebuilding the Proxbox image with Docker Hub `429 Too Many Requests` for `python:3.13-alpine`. This keeps Docker Hub quota exposure in the small image-prep jobs instead of every E2E matrix leg.

## Verification

- `uv sync --extra test --group dev`
- `uv run pytest tests/test_release_workflows.py -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml', encoding='utf-8')); print('ok')"`
- generated matrix shape check for E2E and Proxbox image artifacts
- `git diff --check`
