### PR TITLE
fix(e2e): gate legacy custom fields in VM/backup E2E writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -887,7 +887,10 @@ jobs:
               raise SystemExit(f"NetBox status check failed: {payload}")
           PY
 
-      - name: Create Proxbox custom fields in NetBox
+      - name: Reconcile Proxbox custom fields in NetBox
+        # Smoke-checks the legacy extras route. It is a documented no-op while
+        # custom_fields_enabled=false (the default), so the E2E writes must not
+        # depend on these definitions existing.
         run: |
           set -eux
           PROXBOX_API_KEY="proxbox-e2e-api-key-proxbox-e2e-api-key-1234567890"

--- a/tests/e2e/test_backups_sync.py
+++ b/tests/e2e/test_backups_sync.py
@@ -31,8 +31,16 @@ from proxbox_api.proxmox_to_netbox.models import (
     NetBoxVirtualMachineCreateBody,
     _relation_id,
 )
+from proxbox_api.services.custom_fields import legacy_custom_fields_payload
 from proxbox_api.services.sync.device_ensure import _slugify
 from proxbox_api.services.sync.virtual_machines import build_netbox_virtual_machine_payload
+
+# Legacy reflection custom fields are deprecated and gated by the
+# ``custom_fields_enabled`` plugin setting (default false). Route the VM payload
+# builder output through the same gate the sync services use, otherwise these
+# tests POST ``custom_fields`` keys whose definitions the extras reconcile no
+# longer creates and NetBox rejects the whole write.
+LEGACY_CF_CONTEXT = "e2e VM custom-field payload"
 
 pytestmark = pytest.mark.usefixtures("requires_pve_schema")
 
@@ -126,7 +134,11 @@ class TestBackupsSync:
             nb,
             "/api/virtualization/virtual-machines/",
             lookup={"name": vm.name},
-            payload=netbox_vm_payload,
+            payload=legacy_custom_fields_payload(
+                netbox_vm_payload,
+                overwrite=True,
+                context=LEGACY_CF_CONTEXT,
+            ),
             schema=NetBoxVirtualMachineCreateBody,
             current_normalizer=lambda record: {
                 "name": record.get("name"),
@@ -281,7 +293,11 @@ class TestBackupsSync:
                 nb,
                 "/api/virtualization/virtual-machines/",
                 lookup={"name": vm.name},
-                payload=payload,
+                payload=legacy_custom_fields_payload(
+                    payload,
+                    overwrite=True,
+                    context=LEGACY_CF_CONTEXT,
+                ),
                 schema=NetBoxVirtualMachineCreateBody,
                 current_normalizer=lambda record: {
                     "name": record.get("name"),

--- a/tests/e2e/test_vm_sync.py
+++ b/tests/e2e/test_vm_sync.py
@@ -29,8 +29,20 @@ from proxbox_api.proxmox_to_netbox.models import (
     NetBoxVirtualMachineCreateBody,
     _relation_id,
 )
+from proxbox_api.services.custom_fields import (
+    custom_fields_enabled,
+    legacy_custom_fields_payload,
+)
 from proxbox_api.services.sync.device_ensure import _slugify
 from proxbox_api.services.sync.virtual_machines import build_netbox_virtual_machine_payload
+
+# Legacy reflection custom fields are deprecated and gated by the
+# ``custom_fields_enabled`` plugin setting (default false), so the VM payload
+# builder output must pass through the same gate the sync services apply before
+# it reaches NetBox. Without the gate these tests POST ``custom_fields`` keys
+# whose definitions the extras reconcile no longer creates, and NetBox rejects
+# the whole write.
+LEGACY_CF_CONTEXT = "e2e VM custom-field payload"
 
 pytestmark = pytest.mark.usefixtures("requires_pve_schema")
 
@@ -129,7 +141,11 @@ class TestVMSync:
             nb,
             "/api/virtualization/virtual-machines/",
             lookup={"name": vm.name},
-            payload=netbox_vm_payload,
+            payload=legacy_custom_fields_payload(
+                netbox_vm_payload,
+                overwrite=True,
+                context=LEGACY_CF_CONTEXT,
+            ),
             schema=NetBoxVirtualMachineCreateBody,
             current_normalizer=lambda record: {
                 "name": record.get("name"),
@@ -253,7 +269,11 @@ class TestVMSync:
             nb,
             "/api/virtualization/virtual-machines/",
             lookup={"name": lxc_vm.name},
-            payload=netbox_vm_payload,
+            payload=legacy_custom_fields_payload(
+                netbox_vm_payload,
+                overwrite=True,
+                context=LEGACY_CF_CONTEXT,
+            ),
             schema=NetBoxVirtualMachineCreateBody,
             current_normalizer=lambda record: {
                 "name": record.get("name"),
@@ -367,7 +387,11 @@ class TestVMSync:
             nb,
             "/api/virtualization/virtual-machines/",
             lookup={"name": vm.name},
-            payload=netbox_vm_payload,
+            payload=legacy_custom_fields_payload(
+                netbox_vm_payload,
+                overwrite=True,
+                context=LEGACY_CF_CONTEXT,
+            ),
             schema=NetBoxVirtualMachineCreateBody,
             current_normalizer=lambda record: {
                 "name": record.get("name"),
@@ -386,6 +410,11 @@ class TestVMSync:
 
         vm_data = virtual_machine.serialize()
         custom_fields = vm_data.get("custom_fields") or {}
+        if not custom_fields_enabled():
+            # Deprecated legacy reflection: with custom_fields_enabled=false the
+            # gate strips the key, so NetBox must not carry any Proxmox value.
+            assert custom_fields.get("proxmox_vm_id") is None
+            return
         if custom_fields.get("proxmox_vm_id") is None:
             pytest.skip(
                 "NetBox demo does not return Proxmox VM custom fields (unset or no permission)."
@@ -486,7 +515,11 @@ class TestVMSync:
                 nb,
                 "/api/virtualization/virtual-machines/",
                 lookup={"name": vm.name},
-                payload=payload,
+                payload=legacy_custom_fields_payload(
+                    payload,
+                    overwrite=True,
+                    context=LEGACY_CF_CONTEXT,
+                ),
                 schema=NetBoxVirtualMachineCreateBody,
                 current_normalizer=lambda record: {
                     "name": record.get("name"),


### PR DESCRIPTION
Fixes the 49 red `E2E Docker / PX:pve` jobs on `main` (7 transport combos x 7 NetBox versions), failing since `e07e512` ("Make sync-state models the default; deprecate custom fields behind a flag").

## Root cause

`e07e512` put legacy reflection custom fields behind `custom_fields_enabled` (default `false`). The CI step that calls `/extras/extras/custom-fields/create` therefore became a no-op and returns `[]`, so the `proxmox_*` custom-field definitions no longer exist in the E2E NetBox.

The E2E VM and backup tests, however, POST the raw `build_netbox_virtual_machine_payload()` output straight to NetBox — including its `custom_fields` dict — without the `legacy_custom_fields_payload()` gate that every production sync write goes through (`vm_create.py:341`, `sync_vm.py:2815`). NetBox rejects the whole write:

```
NetBox REST request failed | {"custom_fields":{
  "proxmox_vm_id":"Custom field 'proxmox_vm_id' does not exist for this object type.", ... }}
```

8 of the 9 keys are rejected — `proxmox_node` survives only because netbox-proxbox `develop` is installed in the E2E NetBox and one of its migrations creates that single field, which is why the error lists 8 and not 9.

Six tests fail per job: 4 in `test_vm_sync.py`, 2 in `test_backups_sync.py`.

## Fix

Route the six VM reconcile payloads through `legacy_custom_fields_payload(..., overwrite=True)` — the same gate the sync services already apply — so the E2E writes exercise the **default** configuration instead of a disabled deprecated path. `NetBoxVirtualMachineCreateBody` still emits an empty `custom_fields` dict, which NetBox accepts.

`test_sync_vm_creates_custom_fields` now asserts the flag-off contract explicitly (no Proxmox values reach NetBox) instead of sliding into the pre-existing "demo NetBox" skip, and keeps its value assertions for when the flag is enabled.

The workflow step is renamed and annotated as a documented no-op while `custom_fields_enabled=false`, so nothing downstream assumes those definitions exist.

## Verification

- Failure reproduced and fixed against the real payload builder + create-body schema: before, 9 `custom_fields` keys were sent; after, NetBox receives `custom_fields: {}`.
- Core suite green: **6238 passed, 11 skipped** (`pytest tests --ignore=tests/e2e`).
- `ruff check`, `ruff format --check`, `compileall` clean on `tests/e2e/`.
- The E2E matrix itself is validated by this PR's own run — the stack is built inline by the workflow with no local compose equivalent.

Test-only plus a workflow comment; no change to the shipping package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)