### PR TITLE
Fix endpoint-scoped VM identity during sync

### DIFF
--- a/proxbox-reconcile-rs/src/vm.rs
+++ b/proxbox-reconcile-rs/src/vm.rs
@@ -64,28 +64,32 @@ pub fn build_vm_operation_queue_json(input: &[u8]) -> Result<Vec<u8>, ReconcileE
 }
 
 fn build_vm_operation_queue(input: VmQueueInput) -> Vec<VmOperation> {
-    let (typed_index, untyped_candidates) =
-        build_vm_snapshot_identity_indexes(input.netbox_snapshot);
+    let (
+        endpoint_typed_index,
+        endpoint_untyped_candidates,
+        cluster_typed_index,
+        cluster_untyped_candidates,
+    ) = build_vm_snapshot_identity_indexes(input.netbox_snapshot);
     let mut operations = Vec::with_capacity(input.prepared_vms.len());
 
     for prepared in input.prepared_vms {
+        let endpoint_id = extract_proxmox_endpoint_id_from_payload(&prepared.desired_payload);
         let cluster_id = relation_id(prepared.desired_payload.get("cluster"));
         let proxmox_vmid = relation_id(prepared.resource.get("vmid"));
         let Some(vmid) = proxmox_vmid else {
             operations.push(create_op(prepared, 0, &input.flags));
             continue;
         };
-        let Some(cluster_id) = cluster_id else {
-            operations.push(create_op(prepared, vmid, &input.flags));
-            continue;
-        };
 
         let Some(existing_record) = select_existing_vm_record(
             &prepared,
+            endpoint_id,
             cluster_id,
             vmid,
-            &typed_index,
-            &untyped_candidates,
+            &endpoint_typed_index,
+            &endpoint_untyped_candidates,
+            &cluster_typed_index,
+            &cluster_untyped_candidates,
         ) else {
             operations.push(create_op(prepared, vmid, &input.flags));
             continue;
@@ -152,41 +156,78 @@ fn output_desired_payload(
 
 fn build_vm_snapshot_identity_indexes(
     netbox_snapshot: Vec<Value>,
-) -> (TypedSnapshotIndex, UntypedSnapshotIndex) {
-    let mut typed_index = HashMap::new();
-    let mut untyped_candidates: UntypedSnapshotIndex = HashMap::new();
+) -> (
+    TypedSnapshotIndex,
+    UntypedSnapshotIndex,
+    TypedSnapshotIndex,
+    UntypedSnapshotIndex,
+) {
+    let mut endpoint_typed_index = HashMap::new();
+    let mut endpoint_untyped_candidates: UntypedSnapshotIndex = HashMap::new();
+    let mut cluster_typed_index = HashMap::new();
+    let mut cluster_untyped_candidates: UntypedSnapshotIndex = HashMap::new();
 
     for record in netbox_snapshot {
-        let Some((cluster_id, proxmox_vmid)) = extract_cluster_and_proxmox_vmid(&record) else {
-            continue;
-        };
-        untyped_candidates
-            .entry((cluster_id, proxmox_vmid))
-            .or_default()
-            .push(record.clone());
-        if let Some(vm_type) = extract_proxmox_vm_type(&record) {
-            typed_index
-                .entry((cluster_id, proxmox_vmid, vm_type))
-                .or_insert(record);
+        let vm_type = extract_proxmox_vm_type(&record);
+        if let Some((endpoint_id, proxmox_vmid)) = extract_endpoint_and_proxmox_vmid(&record) {
+            endpoint_untyped_candidates
+                .entry((endpoint_id, proxmox_vmid))
+                .or_default()
+                .push(record.clone());
+            if let Some(vm_type) = vm_type.clone() {
+                endpoint_typed_index
+                    .entry((endpoint_id, proxmox_vmid, vm_type))
+                    .or_insert(record.clone());
+            }
+        }
+        if let Some((cluster_id, proxmox_vmid)) = extract_cluster_and_proxmox_vmid(&record) {
+            cluster_untyped_candidates
+                .entry((cluster_id, proxmox_vmid))
+                .or_default()
+                .push(record.clone());
+            if let Some(vm_type) = vm_type {
+                cluster_typed_index
+                    .entry((cluster_id, proxmox_vmid, vm_type))
+                    .or_insert(record);
+            }
         }
     }
 
-    (typed_index, untyped_candidates)
+    (
+        endpoint_typed_index,
+        endpoint_untyped_candidates,
+        cluster_typed_index,
+        cluster_untyped_candidates,
+    )
 }
 
 fn select_existing_vm_record(
     prepared: &PreparedVm,
-    cluster_id: i64,
+    endpoint_id: Option<i64>,
+    cluster_id: Option<i64>,
     proxmox_vmid: i64,
-    typed_index: &TypedSnapshotIndex,
-    untyped_candidates: &UntypedSnapshotIndex,
+    endpoint_typed_index: &TypedSnapshotIndex,
+    endpoint_untyped_candidates: &UntypedSnapshotIndex,
+    cluster_typed_index: &TypedSnapshotIndex,
+    cluster_untyped_candidates: &UntypedSnapshotIndex,
 ) -> Option<Value> {
     let prepared_vm_type =
         normalize_proxmox_vm_type(Some(&Value::String(prepared.vm_type.clone())));
-    let untyped_key = (cluster_id, proxmox_vmid);
+    let (scope_id, typed_index, untyped_candidates) = if let Some(endpoint_id) = endpoint_id {
+        (
+            endpoint_id,
+            endpoint_typed_index,
+            endpoint_untyped_candidates,
+        )
+    } else if let Some(cluster_id) = cluster_id {
+        (cluster_id, cluster_typed_index, cluster_untyped_candidates)
+    } else {
+        return None;
+    };
+    let untyped_key = (scope_id, proxmox_vmid);
 
     if let Some(prepared_vm_type) = prepared_vm_type {
-        if let Some(record) = typed_index.get(&(cluster_id, proxmox_vmid, prepared_vm_type)) {
+        if let Some(record) = typed_index.get(&(scope_id, proxmox_vmid, prepared_vm_type)) {
             return Some(record.clone());
         }
         let candidates = untyped_candidates.get(&untyped_key)?;
@@ -207,6 +248,45 @@ fn extract_cluster_and_proxmox_vmid(record: &Value) -> Option<(i64, i64)> {
     let raw_vmid = custom_fields.get("proxmox_vm_id")?;
     let proxmox_vmid = relation_id(Some(raw_vmid))?;
     Some((cluster_id, proxmox_vmid))
+}
+
+fn extract_endpoint_and_proxmox_vmid(record: &Value) -> Option<(i64, i64)> {
+    let endpoint_id = extract_proxmox_endpoint_id(record)?;
+    let custom_fields = record.get("custom_fields")?.as_object()?;
+    let raw_vmid = custom_fields.get("proxmox_vm_id")?;
+    let proxmox_vmid = relation_id(Some(raw_vmid))?;
+    Some((endpoint_id, proxmox_vmid))
+}
+
+fn extract_proxmox_endpoint_id(record: &Value) -> Option<i64> {
+    let object = record.as_object()?;
+    for key in ["cf_proxmox_endpoint_id", "proxmox_endpoint_id"] {
+        if let Some(endpoint_id) = relation_id(object.get(key)) {
+            return Some(endpoint_id);
+        }
+    }
+    let custom_fields = object.get("custom_fields")?.as_object()?;
+    for key in ["proxmox_endpoint_id", "cf_proxmox_endpoint_id"] {
+        if let Some(endpoint_id) = relation_id(custom_fields.get(key)) {
+            return Some(endpoint_id);
+        }
+    }
+    None
+}
+
+fn extract_proxmox_endpoint_id_from_payload(payload: &Map<String, Value>) -> Option<i64> {
+    for key in ["cf_proxmox_endpoint_id", "proxmox_endpoint_id"] {
+        if let Some(endpoint_id) = relation_id(payload.get(key)) {
+            return Some(endpoint_id);
+        }
+    }
+    let custom_fields = payload.get("custom_fields")?.as_object()?;
+    for key in ["proxmox_endpoint_id", "cf_proxmox_endpoint_id"] {
+        if let Some(endpoint_id) = relation_id(custom_fields.get(key)) {
+            return Some(endpoint_id);
+        }
+    }
+    None
 }
 
 fn extract_proxmox_vm_type(record: &Value) -> Option<String> {
@@ -245,16 +325,21 @@ mod tests {
                 "memory": 2048,
                 "disk": 30,
                 "tags": [99],
-                "custom_fields": {"proxmox_vm_id": vmid, "proxmox_vm_type": vm_type},
+                "custom_fields": {
+                    "proxmox_endpoint_id": 500,
+                    "proxmox_vm_id": vmid,
+                    "proxmox_vm_type": vm_type
+                },
                 "description": "Synced from Proxmox node pve01"
             },
-            "lookup": {"cf_proxmox_vm_id": vmid, "cluster_id": 1},
+            "lookup": {"cf_proxmox_vm_id": vmid, "cf_proxmox_endpoint_id": 500},
             "vm_type": vm_type
         })
     }
 
     fn snapshot(record_id: i64, vmid: i64, vm_type: Option<&str>) -> Value {
         let mut custom_fields = Map::new();
+        custom_fields.insert("proxmox_endpoint_id".to_string(), json!(500));
         custom_fields.insert("proxmox_vm_id".to_string(), json!(vmid));
         if let Some(vm_type) = vm_type {
             custom_fields.insert("proxmox_vm_type".to_string(), json!(vm_type));
@@ -297,7 +382,11 @@ mod tests {
                     "memory": 1024,
                     "disk": 30,
                     "tags": [{"id": 99}],
-                    "custom_fields": {"proxmox_vm_id": 102, "proxmox_vm_type": "qemu"},
+                    "custom_fields": {
+                        "proxmox_endpoint_id": 500,
+                        "proxmox_vm_id": 102,
+                        "proxmox_vm_type": "qemu"
+                    },
                     "description": "Synced from Proxmox node pve01"
                 }
             ],
@@ -326,6 +415,32 @@ mod tests {
         assert_eq!(operations[0]["existing_record"]["id"], 3001);
         assert_eq!(operations[1]["method"], "GET");
         assert_eq!(operations[1]["existing_record"]["id"], 3002);
+    }
+
+    #[test]
+    fn keeps_same_vmid_on_different_endpoints_separate() {
+        let mut first = prepared(105, "qemu");
+        first["desired_payload"]["custom_fields"]["proxmox_endpoint_id"] = json!(1);
+        first["lookup"] = json!({"cf_proxmox_vm_id": 105, "cf_proxmox_endpoint_id": 1});
+        let mut second = prepared(105, "qemu");
+        second["desired_payload"]["custom_fields"]["proxmox_endpoint_id"] = json!(2);
+        second["lookup"] = json!({"cf_proxmox_vm_id": 105, "cf_proxmox_endpoint_id": 2});
+
+        let mut first_snapshot = snapshot(4105, 105, Some("qemu"));
+        first_snapshot["custom_fields"]["proxmox_endpoint_id"] = json!(1);
+        let mut second_snapshot = snapshot(4205, 105, Some("qemu"));
+        second_snapshot["custom_fields"]["proxmox_endpoint_id"] = json!(2);
+
+        let input = json!({
+            "prepared_vms": [first, second],
+            "netbox_snapshot": [first_snapshot, second_snapshot],
+            "flags": default_flags()
+        });
+
+        let operations = run(input);
+
+        assert_eq!(operations[0]["existing_record"]["id"], 4105);
+        assert_eq!(operations[1]["existing_record"]["id"], 4205);
     }
 
     #[test]

--- a/proxbox_api/routes/proxmox/runtime_generated.py
+++ b/proxbox_api/routes/proxmox/runtime_generated.py
@@ -8,6 +8,7 @@ import sys
 import threading
 from copy import deepcopy
 from datetime import UTC, datetime
+from hashlib import sha256
 from pathlib import Path as FilePath
 from types import ModuleType
 from typing import Literal
@@ -51,7 +52,16 @@ _GENERATED_ROUTE_STATE: dict[str, object] = {
 # rebuild (~25s on some CPython patch levels), making the suite time out.
 # Production starts once per process, so reusing an already-built module here
 # does not change its behavior.
-_MODEL_MODULE_CACHE: dict[str, ModuleType] = {}
+_MODEL_MODULE_CACHE: dict[tuple[str, str], ModuleType] = {}
+
+
+def _model_module_cache_key(
+    openapi_document: dict[str, object], version_tag: str
+) -> tuple[str, str]:
+    document_fingerprint = sha256(
+        json.dumps(openapi_document, sort_keys=True, default=str).encode("utf-8")
+    ).hexdigest()
+    return version_tag, document_fingerprint
 
 
 def _schema_to_annotation(schema: dict[str, object] | None) -> object:
@@ -113,8 +123,9 @@ def _render_proxmox_path(path_template: str, path_values: dict[str, object]) -> 
 
 
 def _load_model_module(openapi_document: dict[str, object], version_tag: str) -> ModuleType:
+    cache_key = _model_module_cache_key(openapi_document, version_tag)
     with _GENERATED_ROUTE_STATE_LOCK:
-        cached_module = _MODEL_MODULE_CACHE.get(version_tag)
+        cached_module = _MODEL_MODULE_CACHE.get(cache_key)
         if cached_module is not None:
             return cached_module
         code = generate_pydantic_models_from_openapi(openapi_document)
@@ -130,7 +141,7 @@ def _load_model_module(openapi_document: dict[str, object], version_tag: str) ->
                 and hasattr(value, "model_rebuild")
             ):
                 value.model_rebuild(_types_namespace=module.__dict__)
-        _MODEL_MODULE_CACHE[version_tag] = module
+        _MODEL_MODULE_CACHE[cache_key] = module
         return module
 
 

--- a/proxbox_api/routes/virtualization/virtual_machines/CLAUDE.md
+++ b/proxbox_api/routes/virtualization/virtual_machines/CLAUDE.md
@@ -66,22 +66,21 @@ Main synchronization endpoints for virtual machines and related resources.
   CPU validation/payload building and NetBox dependency calls out of the fetch
   semaphore so pending Proxmox HTTP responses are drained promptly and aiohttp
   wall-clock timeouts do not fire while other slots are doing CPU or NetBox work.
-- **VM lookups are scoped by `(cluster_id, vmid)`, not vmid alone (issue #223).**
-  Proxmox `vmid` is only unique within one cluster, so the same `vmid` can exist
-  on several clusters. The VM snapshot index is keyed by the
-  `(NetBox cluster id, proxmox_vm_id)` tuple
-  (`_build_vm_index_by_proxmox_id`), and interface/IP sync resolve their NetBox
-  VM through `_resolve_vm_from_index_or_unique_vmid` and
-  `_resolve_netbox_virtual_machine_by_proxmox_id`, both of which take a
-  `cluster_id`/`cluster_name`. The NetBox cluster id is resolved by name once
-  per cluster via `resolve_netbox_cluster_id_by_name`
-  (`services/sync/vm_helpers.py`) and memoized in a per-run cache. When the
-  cluster cannot be resolved, the code falls back to a vmid-only lookup **only
-  when it is globally unambiguous** (exactly one NetBox VM matches); an
-  ambiguous vmid is logged and skipped rather than mapped to the wrong VM. This
-  prevents interfaces/IPs from attaching to a same-vmid VM on another cluster
-  and is why the interface-collection loop also filters Proxmox resources by
-  `cluster_name`. Regression coverage: `tests/test_vm_cross_cluster_vmid.py`.
+- **VM lookups are scoped by `(proxmox_endpoint_id, vmid)` first (issue #255).**
+  Proxmox `vmid` values can repeat across standalone endpoints, even when those
+  endpoints have no shared NetBox cluster identity. The VM snapshot index is
+  keyed by `(proxmox_endpoint_id, proxmox_vm_id)` via
+  `_build_vm_index_by_proxmox_id`, and full VM sync, interface sync, IP sync,
+  individual VM sync, and the reconciliation queue all prefer
+  `cf_proxmox_endpoint_id + cf_proxmox_vm_id`. Cluster-scoped matching remains
+  only as legacy fallback when no endpoint id is available. A VMID-only fallback
+  is allowed only for one legacy NetBox VM that has no endpoint id; ambiguous
+  VMIDs are logged and skipped instead of being mapped to the wrong endpoint.
+  Disk and snapshot sync must route config/list calls through the Proxmox
+  session whose endpoint id matches the NetBox VM, so a same-VMID guest on
+  another endpoint cannot supply disks or snapshots. Regression coverage:
+  `tests/test_vm_cross_cluster_vmid.py`, `tests/test_virtual_disks_sync.py`,
+  `tests/test_snapshots_sync.py`, and `tests/reconciliation/test_vm_queue_python.py`.
 - **VM create routes bootstrap NetBox dependencies before writing.** The
   `/create`, `/{netbox_vm_id}/create`, `/create/stream`, and
   `/{netbox_vm_id}/create/stream` handlers attach the

--- a/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
+++ b/proxbox_api/routes/virtualization/virtual_machines/sync_vm.py
@@ -133,6 +133,10 @@ from proxbox_api.services.sync.vm_helpers import (
 from proxbox_api.services.sync.vm_helpers import (
     to_mapping as _to_mapping,
 )
+from proxbox_api.services.sync.vmid_helpers import (
+    extract_proxmox_endpoint_id,
+    extract_proxmox_session_endpoint_id,
+)
 from proxbox_api.session.proxmox import ProxmoxSessionsDep
 from proxbox_api.utils import return_status_html
 from proxbox_api.utils.streaming import WebSocketSSEBridge, sse_event
@@ -158,6 +162,44 @@ class _VMPreparationContext:
     endpoint_id_by_cluster: dict[str, int]
     resolve_vm_type: Callable[[str], Awaitable[object | None]]
     resolve_vm_proxmox_tag_ids: Callable[[str, dict[str, object]], Awaitable[list[int]]]
+
+
+def _vm_identity_lookup(
+    *,
+    vmid: object,
+    endpoint_id: int | None,
+    cluster_id: int | None,
+) -> dict[str, object]:
+    """Build the safest available NetBox lookup for a Proxmox VM."""
+    lookup: dict[str, object] = {"cf_proxmox_vm_id": int(vmid)}
+    if endpoint_id is not None:
+        lookup["cf_proxmox_endpoint_id"] = endpoint_id
+    elif cluster_id is not None:
+        lookup["cluster_id"] = cluster_id
+    return lookup
+
+
+def _endpoint_id_by_cluster_names(
+    pxs: object,
+    cluster_status: list[object] | None,
+) -> dict[str, int]:
+    """Map observed cluster/node names to the Proxmox endpoint id for the run."""
+    endpoint_id_by_cluster: dict[str, int] = {}
+    for px, cluster in zip(list(pxs or []), cluster_status or []):
+        endpoint_id = extract_proxmox_session_endpoint_id(px)
+        if endpoint_id is None:
+            continue
+        names = {
+            getattr(cluster, "name", None),
+            getattr(px, "name", None),
+            getattr(px, "cluster_name", None),
+            getattr(px, "node_name", None),
+        }
+        for name in names:
+            name_text = str(name or "").strip()
+            if name_text:
+                endpoint_id_by_cluster[name_text] = endpoint_id
+    return endpoint_id_by_cluster
 
 
 def _cluster_dependency_site_id(cluster_dependencies: dict[str, object]) -> int | None:
@@ -280,10 +322,13 @@ async def _prepare_vm_from_config(  # noqa: C901
         parse_description_metadata=context.behavior_flags.parse_description_metadata,
         overwrite_flags=context.effective_vm_overwrite_flags,
     )
-    lookup = {
-        "cf_proxmox_vm_id": int(resource.get("vmid")),
-        "cluster_id": int(getattr(cluster, "id", 0) or 0),
-    }
+    cluster_id = int(getattr(cluster, "id", 0) or 0) or None
+    endpoint_id = context.endpoint_id_by_cluster.get(str(cluster_name))
+    lookup = _vm_identity_lookup(
+        vmid=resource.get("vmid"),
+        endpoint_id=endpoint_id,
+        cluster_id=cluster_id,
+    )
 
     return _PreparedVMState(
         cluster_name=str(cluster_name),
@@ -382,21 +427,16 @@ async def _load_netbox_virtual_machine_snapshot(
 def _build_vm_index_by_proxmox_id(
     snapshot: list[dict[str, object]],
 ) -> dict[tuple[int, int], dict[str, object]]:
-    """Index a VM snapshot by ``(cluster_id, cf_proxmox_vm_id)`` for O(1) lookup."""
+    """Index a VM snapshot by ``(proxmox_endpoint_id, proxmox_vm_id)``."""
     index: dict[tuple[int, int], dict[str, object]] = {}
     for vm in snapshot:
-        cluster_id = _relation_id(vm.get("cluster"))
-        if cluster_id is None:
+        endpoint_id = extract_proxmox_endpoint_id(vm)
+        if endpoint_id is None:
             continue
-        custom_fields = vm.get("custom_fields")
-        if not isinstance(custom_fields, dict):
+        vmid = _extract_proxmox_vmid_from_vm_record(vm)
+        if vmid is None:
             continue
-        try:
-            vmid = int(custom_fields.get("proxmox_vm_id") or 0)
-        except (TypeError, ValueError):
-            continue
-        if vmid:
-            index[(cluster_id, vmid)] = vm
+        index.setdefault((endpoint_id, vmid), vm)
     return index
 
 
@@ -449,21 +489,39 @@ def _resolve_vm_from_index_or_unique_vmid(
     vm_index: dict[tuple[int, int], dict[str, object]],
     candidates_by_vmid: dict[int, list[dict[str, object]]],
     *,
-    cluster_id: int | None,
+    endpoint_id: int | None,
     raw_vmid: object,
     cluster_name: str,
     sync_context: str,
 ) -> dict[str, object] | None:
-    """Resolve a VM by scoped key first, then by unique vmid-only fallback."""
+    """Resolve a VM by endpoint-scoped key, with legacy fallback only when safe."""
     try:
         vmid = int(str(raw_vmid).strip())
     except (TypeError, ValueError):
         return None
 
-    if cluster_id is not None:
-        scoped_vm = vm_index.get((cluster_id, vmid))
+    if endpoint_id is not None:
+        scoped_vm = vm_index.get((endpoint_id, vmid))
         if scoped_vm is not None:
             return scoped_vm
+
+        legacy_candidates = [
+            candidate
+            for candidate in candidates_by_vmid.get(vmid, [])
+            if extract_proxmox_endpoint_id(candidate) is None
+        ]
+        if len(legacy_candidates) == 1:
+            return legacy_candidates[0]
+        if legacy_candidates or candidates_by_vmid.get(vmid):
+            logger.warning(
+                "Skipping VM %s sync for endpoint_id=%s cluster=%s vmid=%s: "
+                "no unambiguous endpoint-scoped NetBox VM match",
+                sync_context,
+                endpoint_id,
+                cluster_name or "unknown",
+                vmid,
+            )
+        return None
 
     return _select_unique_vm_candidate_by_vmid(
         candidates_by_vmid,
@@ -530,7 +588,12 @@ async def _resolve_vm_names_pre_pass(
     the bare name; subsequent VMs receive ``" (2)"``, ``" (3)"``, ...
     """
 
-    typed_vm_index, untyped_vm_candidates = _build_vm_snapshot_identity_indexes(netbox_snapshot)
+    (
+        endpoint_typed_vm_index,
+        endpoint_untyped_vm_candidates,
+        cluster_typed_vm_index,
+        cluster_untyped_vm_candidates,
+    ) = _build_vm_snapshot_identity_indexes(netbox_snapshot)
     cluster_used_names: dict[int, set[str]] = {}
     cluster_no_id_used_names: set[str] = set()
     for record in netbox_snapshot:
@@ -571,10 +634,13 @@ async def _resolve_vm_names_pre_pass(
                 vmid = 0
             existing = _select_existing_vm_record(
                 prepared=prepared,
+                endpoint_id=extract_proxmox_endpoint_id(prepared.desired_payload),
                 cluster_id=cluster_id,
                 proxmox_vmid=vmid or None,
-                typed_index=typed_vm_index,
-                untyped_candidates=untyped_vm_candidates,
+                endpoint_typed_index=endpoint_typed_vm_index,
+                endpoint_untyped_candidates=endpoint_untyped_vm_candidates,
+                cluster_typed_index=cluster_typed_vm_index,
+                cluster_untyped_candidates=cluster_untyped_vm_candidates,
             )
             if existing is not None:
                 existing_name = existing.get("name")
@@ -598,10 +664,13 @@ async def _resolve_vm_names_pre_pass(
 
             existing = _select_existing_vm_record(
                 prepared=prepared,
+                endpoint_id=extract_proxmox_endpoint_id(prepared.desired_payload),
                 cluster_id=cluster_id,
                 proxmox_vmid=vmid,
-                typed_index=typed_vm_index,
-                untyped_candidates=untyped_vm_candidates,
+                endpoint_typed_index=endpoint_typed_vm_index,
+                endpoint_untyped_candidates=endpoint_untyped_vm_candidates,
+                cluster_typed_index=cluster_typed_vm_index,
+                cluster_untyped_candidates=cluster_untyped_vm_candidates,
             )
             resolution = await resolve_unique_vm_name(
                 None,
@@ -839,8 +908,10 @@ def _filter_cluster_resources_for_vm(  # noqa: C901
     *,
     vm_name: str,
     proxmox_vm_id: int | None,
-    cluster_name: str | None,
-    cluster_id: int | None,
+    endpoint_id: int | None = None,
+    endpoint_id_by_cluster: dict[str, int] | None = None,
+    cluster_name: str | None = None,
+    cluster_id: int | None = None,
 ) -> list[dict]:
     """Filter cluster resources to find VM matching name and/or ID criteria.
 
@@ -868,6 +939,10 @@ def _filter_cluster_resources_for_vm(  # noqa: C901
             cluster_key_str = str(cluster_key)
             if cluster_hint and cluster_key_str.strip().lower() != cluster_hint:
                 continue
+            if endpoint_id is not None and endpoint_id_by_cluster:
+                cluster_endpoint_id = endpoint_id_by_cluster.get(cluster_key_str)
+                if cluster_endpoint_id is not None and cluster_endpoint_id != endpoint_id:
+                    continue
             selected = []
             for resource in resources:
                 if not isinstance(resource, dict):
@@ -1061,10 +1136,11 @@ async def _resolve_netbox_virtual_machine_by_proxmox_id(
     netbox_session: NetBoxSessionDep,
     proxmox_vm_id: int | str | None,
     *,
+    endpoint_id: int | None = None,
     cluster_id: int | None = None,
     cluster_name: str | None = None,
 ) -> dict[str, object] | None:
-    """Resolve the NetBox VM row for a Proxmox VM ID, scoped by NetBox cluster when possible."""
+    """Resolve the NetBox VM row for a Proxmox VM ID, scoped by endpoint when possible."""
     if proxmox_vm_id is None:
         return None
 
@@ -1073,17 +1149,20 @@ async def _resolve_netbox_virtual_machine_by_proxmox_id(
     except (TypeError, ValueError):
         return None
 
+    resolved_endpoint_id = endpoint_id
     resolved_cluster_id = cluster_id
-    if resolved_cluster_id is None and cluster_name:
+    if resolved_endpoint_id is None and resolved_cluster_id is None and cluster_name:
         resolved_cluster_id = await resolve_netbox_cluster_id_by_name(netbox_session, cluster_name)
 
     query: dict[str, object] = {"cf_proxmox_vm_id": vmid}
-    if resolved_cluster_id is not None:
+    if resolved_endpoint_id is not None:
+        query["cf_proxmox_endpoint_id"] = resolved_endpoint_id
+    elif resolved_cluster_id is not None:
         query["cluster_id"] = resolved_cluster_id
     else:
         logger.warning(
-            "Resolving NetBox VM by Proxmox VMID %s without cluster scope; "
-            "caller did not provide a resolvable cluster",
+            "Resolving NetBox VM by Proxmox VMID %s without endpoint or cluster scope; "
+            "caller did not provide a resolvable endpoint or cluster",
             proxmox_vm_id,
         )
 
@@ -1097,8 +1176,9 @@ async def _resolve_netbox_virtual_machine_by_proxmox_id(
         error_detail = getattr(exc, "detail", str(exc))
         error_msg = f"{type(exc).__name__}: {error_detail}"
         logger.warning(
-            "Could not resolve NetBox VM for Proxmox VMID %s cluster_id=%s: %s",
+            "Could not resolve NetBox VM for Proxmox VMID %s endpoint_id=%s cluster_id=%s: %s",
             proxmox_vm_id,
+            resolved_endpoint_id,
             resolved_cluster_id,
             error_msg,
         )
@@ -1107,9 +1187,9 @@ async def _resolve_netbox_virtual_machine_by_proxmox_id(
     if not virtual_machines:
         return None
 
-    if resolved_cluster_id is None and len(virtual_machines) > 1:
+    if resolved_endpoint_id is None and resolved_cluster_id is None and len(virtual_machines) > 1:
         logger.warning(
-            "ambiguous vmid across clusters: proxmox_vm_id=%s matched %s NetBox VMs",
+            "ambiguous vmid across endpoints/clusters: proxmox_vm_id=%s matched %s NetBox VMs",
             proxmox_vm_id,
             len(virtual_machines),
         )
@@ -1427,6 +1507,7 @@ async def _create_virtual_machine_by_netbox_id(
     vm_name = str(vm_data.get("name", "")).strip()
     vm_cluster_name = _relation_name(vm_data.get("cluster"))
     vm_cluster_id = _relation_id(vm_data.get("cluster"))
+    vm_endpoint_id = extract_proxmox_endpoint_id(vm_data)
     cf = vm_data.get("custom_fields")
     proxmox_vm_id = None
     if isinstance(cf, dict):
@@ -1454,6 +1535,8 @@ async def _create_virtual_machine_by_netbox_id(
         cluster_resources,
         vm_name=vm_name,
         proxmox_vm_id=proxmox_vm_id,
+        endpoint_id=vm_endpoint_id,
+        endpoint_id_by_cluster=_endpoint_id_by_cluster_names(pxs, cluster_status),
         cluster_name=vm_cluster_name,
         cluster_id=vm_cluster_id,
     )
@@ -1750,7 +1833,7 @@ async def create_virtual_machines(  # noqa: C901
     # Build a mapping from cluster name to Proxmox base URL for populating proxmox_link,
     # and a parallel mapping to the ProxmoxEndpoint DB ID for the console access custom field.
     proxmox_url_by_cluster: dict[str, str] = {}
-    endpoint_id_by_cluster: dict[str, int] = {}
+    endpoint_id_by_cluster = _endpoint_id_by_cluster_names(pxs, cluster_status)
     px_by_cluster: dict[str, object] = {}
     for px, cs in zip(pxs, cluster_status):
         cluster_n = getattr(cs, "name", None) or getattr(px, "cluster_name", None)
@@ -1758,11 +1841,15 @@ async def create_virtual_machines(  # noqa: C901
         px_port = getattr(px, "http_port", 8006)
         if cluster_n and px_domain:
             proxmox_url_by_cluster[str(cluster_n)] = f"https://{px_domain}:{px_port}"
-        if cluster_n:
-            px_by_cluster[str(cluster_n)] = px
-            px_db_endpoint_id = getattr(px, "db_endpoint_id", None)
-            if px_db_endpoint_id is not None:
-                endpoint_id_by_cluster[str(cluster_n)] = int(px_db_endpoint_id)
+        for px_name in {
+            cluster_n,
+            getattr(px, "name", None),
+            getattr(px, "cluster_name", None),
+            getattr(px, "node_name", None),
+        }:
+            px_name_text = str(px_name or "").strip()
+            if px_name_text:
+                px_by_cluster[px_name_text] = px
 
     # Per-cluster color-map cache: fetched once on first VM that needs it.
     tag_color_map_by_cluster: dict[str, dict[str, str]] = {}
@@ -2070,13 +2157,21 @@ async def create_virtual_machines(  # noqa: C901
 
         fetch_semaphore = asyncio.Semaphore(max(1, resolve_vm_sync_concurrency()))
 
-        async def _fetch_with_limit(resource: dict[str, object]) -> dict[str, object]:
+        async def _fetch_with_limit(
+            cluster_name: str,
+            resource: dict[str, object],
+        ) -> dict[str, object]:
             async with fetch_semaphore:
-                return await _fetch_vm_config_only(pxs=pxs, resource=resource)
+                cluster_px = px_by_cluster.get(str(cluster_name))
+                fetch_pxs = [cluster_px] if cluster_px is not None else pxs
+                return await _fetch_vm_config_only(pxs=fetch_pxs, resource=resource)
 
         fetch_t0 = time.perf_counter()
         fetch_results = await asyncio.gather(
-            *[_fetch_with_limit(resource) for _, resource in operation_inputs],
+            *[
+                _fetch_with_limit(cluster_name, resource)
+                for cluster_name, resource in operation_inputs
+            ],
             return_exceptions=True,
         )
         fetch_ms = (time.perf_counter() - fetch_t0) * 1000
@@ -2450,10 +2545,11 @@ async def create_virtual_machines(  # noqa: C901
         virtual_machine = await rest_reconcile_async(
             nb,
             "/api/virtualization/virtual-machines/",
-            lookup={
-                "cf_proxmox_vm_id": int(resource.get("vmid")),
-                "cluster_id": int(getattr(cluster, "id", 0) or 0),
-            },
+            lookup=_vm_identity_lookup(
+                vmid=resource.get("vmid"),
+                endpoint_id=endpoint_id_by_cluster.get(str(cluster_name)),
+                cluster_id=int(getattr(cluster, "id", 0) or 0) or None,
+            ),
             payload=netbox_vm_payload,
             schema=NetBoxVirtualMachineCreateBody,
             patchable_fields=vm_patchable_fields,
@@ -2461,6 +2557,7 @@ async def create_virtual_machines(  # noqa: C901
                 record,
                 supports_virtual_machine_type_field=supports_vm_type,
             ),
+            strict_lookup=True,
         )
 
         await stamp_vm_last_run_id(nb, virtual_machine, effective_run_id)
@@ -2943,10 +3040,12 @@ async def create_only_vm_interfaces(  # noqa: C901
     vm_index = _build_vm_index_by_proxmox_id(vm_snapshot)
     vm_candidates_by_vmid = _build_vm_candidates_by_proxmox_id(vm_snapshot)
     cluster_id_cache = _build_cluster_id_cache_from_vm_snapshot(vm_snapshot)
+    endpoint_id_by_cluster = _endpoint_id_by_cluster_names(pxs, cluster_status)
 
     async def _sync_vm_interfaces(  # noqa: C901
         cluster_name: str,
         cluster_id: int | None,
+        endpoint_id: int | None,
         resource: dict,
     ) -> tuple[list[dict], dict]:
         """Collect interface payloads for a single VM. Returns (payloads, interface_info_dict)."""
@@ -2977,7 +3076,7 @@ async def create_only_vm_interfaces(  # noqa: C901
         netbox_vm = _resolve_vm_from_index_or_unique_vmid(
             vm_index,
             vm_candidates_by_vmid,
-            cluster_id=cluster_id,
+            endpoint_id=endpoint_id,
             raw_vmid=vmid,
             cluster_name=cluster_name_str,
             sync_context="interface",
@@ -3006,7 +3105,7 @@ async def create_only_vm_interfaces(  # noqa: C901
         try:
             if proxmox_session and resource_node:
                 vm_config_result = get_vm_config(
-                    pxs=pxs,
+                    pxs=[proxmox_session],
                     node=resource_node,
                     type=vm_type,
                     vmid=int(vmid),
@@ -3134,10 +3233,11 @@ async def create_only_vm_interfaces(  # noqa: C901
     async def _run_task(
         cluster_name: str,
         cluster_id: int | None,
+        endpoint_id: int | None,
         resource: dict,
     ) -> tuple[list[dict], dict]:
         async with semaphore:
-            return await _sync_vm_interfaces(cluster_name, cluster_id, resource)
+            return await _sync_vm_interfaces(cluster_name, cluster_id, endpoint_id, resource)
 
     async def _create_cluster_tasks(cluster: dict) -> list:
         tasks = []
@@ -3147,9 +3247,10 @@ async def create_only_vm_interfaces(  # noqa: C901
                 str(cluster_name),
                 cache=cluster_id_cache,
             )
+            endpoint_id = endpoint_id_by_cluster.get(str(cluster_name))
             for resource in resources:
                 if resource.get("type") in ("qemu", "lxc"):
-                    tasks.append(_run_task(cluster_name, cluster_id, resource))
+                    tasks.append(_run_task(cluster_name, cluster_id, endpoint_id, resource))
         return await asyncio.gather(*tasks, return_exceptions=True)
 
     # Collect all interface payloads and metadata from all VMs
@@ -3495,10 +3596,12 @@ async def create_only_vm_ip_addresses(  # noqa: C901
     vm_index = _build_vm_index_by_proxmox_id(vm_snapshot)
     vm_candidates_by_vmid = _build_vm_candidates_by_proxmox_id(vm_snapshot)
     cluster_id_cache = _build_cluster_id_cache_from_vm_snapshot(vm_snapshot)
+    endpoint_id_by_cluster = _endpoint_id_by_cluster_names(pxs, cluster_status)
 
     async def _sync_vm_ips(
         cluster_name: str,
         cluster_id: int | None,
+        endpoint_id: int | None,
         resource: dict,
     ) -> tuple[list[dict], list[dict], dict]:  # noqa: C901
         """Collect IP payloads for a single VM. Returns (ip_payloads, first_ip_per_vm, ip_info)."""
@@ -3514,7 +3617,7 @@ async def create_only_vm_ip_addresses(  # noqa: C901
         netbox_vm = _resolve_vm_from_index_or_unique_vmid(
             vm_index,
             vm_candidates_by_vmid,
-            cluster_id=cluster_id,
+            endpoint_id=endpoint_id,
             raw_vmid=vmid,
             cluster_name=cluster_name_str,
             sync_context="IP address",
@@ -3543,7 +3646,7 @@ async def create_only_vm_ip_addresses(  # noqa: C901
         try:
             if proxmox_session and resource_node:
                 vm_config_result = get_vm_config(
-                    pxs=pxs,
+                    pxs=[proxmox_session],
                     node=resource_node,
                     type=vm_type,
                     vmid=int(vmid),
@@ -3794,10 +3897,11 @@ async def create_only_vm_ip_addresses(  # noqa: C901
     async def _run_task(
         cluster_name: str,
         cluster_id: int | None,
+        endpoint_id: int | None,
         resource: dict,
     ) -> tuple[list[dict], list[dict], dict]:
         async with semaphore:
-            return await _sync_vm_ips(cluster_name, cluster_id, resource)
+            return await _sync_vm_ips(cluster_name, cluster_id, endpoint_id, resource)
 
     async def _create_cluster_tasks(cluster: dict) -> list:
         tasks = []
@@ -3807,9 +3911,10 @@ async def create_only_vm_ip_addresses(  # noqa: C901
                 str(cluster_name),
                 cache=cluster_id_cache,
             )
+            endpoint_id = endpoint_id_by_cluster.get(str(cluster_name))
             for resource in resources:
                 if resource.get("type") in ("qemu", "lxc"):
-                    tasks.append(_run_task(cluster_name, cluster_id, resource))
+                    tasks.append(_run_task(cluster_name, cluster_id, endpoint_id, resource))
         return await asyncio.gather(*tasks, return_exceptions=True)
 
     # Collect all IP payloads and metadata from all VMs

--- a/proxbox_api/services/sync/individual/helpers.py
+++ b/proxbox_api/services/sync/individual/helpers.py
@@ -13,6 +13,7 @@ from proxbox_api.services.sync.vm_helpers import (
     parse_key_value_string,
     resolve_netbox_cluster_id_by_name,
 )
+from proxbox_api.services.sync.vmid_helpers import extract_proxmox_session_endpoint_id
 
 
 def normalize_mac(value: str | None) -> str:
@@ -288,10 +289,20 @@ async def _lookup_vm_by_scope_or_unique_vmid(
     nb: object,
     *,
     vmid: int,
+    endpoint_id: int | None,
     cluster_id: int | None,
     cluster_name: str,
 ) -> tuple[object | None, bool]:
     """Resolve by scoped VMID when possible, otherwise by unique vmid-only fallback."""
+    if endpoint_id is not None:
+        existing_vms = await rest_list_async(
+            nb,
+            "/api/virtualization/virtual-machines/",
+            query={"cf_proxmox_vm_id": vmid, "cf_proxmox_endpoint_id": endpoint_id},
+        )
+        if existing_vms:
+            return existing_vms[0], False
+        return None, False
     if cluster_id is not None:
         existing_vms = await rest_list_async(
             nb,
@@ -324,6 +335,7 @@ async def ensure_vm_record(
 ) -> tuple[object | None, str | None]:
     """Resolve the NetBox VM record for a Proxmox VM ID, creating it if requested."""
     resolved_cluster_name = str(cluster_name or getattr(px, "name", "") or "").strip()
+    endpoint_id = extract_proxmox_session_endpoint_id(px)
     resolved_cluster_id = cluster_id
     if resolved_cluster_id is None:
         resolved_cluster_id = await resolve_netbox_cluster_id_by_name(nb, resolved_cluster_name)
@@ -331,6 +343,7 @@ async def ensure_vm_record(
     vm_record, ambiguous = await _lookup_vm_by_scope_or_unique_vmid(
         nb,
         vmid=vmid,
+        endpoint_id=endpoint_id,
         cluster_id=resolved_cluster_id,
         cluster_name=resolved_cluster_name,
     )
@@ -361,6 +374,7 @@ async def ensure_vm_record(
     vm_record, ambiguous = await _lookup_vm_by_scope_or_unique_vmid(
         nb,
         vmid=vmid,
+        endpoint_id=endpoint_id,
         cluster_id=resolved_cluster_id,
         cluster_name=resolved_cluster_name,
     )

--- a/proxbox_api/services/sync/individual/vm_sync.py
+++ b/proxbox_api/services/sync/individual/vm_sync.py
@@ -40,6 +40,7 @@ from proxbox_api.services.sync.vm_helpers import (
     resolve_netbox_cluster_id_by_name,
     stamp_vm_last_run_id,
 )
+from proxbox_api.services.sync.vmid_helpers import extract_proxmox_session_endpoint_id
 
 
 def _mb_from_bytes(value: object) -> int:
@@ -160,11 +161,14 @@ async def _lookup_existing_vm_for_dry_run(
     *,
     cluster_name: str,
     vmid: int,
+    endpoint_id: int | None = None,
 ) -> object | None:
     """Resolve an existing VM for dry-run output without guessing ambiguous vmids."""
     cluster_id = await resolve_netbox_cluster_id_by_name(nb, cluster_name)
     vm_query: dict[str, object] = {"cf_proxmox_vm_id": vmid}
-    if cluster_id is not None:
+    if endpoint_id is not None:
+        vm_query["cf_proxmox_endpoint_id"] = endpoint_id
+    elif cluster_id is not None:
         vm_query["cluster_id"] = cluster_id
     existing = await rest_list_async(
         nb,
@@ -173,7 +177,7 @@ async def _lookup_existing_vm_for_dry_run(
     )
     if cluster_id is None and len(existing) > 1:
         logger.warning(
-            "ambiguous vmid across clusters: dry-run cluster=%s vmid=%s matched %s NetBox VMs",
+            "ambiguous vmid across endpoints/clusters: dry-run cluster=%s vmid=%s matched %s NetBox VMs",
             cluster_name,
             vmid,
             len(existing),
@@ -194,6 +198,7 @@ def _build_netbox_vm_payload(
     last_updated: datetime,
     cluster_name: str | None = None,
     proxmox_url: str | None = None,
+    endpoint_id: int | None = None,
     virtual_machine_type_id: int | None = None,
     site_id: int | None = None,
 ) -> dict:
@@ -236,6 +241,7 @@ def _build_netbox_vm_payload(
         "proxmox_node": node,
         "proxmox_status": proxmox_status,
         "proxmox_last_updated": last_updated.isoformat(),
+        "proxmox_endpoint_id": endpoint_id,
     }
     if cluster_name:
         vm_custom_fields["proxmox_cluster"] = cluster_name
@@ -298,6 +304,7 @@ async def sync_vm_individual(
     effective_run_id = run_id or str(uuid.uuid4())
     service = BaseIndividualSyncService(nb, px, tag, overwrite_flags=overwrite_flags)
     now = datetime.now(timezone.utc)
+    endpoint_id = extract_proxmox_session_endpoint_id(px)
 
     tag_id = int(getattr(tag, "id", 0) or 0)
     tag_ids = [tag_id] if tag_id > 0 else []
@@ -339,6 +346,7 @@ async def sync_vm_individual(
             nb,
             cluster_name=cluster_name,
             vmid=vmid,
+            endpoint_id=endpoint_id,
         )
         netbox_object = None
         if existing_vm is not None:
@@ -394,7 +402,15 @@ async def sync_vm_individual(
         existing_vms = await rest_list_async(
             nb,
             "/api/virtualization/virtual-machines/",
-            query={"cf_proxmox_vm_id": vmid, "cluster_id": cluster_id},
+            query={
+                key: value
+                for key, value in {
+                    "cf_proxmox_vm_id": vmid,
+                    "cf_proxmox_endpoint_id": endpoint_id,
+                    "cluster_id": cluster_id if endpoint_id is None else None,
+                }.items()
+                if value is not None
+            },
         )
 
         # Merge proxbox tag with any existing user tags so sync never erases them.
@@ -436,6 +452,7 @@ async def sync_vm_individual(
             last_updated=now,
             cluster_name=cluster_name,
             proxmox_url=px_url,
+            endpoint_id=endpoint_id,
             virtual_machine_type_id=vm_type_id,
             site_id=site_id,
         )
@@ -454,8 +471,13 @@ async def sync_vm_individual(
             nb,
             "/api/virtualization/virtual-machines/",
             lookup={
-                "cf_proxmox_vm_id": vmid,
-                "cluster_id": cluster_id,
+                key: value
+                for key, value in {
+                    "cf_proxmox_vm_id": vmid,
+                    "cf_proxmox_endpoint_id": endpoint_id,
+                    "cluster_id": cluster_id if endpoint_id is None else None,
+                }.items()
+                if value is not None
             },
             payload=netbox_vm_payload,
             schema=NetBoxVirtualMachineCreateBody,
@@ -469,6 +491,7 @@ async def sync_vm_individual(
                 record,
                 supports_virtual_machine_type_field=supports_vm_type,
             ),
+            strict_lookup=True,
         )
 
         await stamp_vm_last_run_id(nb, virtual_machine, effective_run_id)

--- a/proxbox_api/services/sync/reconciliation/vm_queue.py
+++ b/proxbox_api/services/sync/reconciliation/vm_queue.py
@@ -23,11 +23,14 @@ from proxbox_api.services.sync.vm_helpers import (
 from proxbox_api.services.sync.vm_helpers import (
     relation_id as _relation_id,
 )
+from proxbox_api.services.sync.vmid_helpers import extract_proxmox_endpoint_id
 
 logger = logging.getLogger(__name__)
 
 _VALID_ENGINES = {"python", "compare", "rust"}
 _MAX_DIFF_CHARS = 12000
+_TypedSnapshotIndex = dict[tuple[int, int, str], dict[str, object]]
+_UntypedSnapshotIndex = dict[tuple[int, int], list[dict[str, object]]]
 
 
 class RustOperationAdaptationError(RuntimeError):
@@ -48,7 +51,7 @@ def normalize_current_vm_payload(
 
 
 def extract_cluster_and_proxmox_vmid(record: dict[str, object]) -> tuple[int, int] | None:
-    """Build the in-memory index key used to correlate NetBox VM records."""
+    """Build the legacy cluster-scoped index key used when endpoint identity is absent."""
 
     cluster_id = _relation_id(record.get("cluster"))
     if cluster_id is None:
@@ -62,6 +65,23 @@ def extract_cluster_and_proxmox_vmid(record: dict[str, object]) -> tuple[int, in
     except (TypeError, ValueError):
         return None
     return (cluster_id, proxmox_vmid)
+
+
+def extract_endpoint_and_proxmox_vmid(record: dict[str, object]) -> tuple[int, int] | None:
+    """Build the endpoint-scoped index key used to correlate NetBox VM records."""
+
+    endpoint_id = extract_proxmox_endpoint_id(record)
+    if endpoint_id is None:
+        return None
+    custom_fields = record.get("custom_fields")
+    if not isinstance(custom_fields, dict):
+        return None
+    raw_vmid = custom_fields.get("proxmox_vm_id")
+    try:
+        proxmox_vmid = int(str(raw_vmid).strip())
+    except (TypeError, ValueError):
+        return None
+    return (endpoint_id, proxmox_vmid)
 
 
 def normalize_proxmox_vm_type(value: object) -> str | None:
@@ -93,41 +113,70 @@ def extract_proxmox_vm_type(record: dict[str, object]) -> str | None:
 def build_vm_snapshot_identity_indexes(
     snapshot: list[dict[str, object]],
 ) -> tuple[
-    dict[tuple[int, int, str], dict[str, object]],
-    dict[tuple[int, int], list[dict[str, object]]],
+    _TypedSnapshotIndex,
+    _UntypedSnapshotIndex,
+    _TypedSnapshotIndex,
+    _UntypedSnapshotIndex,
 ]:
-    """Index NetBox VM records by typed identity plus legacy untyped candidates."""
+    """Index NetBox VM records by endpoint identity plus legacy cluster identity."""
 
-    typed_index: dict[tuple[int, int, str], dict[str, object]] = {}
-    untyped_candidates: dict[tuple[int, int], list[dict[str, object]]] = {}
+    endpoint_typed_index: _TypedSnapshotIndex = {}
+    endpoint_untyped_candidates: _UntypedSnapshotIndex = {}
+    cluster_typed_index: _TypedSnapshotIndex = {}
+    cluster_untyped_candidates: _UntypedSnapshotIndex = {}
     for current in snapshot:
-        key = extract_cluster_and_proxmox_vmid(current)
-        if key is None:
-            continue
-        untyped_candidates.setdefault(key, []).append(current)
         vm_type = extract_proxmox_vm_type(current)
-        if vm_type is not None:
-            typed_index.setdefault((key[0], key[1], vm_type), current)
-    return typed_index, untyped_candidates
+        endpoint_key = extract_endpoint_and_proxmox_vmid(current)
+        if endpoint_key is not None:
+            endpoint_untyped_candidates.setdefault(endpoint_key, []).append(current)
+            if vm_type is not None:
+                endpoint_typed_index.setdefault(
+                    (endpoint_key[0], endpoint_key[1], vm_type), current
+                )
+
+        cluster_key = extract_cluster_and_proxmox_vmid(current)
+        if cluster_key is not None:
+            cluster_untyped_candidates.setdefault(cluster_key, []).append(current)
+            if vm_type is not None:
+                cluster_typed_index.setdefault((cluster_key[0], cluster_key[1], vm_type), current)
+    return (
+        endpoint_typed_index,
+        endpoint_untyped_candidates,
+        cluster_typed_index,
+        cluster_untyped_candidates,
+    )
 
 
 def select_existing_vm_record(
     *,
     prepared: PreparedVMState,
+    endpoint_id: int | None,
     cluster_id: int | None,
     proxmox_vmid: int | None,
-    typed_index: dict[tuple[int, int, str], dict[str, object]],
-    untyped_candidates: dict[tuple[int, int], list[dict[str, object]]],
+    endpoint_typed_index: _TypedSnapshotIndex,
+    endpoint_untyped_candidates: _UntypedSnapshotIndex,
+    cluster_typed_index: _TypedSnapshotIndex,
+    cluster_untyped_candidates: _UntypedSnapshotIndex,
 ) -> dict[str, object] | None:
     """Find the NetBox VM record for prepared state without guessing on type collisions."""
 
-    if cluster_id is None or proxmox_vmid is None:
+    if proxmox_vmid is None:
+        return None
+    if endpoint_id is not None:
+        scope_id = endpoint_id
+        typed_index = endpoint_typed_index
+        untyped_candidates = endpoint_untyped_candidates
+    elif cluster_id is not None:
+        scope_id = cluster_id
+        typed_index = cluster_typed_index
+        untyped_candidates = cluster_untyped_candidates
+    else:
         return None
 
     prepared_vm_type = normalize_proxmox_vm_type(prepared.vm_type)
-    untyped_key = (cluster_id, proxmox_vmid)
+    untyped_key = (scope_id, proxmox_vmid)
     if prepared_vm_type is not None:
-        exact_record = typed_index.get((cluster_id, proxmox_vmid, prepared_vm_type))
+        exact_record = typed_index.get((scope_id, proxmox_vmid, prepared_vm_type))
         if exact_record is not None:
             return exact_record
 
@@ -162,23 +211,32 @@ def build_vm_operation_queue_python(  # noqa: C901
 ) -> list[NetBoxVMOperation]:
     """Classify desired VM state into GET/CREATE/UPDATE operations using Pydantic."""
 
-    typed_vm_index, untyped_vm_candidates = build_vm_snapshot_identity_indexes(netbox_snapshot)
+    (
+        endpoint_typed_vm_index,
+        endpoint_untyped_vm_candidates,
+        cluster_typed_vm_index,
+        cluster_untyped_vm_candidates,
+    ) = build_vm_snapshot_identity_indexes(netbox_snapshot)
 
     operation_queue: list[NetBoxVMOperation] = []
 
     for prepared in prepared_vms:
         cluster_id = _relation_id(prepared.desired_payload.get("cluster"))
+        endpoint_id = extract_proxmox_endpoint_id(prepared.desired_payload)
         proxmox_vmid = _relation_id(prepared.resource.get("vmid"))
-        if cluster_id is None or proxmox_vmid is None:
+        if proxmox_vmid is None:
             operation_queue.append(NetBoxVMOperation(method="CREATE", prepared=prepared))
             continue
 
         existing_record = select_existing_vm_record(
             prepared=prepared,
+            endpoint_id=endpoint_id,
             cluster_id=cluster_id,
             proxmox_vmid=proxmox_vmid,
-            typed_index=typed_vm_index,
-            untyped_candidates=untyped_vm_candidates,
+            endpoint_typed_index=endpoint_typed_vm_index,
+            endpoint_untyped_candidates=endpoint_untyped_vm_candidates,
+            cluster_typed_index=cluster_typed_vm_index,
+            cluster_untyped_candidates=cluster_untyped_vm_candidates,
         )
         if existing_record is None:
             operation_queue.append(NetBoxVMOperation(method="CREATE", prepared=prepared))

--- a/proxbox_api/services/sync/snapshots.py
+++ b/proxbox_api/services/sync/snapshots.py
@@ -22,10 +22,14 @@ from proxbox_api.services.sync.storage_links import (
     find_storage_record,
     storage_name_from_volume_id,
 )
+from proxbox_api.services.sync.vm_helpers import to_mapping
 from proxbox_api.services.sync.vmid_helpers import (
+    extract_proxmox_endpoint_id,
+    extract_proxmox_node,
     extract_proxmox_vm_type,
     extract_proxmox_vmid,
     normalize_vmid,
+    select_proxmox_sessions_by_endpoint,
 )
 from proxbox_api.session.proxmox import ProxmoxSessionsDep
 from proxbox_api.utils import return_status_html
@@ -157,11 +161,30 @@ async def build_snapshot_payload(
 def _resolve_snapshot_node_from_resources(
     vmid: int,
     cluster_resources: list[dict[str, object]] | None,
+    cluster_name: str | None = None,
 ) -> tuple[str | None, str | None]:
     """Resolve node and cluster from cluster resource listings."""
     if not cluster_resources:
         return None, None
 
+    vmid_key = normalize_vmid(vmid)
+    candidates = _snapshot_node_candidates_for_vmid(cluster_resources, vmid_key)
+    if not candidates:
+        return None, None
+    if cluster_name:
+        for node_name, candidate_cluster_name in candidates:
+            if str(candidate_cluster_name or "") == cluster_name:
+                return node_name, candidate_cluster_name
+    if len(candidates) == 1:
+        return candidates[0]
+    return None, None
+
+
+def _snapshot_node_candidates_for_vmid(
+    cluster_resources: list[dict[str, object]],
+    vmid_key: str,
+) -> list[tuple[str | None, str | None]]:
+    candidates: list[tuple[str | None, str | None]] = []
     for cluster in cluster_resources:
         if not isinstance(cluster, dict):
             continue
@@ -171,10 +194,22 @@ def _resolve_snapshot_node_from_resources(
         cluster_key, resources = cluster_items[0]
         if not isinstance(resources, list):
             continue
-        for resource in resources:
-            if normalize_vmid(resource.get("vmid")) == vmid:
-                return resource.get("node"), cluster_key
-    return None, None
+        candidates.extend(_snapshot_node_candidates_in_cluster(resources, cluster_key, vmid_key))
+    return candidates
+
+
+def _snapshot_node_candidates_in_cluster(
+    resources: list[object],
+    cluster_key: object,
+    vmid_key: str,
+) -> list[tuple[str | None, str | None]]:
+    candidates: list[tuple[str | None, str | None]] = []
+    for resource in resources:
+        if not isinstance(resource, dict):
+            continue
+        if normalize_vmid(resource.get("vmid")) == vmid_key:
+            candidates.append((resource.get("node"), cluster_key))
+    return candidates
 
 
 def _resolve_snapshot_node_from_status(
@@ -204,6 +239,7 @@ def _resolve_snapshot_node_from_status(
 def _resolve_snapshot_node_context(
     vmid: int,
     node: str | None,
+    cluster_name: str | None,
     cluster_status: list | None,
     cluster_resources: list[dict[str, object]] | None,
 ) -> tuple[str | None, str | None]:
@@ -211,6 +247,7 @@ def _resolve_snapshot_node_context(
     node_name, cluster_name = _resolve_snapshot_node_from_resources(
         vmid,
         cluster_resources,
+        cluster_name=cluster_name,
     )
     if node_name:
         return node_name, cluster_name
@@ -310,9 +347,16 @@ async def _sync_single_vm_snapshots(
     snapshot_payloads: list[dict] = []
     proxmox_snapshot_names: set[str] = set()
 
-    vmid = extract_proxmox_vmid(vm)
-    vm_name = vm.get("name", "unknown")
-    netbox_vm_id = vm.get("id")
+    vm_data = to_mapping(vm)
+    vmid = extract_proxmox_vmid(vm_data)
+    vm_name = vm_data.get("name", "unknown")
+    netbox_vm_id = vm_data.get("id")
+    endpoint_id = extract_proxmox_endpoint_id(vm_data)
+    stored_node = node or extract_proxmox_node(vm_data)
+    vm_cluster_name = None
+    cluster = vm_data.get("cluster")
+    if isinstance(cluster, dict):
+        vm_cluster_name = str(cluster.get("name") or "").strip() or None
 
     if not vmid:
         return ([], set())
@@ -332,13 +376,12 @@ async def _sync_single_vm_snapshots(
         )
 
     try:
-        proxmox_type = extract_proxmox_vm_type(vm) or vm.get("type", "qemu")
-        if proxmox_type not in ("qemu", "lxc"):
-            proxmox_type = "qemu"
+        proxmox_type = _normalize_snapshot_vm_type(extract_proxmox_vm_type(vm) or vm.get("type"))
 
         node_name, cluster_name = _resolve_snapshot_node_context(
             vmid,
-            node,
+            stored_node,
+            vm_cluster_name,
             cluster_status,
             cluster_resources,
         )
@@ -380,14 +423,20 @@ async def _sync_single_vm_snapshots(
             storage_index=storage_index,
         )
 
-        # Only query the Proxmox session that owns this VM's cluster/node.
-        # Fanning out to all sessions causes N duplicate warnings per VM when
-        # a session doesn't host the VM (e.g. HTTP 501 for LXC snapshots on the
-        # wrong cluster).
-        matched_pxs = [
-            px for px in pxs if px.name and (px.name == cluster_name or px.name == node_name)
-        ]
-        effective_pxs = matched_pxs if matched_pxs else pxs
+        effective_pxs = _snapshot_sessions_for_vm(
+            pxs,
+            endpoint_id=endpoint_id,
+            cluster_name=cluster_name,
+            node_name=node_name,
+        )
+        if endpoint_id is not None and not effective_pxs:
+            logger.warning(
+                "Snapshot sync skipped for VM %s (vmid=%s endpoint_id=%s): endpoint session not available",
+                vm_name,
+                vmid,
+                endpoint_id,
+            )
+            return ([], set())
 
         snapshot_payloads, proxmox_snapshot_names = await _collect_snapshot_payloads_for_vm(
             effective_pxs,
@@ -431,6 +480,29 @@ async def _sync_single_vm_snapshots(
             )
 
     return (snapshot_payloads, proxmox_snapshot_names)
+
+
+def _normalize_snapshot_vm_type(proxmox_type: object) -> str:
+    if proxmox_type in ("qemu", "lxc"):
+        return str(proxmox_type)
+    return "qemu"
+
+
+def _snapshot_sessions_for_vm(
+    pxs: list,
+    *,
+    endpoint_id: int | None,
+    cluster_name: str | None,
+    node_name: str | None,
+) -> list:
+    """Select the Proxmox session that can own this VM's snapshot calls."""
+    effective_pxs = select_proxmox_sessions_by_endpoint(pxs, endpoint_id)
+    if endpoint_id is not None:
+        return effective_pxs
+    matched_pxs = [
+        px for px in pxs if px.name and (px.name == cluster_name or px.name == node_name)
+    ]
+    return matched_pxs if matched_pxs else list(pxs)
 
 
 async def _list_all_vms_with_proxmox_id(
@@ -586,11 +658,12 @@ async def create_virtual_machine_snapshots(  # noqa: C901
 
     # Collect all snapshot payloads from all VMs, emit per-VM item_progress
     all_snapshot_payloads: list[dict] = []
-    proxmox_snapshot_names_by_vmid: dict[int, set[str]] = {}
+    proxmox_snapshot_names_by_vm_id: dict[int, set[str]] = {}
     vm_failed = 0
 
     for idx, (vm, result) in enumerate(zip(vms, results), start=1):
-        vm_name = str(vm.get("name", ""))
+        vm_data = to_mapping(vm)
+        vm_name = str(vm_data.get("name", ""))
         if isinstance(result, Exception):
             logger.warning("Snapshot sync task failed: %s", result)
             skipped += 1
@@ -609,12 +682,12 @@ async def create_virtual_machine_snapshots(  # noqa: C901
         else:
             snapshot_payloads, snapshot_names = result
             all_snapshot_payloads.extend(snapshot_payloads)
-            vm_vmid = extract_proxmox_vmid(vm)
-            if vm_vmid:
-                try:
-                    proxmox_snapshot_names_by_vmid[int(vm_vmid)] = snapshot_names
-                except (ValueError, TypeError):
-                    pass
+            netbox_vm_id = vm_data.get("id")
+            try:
+                if netbox_vm_id is not None:
+                    proxmox_snapshot_names_by_vm_id[int(netbox_vm_id)] = snapshot_names
+            except (ValueError, TypeError):
+                pass
             snap_count = len(snapshot_payloads)
             if use_websocket and websocket and hasattr(websocket, "emit_item_progress"):
                 await websocket.emit_item_progress(
@@ -662,32 +735,33 @@ async def create_virtual_machine_snapshots(  # noqa: C901
             skipped = len(all_snapshot_payloads)
             vm_failed += 1
 
-    if delete_nonexistent_snapshot and proxmox_snapshot_names_by_vmid:
+    if delete_nonexistent_snapshot and proxmox_snapshot_names_by_vm_id:
         try:
             netbox_snapshots = await rest_list_async(nb, "/api/plugins/proxbox/snapshots/")
             orphan_ids: list[int] = []
             for nb_snapshot in netbox_snapshots or []:
-                snapshot_vmid = nb_snapshot.vmid
-                snapshot_name = nb_snapshot.name
+                snapshot_data = to_mapping(nb_snapshot)
+                snapshot_name = snapshot_data.get("name")
+                snapshot_vm_id = _extract_fk_id(snapshot_data.get("virtual_machine"))
                 snapshot_id = (
-                    nb_snapshot.id
-                    if hasattr(nb_snapshot, "id")
-                    else (nb_snapshot.get("id") if isinstance(nb_snapshot, dict) else None)
+                    getattr(nb_snapshot, "id", None)
+                    if not isinstance(nb_snapshot, dict)
+                    else nb_snapshot.get("id")
                 )
                 if (
-                    snapshot_vmid
+                    snapshot_vm_id
                     and snapshot_name
                     and snapshot_id
-                    and snapshot_vmid in proxmox_snapshot_names_by_vmid
+                    and snapshot_vm_id in proxmox_snapshot_names_by_vm_id
                 ):
-                    proxmox_names = proxmox_snapshot_names_by_vmid[snapshot_vmid]
+                    proxmox_names = proxmox_snapshot_names_by_vm_id[snapshot_vm_id]
                     if snapshot_name not in proxmox_names:
                         orphan_ids.append(int(snapshot_id))
                         logger.info(
-                            "Marking orphaned snapshot %s (id=%s) for VM vmid=%s for bulk deletion",
+                            "Marking orphaned snapshot %s (id=%s) for NetBox VM id=%s for bulk deletion",
                             snapshot_name,
                             snapshot_id,
-                            snapshot_vmid,
+                            snapshot_vm_id,
                         )
             if orphan_ids:
                 try:

--- a/proxbox_api/services/sync/virtual_disks.py
+++ b/proxbox_api/services/sync/virtual_disks.py
@@ -23,9 +23,11 @@ from proxbox_api.services.sync.storage_links import (
 )
 from proxbox_api.services.sync.vm_helpers import relation_id, relation_name, to_mapping
 from proxbox_api.services.sync.vmid_helpers import (
+    extract_proxmox_endpoint_id,
     extract_proxmox_vm_type,
     extract_proxmox_vmid,
     normalize_vmid,
+    select_proxmox_sessions_by_endpoint,
 )
 from proxbox_api.session.proxmox import ProxmoxSessionsDep
 from proxbox_api.utils import return_status_html
@@ -36,6 +38,7 @@ class VmConfigTarget:
     node: str | None
     vm_type: str
     cluster_name: str | None
+    endpoint_id: int | None
     source: str
     netbox_device_name: str | None
     custom_field_node: str | None
@@ -125,7 +128,9 @@ def _cluster_resource_target(
         for candidate in candidates:
             if candidate[0] == cluster_name:
                 return candidate
-    return candidates[0]
+    if len(candidates) == 1:
+        return candidates[0]
+    return None
 
 
 def _resolve_vm_config_target(
@@ -140,6 +145,7 @@ def _resolve_vm_config_target(
     vm_data = to_mapping(vm)
     device_name = relation_name(vm_data.get("device"))
     custom_field_node = _proxmox_node_custom_field(vm_data)
+    endpoint_id = extract_proxmox_endpoint_id(vm_data)
 
     cluster_target = _cluster_resource_target(
         cluster_resources,
@@ -154,6 +160,7 @@ def _resolve_vm_config_target(
             node=node,
             vm_type=target_vm_type,
             cluster_name=target_cluster or cluster_name,
+            endpoint_id=endpoint_id,
             source="cluster_resources",
             netbox_device_name=device_name,
             custom_field_node=custom_field_node,
@@ -164,6 +171,7 @@ def _resolve_vm_config_target(
             node=custom_field_node,
             vm_type=vm_type,
             cluster_name=cluster_name,
+            endpoint_id=endpoint_id,
             source="custom_fields.proxmox_node",
             netbox_device_name=device_name,
             custom_field_node=custom_field_node,
@@ -173,6 +181,7 @@ def _resolve_vm_config_target(
         node=device_name,
         vm_type=vm_type,
         cluster_name=cluster_name,
+        endpoint_id=endpoint_id,
         source="device.name" if device_name else "unresolved",
         netbox_device_name=device_name,
         custom_field_node=custom_field_node,
@@ -406,18 +415,37 @@ async def _fetch_virtual_disk_vm_config(
         )
 
     logger.debug(
-        "Resolved virtual disk VM config target for %s (vmid=%s type=%s cluster=%s node=%s source=%s)",
+        "Resolved virtual disk VM config target for %s (vmid=%s type=%s endpoint_id=%s cluster=%s node=%s source=%s)",
         vm_name,
         vmid,
         vm_type,
+        target.endpoint_id,
         cluster_name,
         node_name,
         target.source,
     )
 
+    target_pxs = select_proxmox_sessions_by_endpoint(pxs, target.endpoint_id)
+    if target.endpoint_id is not None and not target_pxs:
+        logger.warning(
+            "No Proxmox session found for VM %s (vmid=%s endpoint_id=%s), skipping disk sync",
+            vm_name,
+            vmid,
+            target.endpoint_id,
+        )
+        return VmDiskFetchResult(
+            vm=vm,
+            vmid=vmid,
+            vm_name=vm_name,
+            cluster_name=cluster_name,
+            target=target,
+            vm_config=None,
+            failure_message="Endpoint session not available",
+        )
+
     try:
         vm_config = await resolve_vm_config(
-            pxs=pxs,
+            pxs=target_pxs,
             node=node_name,
             vm_type=vm_type,
             vmid=vmid,

--- a/proxbox_api/services/sync/vm_create.py
+++ b/proxbox_api/services/sync/vm_create.py
@@ -37,6 +37,7 @@ from proxbox_api.services.sync.vm_helpers import (
     _compute_vm_patchable_fields,
     normalize_current_virtual_machine_payload,
 )
+from proxbox_api.services.sync.vmid_helpers import normalize_positive_int
 
 
 async def ensure_vm_dependencies(
@@ -289,6 +290,7 @@ async def create_or_update_virtual_machine(
     netbox_version = await detect_netbox_version(netbox_session)
     supports_vm_type = supports_virtual_machine_type(netbox_version)
     resolved_virtual_machine_type_id = virtual_machine_type_id if supports_vm_type else None
+    endpoint_lookup_id = normalize_positive_int(endpoint_id)
 
     payload = build_netbox_virtual_machine_payload(
         proxmox_resource=proxmox_resource,
@@ -309,8 +311,13 @@ async def create_or_update_virtual_machine(
         netbox_session,
         "/api/virtualization/virtual-machines/",
         lookup={
-            "cf_proxmox_vm_id": vmid_int,
-            "cluster_id": cluster_id,
+            key: value
+            for key, value in {
+                "cf_proxmox_vm_id": vmid_int,
+                "cf_proxmox_endpoint_id": endpoint_lookup_id,
+                "cluster_id": cluster_id if endpoint_lookup_id is None else None,
+            }.items()
+            if value is not None
         },
         payload=payload,
         schema=NetBoxVirtualMachineCreateBody,
@@ -324,6 +331,7 @@ async def create_or_update_virtual_machine(
             record,
             supports_virtual_machine_type_field=supports_vm_type,
         ),
+        strict_lookup=True,
     )
 
     logger.debug("Created/updated virtual machine: %s", virtual_machine)

--- a/proxbox_api/services/sync/vmid_helpers.py
+++ b/proxbox_api/services/sync/vmid_helpers.py
@@ -1,6 +1,29 @@
-"""Shared helpers for Proxmox VMID and VM type extraction from NetBox VM payloads."""
+"""Shared helpers for Proxmox VM identity extraction from NetBox VM payloads."""
 
 from __future__ import annotations
+
+
+def _coerce_mapping(value: object) -> dict[str, object]:
+    if isinstance(value, dict):
+        return value
+    if hasattr(value, "serialize"):
+        try:
+            serialized = value.serialize()
+            if isinstance(serialized, dict):
+                return serialized
+        except Exception:
+            return {}
+    if hasattr(value, "dict"):
+        try:
+            dumped = value.dict()
+            if isinstance(dumped, dict):
+                return dumped
+        except Exception:
+            return {}
+    try:
+        return dict(value) if value else {}
+    except Exception:
+        return {}
 
 
 def normalize_vmid(vmid: object) -> str | None:
@@ -11,16 +34,25 @@ def normalize_vmid(vmid: object) -> str | None:
     return vmid_str or None
 
 
+def normalize_positive_int(value: object) -> int | None:
+    """Normalize a positive integer identity value from mixed API payload shapes."""
+    normalized = normalize_vmid(value)
+    if normalized is None:
+        return None
+    try:
+        result = int(normalized)
+    except (TypeError, ValueError):
+        return None
+    return result if result > 0 else None
+
+
 def extract_proxmox_vmid(vm: dict[str, object]) -> str | None:
     """Extract Proxmox VMID from NetBox VM payload across known field layouts.
 
     Handles both RestRecord objects and plain dicts by detecting the interface
     and converting as needed.
     """
-    if hasattr(vm, "get"):
-        vm = vm.dict() if hasattr(vm, "dict") else dict(vm)
-    else:
-        vm = dict(vm) if vm else {}
+    vm = _coerce_mapping(vm)
 
     top_level_keys = (
         "cf_proxmox_vm_id",
@@ -48,6 +80,66 @@ def extract_proxmox_vmid(vm: dict[str, object]) -> str | None:
     return None
 
 
+def extract_proxmox_endpoint_id(vm: dict[str, object]) -> int | None:
+    """Extract the Proxmox endpoint identity stored on a NetBox VM record."""
+    vm = _coerce_mapping(vm)
+
+    for key in ("cf_proxmox_endpoint_id", "proxmox_endpoint_id"):
+        endpoint_id = normalize_positive_int(vm.get(key))
+        if endpoint_id is not None:
+            return endpoint_id
+
+    custom_fields = vm.get("custom_fields")
+    if isinstance(custom_fields, dict):
+        for key in ("proxmox_endpoint_id", "cf_proxmox_endpoint_id"):
+            endpoint_id = normalize_positive_int(custom_fields.get(key))
+            if endpoint_id is not None:
+                return endpoint_id
+    return None
+
+
+def extract_proxmox_node(vm: dict[str, object]) -> str | None:
+    """Extract the stored Proxmox node name from a NetBox VM record."""
+    vm = _coerce_mapping(vm)
+
+    for key in ("cf_proxmox_node", "proxmox_node"):
+        value = normalize_vmid(vm.get(key))
+        if value:
+            return value
+
+    custom_fields = vm.get("custom_fields")
+    if isinstance(custom_fields, dict):
+        for key in ("proxmox_node", "cf_proxmox_node"):
+            value = normalize_vmid(custom_fields.get(key))
+            if value:
+                return value
+    return None
+
+
+def extract_proxmox_session_endpoint_id(session: object) -> int | None:
+    """Extract the endpoint id attached to a Proxmox session object."""
+    for attr_name in ("db_endpoint_id", "endpoint_id", "proxmox_endpoint_id"):
+        endpoint_id = normalize_positive_int(getattr(session, attr_name, None))
+        if endpoint_id is not None:
+            return endpoint_id
+    return None
+
+
+def select_proxmox_sessions_by_endpoint(
+    sessions: object,
+    endpoint_id: int | None,
+) -> list[object]:
+    """Return only sessions that belong to ``endpoint_id`` when it is known."""
+    session_list = list(sessions or [])
+    if endpoint_id is None:
+        return session_list
+    return [
+        session
+        for session in session_list
+        if extract_proxmox_session_endpoint_id(session) == endpoint_id
+    ]
+
+
 def extract_proxmox_vm_type(vm: dict[str, object]) -> str | None:
     """Extract Proxmox VM type from NetBox VM payload across known field layouts.
 
@@ -56,10 +148,7 @@ def extract_proxmox_vm_type(vm: dict[str, object]) -> str | None:
     Handles both RestRecord objects and plain dicts by detecting the interface
     and converting as needed.
     """
-    if hasattr(vm, "get"):
-        vm = vm.dict() if hasattr(vm, "dict") else dict(vm)
-    else:
-        vm = dict(vm) if vm else {}
+    vm = _coerce_mapping(vm)
 
     top_level_keys = (
         "cf_proxmox_vm_type",

--- a/proxbox_api/session/proxmox_providers.py
+++ b/proxbox_api/session/proxmox_providers.py
@@ -285,6 +285,7 @@ def _parse_netbox_endpoint(
         retry_backoff=float(raw_retry_backoff)
         if raw_retry_backoff is not None
         else settings.get("proxmox_retry_backoff"),  # type: ignore[arg-type]
+        db_endpoint_id=_netbox_field(endpoint, "id"),
         **_relation_metadata(endpoint, "site"),
         **_relation_metadata(endpoint, "tenant"),
     )

--- a/tests/reconciliation/test_vm_queue_python.py
+++ b/tests/reconciliation/test_vm_queue_python.py
@@ -19,6 +19,7 @@ def _prepared_vm(
     memory: object = 2048,
     tags: list[object] | None = None,
     custom_fields: dict[str, object] | None = None,
+    endpoint_id: int = 500,
     role: object = 20,
     description: str | None = "Synced from Proxmox node pve01",
 ) -> PreparedVMState:
@@ -35,7 +36,11 @@ def _prepared_vm(
         "custom_fields": (
             custom_fields
             if custom_fields is not None
-            else {"proxmox_vm_id": vmid, "proxmox_vm_type": vm_type}
+            else {
+                "proxmox_endpoint_id": endpoint_id,
+                "proxmox_vm_id": vmid,
+                "proxmox_vm_type": vm_type,
+            }
         ),
         "description": description,
     }
@@ -45,7 +50,7 @@ def _prepared_vm(
         vm_config={},
         vm_config_obj=ProxmoxVmConfigInput.model_validate({}),
         desired_payload=desired_payload,
-        lookup={"cf_proxmox_vm_id": vmid, "cluster_id": 1},
+        lookup={"cf_proxmox_vm_id": vmid, "cf_proxmox_endpoint_id": endpoint_id},
         now=datetime.now(timezone.utc),
         vm_type=vm_type,
     )
@@ -61,6 +66,7 @@ def _snapshot_vm(
     memory: object = 2048,
     tags: list[object] | None = None,
     custom_fields: dict[str, object] | None = None,
+    endpoint_id: int = 500,
     role: object = 20,
     description: str | None = "Synced from Proxmox node pve01",
     include_virtual_machine_type: bool = True,
@@ -68,6 +74,7 @@ def _snapshot_vm(
 ) -> dict[str, object]:
     if custom_fields is None:
         custom_fields = {}
+        custom_fields["proxmox_endpoint_id"] = endpoint_id
         if vmid is not None:
             custom_fields["proxmox_vm_id"] = vmid
         if vm_type is not None:
@@ -104,12 +111,12 @@ def _queue(
     return build_vm_operation_queue_python(prepared, snapshot, **flags)
 
 
-def test_missing_cluster_in_desired_payload_creates() -> None:
+def test_missing_cluster_in_desired_payload_matches_by_endpoint() -> None:
     prepared = [_prepared_vm(cluster=None)]
 
     queue = _queue(prepared, [_snapshot_vm()])
 
-    assert [op.method for op in queue] == ["CREATE"]
+    assert [op.method for op in queue] == ["GET"]
 
 
 def test_missing_proxmox_vmid_in_netbox_record_creates() -> None:
@@ -243,6 +250,22 @@ def test_qemu_vm_and_lxc_container_with_same_vmid_in_same_cluster_do_not_collide
     assert [op.existing_record["id"] for op in queue if op.existing_record] == [3001, 3002]
 
 
+def test_same_vmid_on_different_endpoints_does_not_collide() -> None:
+    prepared = [
+        _prepared_vm(vmid=100, endpoint_id=1, name="qemu-100"),
+        _prepared_vm(vmid=100, endpoint_id=2, name="qemu-100"),
+    ]
+    snapshot = [
+        _snapshot_vm(record_id=4001, vmid=100, endpoint_id=1, name="qemu-100"),
+        _snapshot_vm(record_id=4002, vmid=100, endpoint_id=2, name="qemu-100"),
+    ]
+
+    queue = _queue(prepared, snapshot)
+
+    assert [op.method for op in queue] == ["GET", "GET"]
+    assert [op.existing_record["id"] for op in queue if op.existing_record] == [4001, 4002]
+
+
 def test_int_and_float_memory_values_do_not_create_spurious_diff() -> None:
     prepared = [_prepared_vm(vmid=111, memory=2048)]
     snapshot = [_snapshot_vm(record_id=2111, vmid=111, name="qemu-111", memory=2048.0)]
@@ -297,6 +320,7 @@ def test_untyped_snapshot_record_matches_only_when_unambiguous() -> None:
     assert [op.method for op in queue] == ["UPDATE"]
     assert queue[0].existing_record and queue[0].existing_record["id"] == 2115
     assert queue[0].patch_payload["custom_fields"] == {
+        "proxmox_endpoint_id": 500,
         "proxmox_vm_id": 115,
         "proxmox_vm_type": "qemu",
     }

--- a/tests/test_qemu_guest_agent_sync.py
+++ b/tests/test_qemu_guest_agent_sync.py
@@ -1165,9 +1165,9 @@ def test_vm_only_ip_sync_surfaces_missing_interface_skip(monkeypatch):
         if event == "phase_summary":
             summaries.append(payload)
 
-    assert any(
-        (s.get("result") or {}).get("skipped") for s in summaries
-    ), f"expected a phase_summary with a non-zero skip count, got {summaries!r}"
-    assert any(
-        "interface" in str(s.get("message", "")).lower() for s in summaries
-    ), f"expected the skip message to mention the missing interface, got {summaries!r}"
+    assert any((s.get("result") or {}).get("skipped") for s in summaries), (
+        f"expected a phase_summary with a non-zero skip count, got {summaries!r}"
+    )
+    assert any("interface" in str(s.get("message", "")).lower() for s in summaries), (
+        f"expected the skip message to mention the missing interface, got {summaries!r}"
+    )

--- a/tests/test_session_and_helpers.py
+++ b/tests/test_session_and_helpers.py
@@ -1538,6 +1538,7 @@ def test_proxmox_sessions_reads_netbox_endpoints_async(monkeypatch, db_engine):
                         "count": 1,
                         "results": [
                             {
+                                "id": 44,
                                 "ip_address": {"address": "10.0.0.10/24"},
                                 "domain": "pve.local",
                                 "port": 8006,
@@ -1559,6 +1560,7 @@ def test_proxmox_sessions_reads_netbox_endpoints_async(monkeypatch, db_engine):
 
     assert len(sessions) == 1
     assert sessions[0].name == "lab-cluster"
+    assert sessions[0].db_endpoint_id == 44
 
 
 def test_get_raw_netbox_session_closes_database_session(monkeypatch):

--- a/tests/test_snapshots_sync.py
+++ b/tests/test_snapshots_sync.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 
 from proxbox_api.services.sync.snapshots import create_virtual_machine_snapshots
 
@@ -122,3 +123,86 @@ def test_create_virtual_machine_snapshots_uses_nested_custom_fields_proxmox_vm_i
     assert reconciled[0][0] == {"vmid": 101, "name": "pre-upgrade", "node": "pve01"}
     assert reconciled[0][1]["virtual_machine"] == 7
     assert reconciled[0][1]["proxmox_storage"] == 41
+
+
+def test_create_virtual_machine_snapshots_scopes_fetch_by_endpoint(monkeypatch):
+    endpoint_a = SimpleNamespace(db_endpoint_id=1, name="pve")
+    endpoint_b = SimpleNamespace(db_endpoint_id=2, name="astro")
+    calls = {"get_vm_snapshots": []}
+
+    async def _fake_rest_list(_nb, _path, query=None):
+        if _path == "/api/virtualization/virtual-machines/":
+            return [
+                {
+                    "id": 7,
+                    "name": "vm-105-a",
+                    "cluster": {"name": "pve"},
+                    "custom_fields": {
+                        "proxmox_endpoint_id": 1,
+                        "proxmox_vm_id": 105,
+                        "proxmox_vm_type": "qemu",
+                        "proxmox_node": "pve",
+                    },
+                },
+                {
+                    "id": 8,
+                    "name": "vm-105-b",
+                    "cluster": {"name": "astro"},
+                    "custom_fields": {
+                        "proxmox_endpoint_id": 2,
+                        "proxmox_vm_id": 105,
+                        "proxmox_vm_type": "qemu",
+                        "proxmox_node": "astro",
+                    },
+                },
+            ]
+        if _path in {"/api/plugins/proxbox/storage/", "/api/virtualization/virtual-disks/"}:
+            return []
+        return []
+
+    def _fake_get_vm_snapshots(*, session, node, vm_type, vmid):
+        calls["get_vm_snapshots"].append(
+            {"session": session, "node": node, "vm_type": vm_type, "vmid": vmid}
+        )
+        return [{"name": f"snap-{node}", "type": "qemu"}]
+
+    async def _fake_bulk_reconcile(_nb, _path, *, payloads, **kwargs):
+        from proxbox_api.netbox_rest import BulkReconcileResult
+
+        return BulkReconcileResult(
+            records=[{"id": index, **payload} for index, payload in enumerate(payloads, start=1)],
+            created=len(payloads),
+            updated=0,
+            unchanged=0,
+            failed=0,
+        )
+
+    monkeypatch.setattr("proxbox_api.services.sync.snapshots.rest_list_async", _fake_rest_list)
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.snapshots.get_vm_snapshots",
+        _fake_get_vm_snapshots,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.snapshots.rest_bulk_reconcile_async",
+        _fake_bulk_reconcile,
+    )
+
+    result = asyncio.run(
+        create_virtual_machine_snapshots(
+            netbox_session=object(),
+            pxs=[endpoint_a, endpoint_b],
+            cluster_status=[],
+            cluster_resources=[
+                {"pve": [{"type": "qemu", "name": "vm-105-a", "vmid": "105", "node": "pve"}]},
+                {"astro": [{"type": "qemu", "name": "vm-105-b", "vmid": "105", "node": "astro"}]},
+            ],
+            tag=None,
+            use_websocket=False,
+        )
+    )
+
+    assert result == {"count": 2, "created": 2, "updated": 0, "skipped": 0, "deleted": 0}
+    assert calls["get_vm_snapshots"] == [
+        {"session": endpoint_a, "node": "pve", "vm_type": "qemu", "vmid": 105},
+        {"session": endpoint_b, "node": "astro", "vm_type": "qemu", "vmid": 105},
+    ]

--- a/tests/test_virtual_disks_sync.py
+++ b/tests/test_virtual_disks_sync.py
@@ -257,6 +257,81 @@ def test_create_virtual_disks_uses_custom_fields_proxmox_vm_id(monkeypatch):
     assert reconciled_payloads[0].get("custom_fields", {}).get("proxbox_storage_id") == 42
 
 
+def test_create_virtual_disks_scopes_config_fetch_by_endpoint(monkeypatch):
+    calls = {"resolve_vm_config": []}
+    endpoint_a = SimpleNamespace(db_endpoint_id=1, name="pve")
+    endpoint_b = SimpleNamespace(db_endpoint_id=2, name="astro")
+
+    async def _fake_rest_list(_nb, _path, query=None):
+        if _path == "/api/virtualization/virtual-machines/":
+            return [
+                {
+                    "id": 7,
+                    "name": "vm-105-a",
+                    "cluster": {"name": "pve"},
+                    "custom_fields": {
+                        "proxmox_endpoint_id": 1,
+                        "proxmox_vm_id": 105,
+                        "proxmox_vm_type": "qemu",
+                        "proxmox_node": "pve",
+                    },
+                },
+                {
+                    "id": 8,
+                    "name": "vm-105-b",
+                    "cluster": {"name": "astro"},
+                    "custom_fields": {
+                        "proxmox_endpoint_id": 2,
+                        "proxmox_vm_id": 105,
+                        "proxmox_vm_type": "qemu",
+                        "proxmox_node": "astro",
+                    },
+                },
+            ]
+        if _path in {"/api/plugins/proxbox/storage/", "/api/virtualization/virtual-disks/"}:
+            return []
+        return []
+
+    async def _fake_resolve_vm_config(**kwargs):
+        calls["resolve_vm_config"].append(kwargs)
+        return {"scsi0": f"local-lvm:vm-{kwargs['vmid']}-disk-0,size=1G"}
+
+    async def _fake_bulk_reconcile(_nb, _path, *, payloads, **kwargs):
+        return SimpleNamespace(records=[], created=len(payloads), updated=0, unchanged=0, failed=0)
+
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.virtual_disks.rest_list_async",
+        _fake_rest_list,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.virtual_disks.resolve_vm_config",
+        _fake_resolve_vm_config,
+    )
+    monkeypatch.setattr(
+        "proxbox_api.services.sync.virtual_disks.rest_bulk_reconcile_async",
+        _fake_bulk_reconcile,
+    )
+
+    result = asyncio.run(
+        create_virtual_disks(
+            netbox_session=object(),
+            pxs=[endpoint_a, endpoint_b],
+            cluster_status=[],
+            cluster_resources=[
+                {"pve": [{"type": "qemu", "name": "vm-105-a", "vmid": "105", "node": "pve"}]},
+                {"astro": [{"type": "qemu", "name": "vm-105-b", "vmid": "105", "node": "astro"}]},
+            ],
+            tag=None,
+            use_websocket=False,
+            use_css=False,
+        )
+    )
+
+    assert result == {"count": 2, "created": 2, "updated": 0, "skipped": 0}
+    assert [call["pxs"] for call in calls["resolve_vm_config"]] == [[endpoint_a], [endpoint_b]]
+    assert [call["node"] for call in calls["resolve_vm_config"]] == ["pve", "astro"]
+
+
 def test_create_virtual_disks_prefers_cluster_resource_node_over_vm_device(monkeypatch):
     result, calls = _run_virtual_disk_sync_for_vm(
         monkeypatch,

--- a/tests/test_vm_cross_cluster_vmid.py
+++ b/tests/test_vm_cross_cluster_vmid.py
@@ -1,9 +1,9 @@
-"""Regression tests for cross-cluster Proxmox VMID collisions.
+"""Regression tests for cross-endpoint Proxmox VMID collisions.
 
-When the same Proxmox VM ID (vmid) exists in two different Proxmox clusters,
-NetBox VM resolution must be scoped by ``(cluster_id, vmid)``. Keying on vmid
-alone mapped interfaces/IPs to the wrong VirtualMachine and dropped duplicate
-vmids, which is the bug these tests pin.
+When the same Proxmox VM ID (vmid) exists on two standalone endpoints, NetBox
+VM resolution must be scoped by ``(proxmox_endpoint_id, vmid)``. Keying on vmid
+alone, or on a fragile cluster relation, mapped interfaces/IPs to the wrong
+VirtualMachine and dropped duplicate vmids.
 """
 
 from __future__ import annotations
@@ -22,46 +22,54 @@ from proxbox_api.services.sync.vm_helpers import resolve_netbox_cluster_id_by_na
 # Two clusters share vmid=100. Each owns one distinct NetBox VM record.
 CLUSTER_ALPHA_ID = 11
 CLUSTER_BETA_ID = 22
+ENDPOINT_ALPHA_ID = 101
+ENDPOINT_BETA_ID = 202
 SHARED_VMID = 100
 
 VM_IN_ALPHA = {
     "id": 1001,
     "name": "shared-vm-alpha",
     "cluster": {"id": CLUSTER_ALPHA_ID, "name": "alpha"},
-    "custom_fields": {"proxmox_vm_id": SHARED_VMID},
+    "custom_fields": {
+        "proxmox_endpoint_id": ENDPOINT_ALPHA_ID,
+        "proxmox_vm_id": SHARED_VMID,
+    },
 }
 VM_IN_BETA = {
     "id": 2002,
     "name": "shared-vm-beta",
     "cluster": {"id": CLUSTER_BETA_ID, "name": "beta"},
-    "custom_fields": {"proxmox_vm_id": SHARED_VMID},
+    "custom_fields": {
+        "proxmox_endpoint_id": ENDPOINT_BETA_ID,
+        "proxmox_vm_id": SHARED_VMID,
+    },
 }
 
 _CLUSTER_NAME_TO_ID = {"alpha": CLUSTER_ALPHA_ID, "beta": CLUSTER_BETA_ID}
 
 
 def _fake_vm_list_by_cluster(_nb, _endpoint, query):
-    """Mimic the NetBox VM list endpoint, honoring the cf_proxmox_vm_id + cluster_id filter."""
+    """Mimic NetBox VM filters for endpoint, cluster, and VMID."""
     vmid = query.get("cf_proxmox_vm_id")
+    endpoint_id = query.get("cf_proxmox_endpoint_id")
     cluster_id = query.get("cluster_id")
     matches = [
         vm
         for vm in (VM_IN_ALPHA, VM_IN_BETA)
         if vm["custom_fields"]["proxmox_vm_id"] == vmid
+        and (endpoint_id is None or vm["custom_fields"]["proxmox_endpoint_id"] == endpoint_id)
         and (cluster_id is None or vm["cluster"]["id"] == cluster_id)
     ]
     return matches
 
 
-def test_build_vm_index_keys_by_cluster_and_vmid():
-    """Duplicate vmids across clusters must both survive, keyed by (cluster_id, vmid)."""
+def test_build_vm_index_keys_by_endpoint_and_vmid():
+    """Duplicate vmids across endpoints must both survive, keyed by endpoint and vmid."""
     index = _build_vm_index_by_proxmox_id([VM_IN_ALPHA, VM_IN_BETA])
 
-    # Both cluster-scoped entries exist and point at the correct VM.
-    assert index[(CLUSTER_ALPHA_ID, SHARED_VMID)] is VM_IN_ALPHA
-    assert index[(CLUSTER_BETA_ID, SHARED_VMID)] is VM_IN_BETA
+    assert index[(ENDPOINT_ALPHA_ID, SHARED_VMID)] is VM_IN_ALPHA
+    assert index[(ENDPOINT_BETA_ID, SHARED_VMID)] is VM_IN_BETA
 
-    # The pre-fix vmid-only key must not exist (that was the collision source).
     assert SHARED_VMID not in index
     assert len(index) == 2
 
@@ -121,7 +129,7 @@ async def test_ensure_vm_record_resolves_correct_cluster(monkeypatch):
     # Syncing within cluster "alpha" must resolve alpha's VM, never beta's.
     record_alpha, error_alpha = await ensure_vm_record(
         object(),
-        SimpleNamespace(name="alpha"),
+        SimpleNamespace(name="alpha", db_endpoint_id=ENDPOINT_ALPHA_ID),
         tag,
         vmid=SHARED_VMID,
         node="pve-a",
@@ -134,7 +142,7 @@ async def test_ensure_vm_record_resolves_correct_cluster(monkeypatch):
     # Syncing within cluster "beta" must resolve beta's VM.
     record_beta, error_beta = await ensure_vm_record(
         object(),
-        SimpleNamespace(name="beta"),
+        SimpleNamespace(name="beta", db_endpoint_id=ENDPOINT_BETA_ID),
         tag,
         vmid=SHARED_VMID,
         node="pve-b",
@@ -144,14 +152,17 @@ async def test_ensure_vm_record_resolves_correct_cluster(monkeypatch):
     assert error_beta is None
     assert record_beta is VM_IN_BETA
 
-    # Every NetBox VM lookup must have been cluster-scoped.
+    # Every NetBox VM lookup must have been endpoint-scoped.
     assert captured_queries, "expected at least one NetBox VM lookup"
-    assert all("cluster_id" in q for q in captured_queries)
-    assert {q["cluster_id"] for q in captured_queries} == {CLUSTER_ALPHA_ID, CLUSTER_BETA_ID}
+    assert all("cf_proxmox_endpoint_id" in q for q in captured_queries)
+    assert {q["cf_proxmox_endpoint_id"] for q in captured_queries} == {
+        ENDPOINT_ALPHA_ID,
+        ENDPOINT_BETA_ID,
+    }
 
 
 @pytest.mark.asyncio
-async def test_resolve_netbox_virtual_machine_by_proxmox_id_scopes_by_cluster(monkeypatch):
+async def test_resolve_netbox_virtual_machine_by_proxmox_id_scopes_by_endpoint(monkeypatch):
     captured_queries: list[dict[str, object]] = []
 
     async def _fake_rest_list_async(_nb, _endpoint, query):
@@ -172,12 +183,15 @@ async def test_resolve_netbox_virtual_machine_by_proxmox_id_scopes_by_cluster(mo
     )
 
     resolved_alpha = await _resolve_netbox_virtual_machine_by_proxmox_id(
-        object(), SHARED_VMID, cluster_name="alpha"
+        object(), SHARED_VMID, endpoint_id=ENDPOINT_ALPHA_ID, cluster_name="alpha"
     )
     resolved_beta = await _resolve_netbox_virtual_machine_by_proxmox_id(
-        object(), SHARED_VMID, cluster_name="beta"
+        object(), SHARED_VMID, endpoint_id=ENDPOINT_BETA_ID, cluster_name="beta"
     )
 
     assert resolved_alpha == VM_IN_ALPHA
     assert resolved_beta == VM_IN_BETA
-    assert all(q.get("cluster_id") in (CLUSTER_ALPHA_ID, CLUSTER_BETA_ID) for q in captured_queries)
+    assert {q.get("cf_proxmox_endpoint_id") for q in captured_queries} == {
+        ENDPOINT_ALPHA_ID,
+        ENDPOINT_BETA_ID,
+    }

--- a/tests/test_vm_sync_reconciliation_queue.py
+++ b/tests/test_vm_sync_reconciliation_queue.py
@@ -11,7 +11,13 @@ from proxbox_api.proxmox_to_netbox.models import ProxmoxVmConfigInput
 from proxbox_api.routes.virtualization.virtual_machines import sync_vm
 
 
-def _prepared_vm(*, cluster_name: str, vmid: int, memory: int) -> sync_vm._PreparedVMState:
+def _prepared_vm(
+    *,
+    cluster_name: str,
+    vmid: int,
+    memory: int,
+    endpoint_id: int = 500,
+) -> sync_vm._PreparedVMState:
     desired_payload = {
         "name": f"vm-{vmid}",
         "status": "active",
@@ -22,7 +28,10 @@ def _prepared_vm(*, cluster_name: str, vmid: int, memory: int) -> sync_vm._Prepa
         "memory": memory,
         "disk": 30,
         "tags": [99],
-        "custom_fields": {"proxmox_vm_id": vmid},
+        "custom_fields": {
+            "proxmox_endpoint_id": endpoint_id,
+            "proxmox_vm_id": vmid,
+        },
         "description": "Synced from Proxmox node pve01",
     }
     return sync_vm._PreparedVMState(
@@ -31,7 +40,7 @@ def _prepared_vm(*, cluster_name: str, vmid: int, memory: int) -> sync_vm._Prepa
         vm_config={},
         vm_config_obj=ProxmoxVmConfigInput.model_validate({}),
         desired_payload=desired_payload,
-        lookup={"cf_proxmox_vm_id": vmid, "cluster_id": 1},
+        lookup={"cf_proxmox_vm_id": vmid, "cf_proxmox_endpoint_id": endpoint_id},
         now=datetime.now(timezone.utc),
         vm_type="qemu",
     )
@@ -56,7 +65,7 @@ def test_build_vm_operation_queue_classifies_ok_create_update():
             "memory": 4096,
             "disk": 30,
             "tags": [{"id": 99}],
-            "custom_fields": {"proxmox_vm_id": 102},
+            "custom_fields": {"proxmox_endpoint_id": 500, "proxmox_vm_id": 102},
             "description": "Synced from Proxmox node pve01",
         },
         {
@@ -70,7 +79,7 @@ def test_build_vm_operation_queue_classifies_ok_create_update():
             "memory": 2048,
             "disk": 30,
             "tags": [{"id": 99}],
-            "custom_fields": {"proxmox_vm_id": 103},
+            "custom_fields": {"proxmox_endpoint_id": 500, "proxmox_vm_id": 103},
             "description": "Synced from Proxmox node pve01",
         },
     ]
@@ -79,6 +88,57 @@ def test_build_vm_operation_queue_classifies_ok_create_update():
 
     assert [op.method for op in queue] == ["CREATE", "GET", "UPDATE"]
     assert queue[2].patch_payload["memory"] == 8192
+
+
+def test_build_vm_operation_queue_keeps_same_vmid_endpoints_separate():
+    prepared = [
+        _prepared_vm(cluster_name="standalone-a", vmid=105, memory=2048, endpoint_id=1),
+        _prepared_vm(cluster_name="standalone-b", vmid=105, memory=2048, endpoint_id=2),
+    ]
+
+    snapshot = [
+        {
+            "id": 5105,
+            "name": "vm-105-a",
+            "status": "active",
+            "cluster": {"id": 1, "name": "standalone-a"},
+            "device": {"id": 10},
+            "role": {"id": 20},
+            "vcpus": 2,
+            "memory": 2048,
+            "disk": 30,
+            "tags": [{"id": 99}],
+            "custom_fields": {
+                "proxmox_endpoint_id": 1,
+                "proxmox_vm_id": 105,
+                "proxmox_vm_type": "qemu",
+            },
+            "description": "Synced from Proxmox node pve01",
+        },
+        {
+            "id": 5205,
+            "name": "vm-105-b",
+            "status": "active",
+            "cluster": {"id": 1, "name": "standalone-b"},
+            "device": {"id": 10},
+            "role": {"id": 20},
+            "vcpus": 2,
+            "memory": 2048,
+            "disk": 30,
+            "tags": [{"id": 99}],
+            "custom_fields": {
+                "proxmox_endpoint_id": 2,
+                "proxmox_vm_id": 105,
+                "proxmox_vm_type": "qemu",
+            },
+            "description": "Synced from Proxmox node pve01",
+        },
+    ]
+
+    queue = sync_vm._build_vm_operation_queue(prepared, snapshot)
+
+    assert [op.method for op in queue] == ["UPDATE", "UPDATE"]
+    assert [op.existing_record["id"] for op in queue if op.existing_record] == [5105, 5205]
 
 
 def test_build_vm_operation_queue_omits_vm_type_when_overwrite_disabled():
@@ -98,7 +158,7 @@ def test_build_vm_operation_queue_omits_vm_type_when_overwrite_disabled():
             "memory": 4096,
             "disk": 30,
             "tags": [{"id": 99}],
-            "custom_fields": {"proxmox_vm_id": 104},
+            "custom_fields": {"proxmox_endpoint_id": 500, "proxmox_vm_id": 104},
             "description": "Synced from Proxmox node pve01",
         }
     ]
@@ -129,7 +189,7 @@ def test_build_vm_operation_queue_omits_vm_type_when_netbox_lacks_native_field()
             "memory": 4096,
             "disk": 30,
             "tags": [{"id": 99}],
-            "custom_fields": {"proxmox_vm_id": 105},
+            "custom_fields": {"proxmox_endpoint_id": 500, "proxmox_vm_id": 105},
             "description": "Synced from Proxmox node pve01",
         }
     ]
@@ -163,7 +223,9 @@ def test_log_vm_reconciliation_measurement_includes_gate_fields(monkeypatch):
     operation_counts = sync_vm._log_vm_reconciliation_measurement(
         operation_queue=queue,
         prepared_vms=[prepared_qemu, prepared_lxc],
-        netbox_snapshot=[{"id": 2106, "custom_fields": {"proxmox_vm_id": 106}}],
+        netbox_snapshot=[
+            {"id": 2106, "custom_fields": {"proxmox_endpoint_id": 500, "proxmox_vm_id": 106}}
+        ],
         duration_ms=12.34,
         supports_virtual_machine_type_field=True,
     )
@@ -229,7 +291,7 @@ async def test_dispatch_vm_operation_queue_runs_writes_sequentially(monkeypatch)
     assert failed_keys == set()
 
     assert calls == ["create:201", "patch:4203"]
-    assert create_lookups == [{"cf_proxmox_vm_id": 201, "cluster_id": 1}]
+    assert create_lookups == [{"cf_proxmox_vm_id": 201, "cf_proxmox_endpoint_id": 500}]
     assert resolved[("cluster-a", 202, "qemu")]["id"] == 4202
     assert resolved[("cluster-a", 201, "qemu")]["id"] == 3201
     assert resolved[("cluster-a", 203, "qemu")]["id"] == 4203

--- a/tests/test_vm_sync_two_phase.py
+++ b/tests/test_vm_sync_two_phase.py
@@ -188,7 +188,7 @@ def test_prepare_vm_from_config_builds_prepared_state_from_fetched_config(monkey
     assert prepared.resource is resource
     assert prepared.vm_config is vm_config
     assert prepared.vm_config_obj.qemu_agent_enabled is True
-    assert prepared.lookup == {"cf_proxmox_vm_id": 101, "cluster_id": 11}
+    assert prepared.lookup == {"cf_proxmox_vm_id": 101, "cf_proxmox_endpoint_id": 1}
     assert prepared.desired_payload["custom_fields"]["proxmox_vm_id"] == 101
     assert captured_payload_kwargs["proxmox_resource"] is resource
     assert captured_payload_kwargs["proxmox_config"] is vm_config


### PR DESCRIPTION
## Summary

Fixes duplicate Proxmox VMID handling across standalone endpoints by making VM reconciliation prefer `proxmox_endpoint_id + proxmox_vm_id` instead of cluster/VMID or VMID-only matching.

Changes include:

- Endpoint-scoped VM lookup in full VM sync, single-VM sync, interface sync, IP sync, and Python/Rust reconciliation queues.
- Endpoint-aware Proxmox session selection for disk and snapshot config fetches.
- NetBox endpoint row IDs carried onto Proxmox sessions created from plugin endpoints.
- Regression coverage for same-VMID VMs on different endpoints across VM creation, interfaces/IP selection, disks, snapshots, and reconciliation parity.
- A runtime generated-route model cache fix discovered during full-suite verification, so refreshed schemas for the same version tag cannot reuse stale Pydantic models.
- Agent docs updated with the endpoint-scoped identity contract.

Closes #255

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python -m compileall proxbox_api tests`
- `uv run python -c "import proxbox_api.main"`
- `uv run python -c "from proxbox_api.proxmox_to_netbox.proxmox_schema import load_proxmox_generated_openapi; assert load_proxmox_generated_openapi().get('paths')"`
- `uv run ty check proxbox_api/types proxbox_api/utils/retry.py proxbox_api/schemas/sync.py`
- `cargo test --no-default-features --manifest-path proxbox-reconcile-rs/Cargo.toml`
- `uv pip install -e proxbox-reconcile-rs`
- `PROXBOX_RECONCILIATION_ENGINE=compare PROXBOX_RECONCILIATION_COMPARE_STRICT=true uv run pytest tests/reconciliation -q`
- `uv run pytest tests -n 8` (`5729 passed, 11 skipped`)
